### PR TITLE
Adds support for sandbox port configuration

### DIFF
--- a/@blaxel/core/src/sandbox/index.ts
+++ b/@blaxel/core/src/sandbox/index.ts
@@ -1,12 +1,13 @@
 export {
-  /* Export SDK functions */
-  deleteFilesystemByPath, deleteNetworkProcessByPidMonitor, deleteProcessByIdentifier, deleteProcessByIdentifierKill, Directory, ErrorResponse,
-  /* Re-export everything from the module except ClientOptions and Options */
-  File, FileRequest, FileWithContent, getFilesystemByPath, getNetworkProcessByPidPorts,
-  getProcess, getProcessByIdentifier, getProcessByIdentifierLogs, getProcessByIdentifierLogsStream, PortMonitorRequest, postNetworkProcessByPidMonitor, postProcess,
-  ProcessRequest, ProcessResponse, putFilesystemByPath, SuccessResponse
+    Directory, ErrorResponse,
+    /* Re-export everything from the module except ClientOptions and Options */
+    File, FileRequest, FileWithContent, PortMonitorRequest, ProcessRequest, ProcessResponse, SuccessResponse,
+    /* Export SDK functions */
+    deleteFilesystemByPath, deleteNetworkProcessByPidMonitor, deleteProcessByIdentifier, deleteProcessByIdentifierKill, getFilesystemByPath, getNetworkProcessByPidPorts,
+    getProcess, getProcessByIdentifier, getProcessByIdentifierLogs, getProcessByIdentifierLogsStream, postNetworkProcessByPidMonitor, postProcess, putFilesystemByPath
 } from "./client/index.js";
 export * from "./filesystem/index.js";
 export * from "./sandbox.js";
+export * from "./types.js";
 // Re-export everything from client except ClientOptions to avoid conflict
 

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "../client/types.gen";
+import { Port, Sandbox } from "../client/types.gen";
 
 export interface SessionCreateOptions {
   expiresAt?: Date;
@@ -24,4 +24,32 @@ export type SandboxCreateConfiguration = {
   name?: string;
   image?: string;
   memory?: number;
+  ports?: (Port | Record<string, any>)[];
+}
+
+export function normalizePorts(ports?: (Port | Record<string, any>)[]): Port[] | undefined {
+  if (!ports || ports.length === 0) {
+    return undefined;
+  }
+
+  const portObjects: Port[] = [];
+  for (const port of ports) {
+    if (typeof port === 'object' && port !== null) {
+      if ('name' in port || 'target' in port || 'protocol' in port) {
+        // It's a Port-like object, ensure protocol defaults to HTTP
+        const normalizedPort: Port = {
+          name: typeof port.name === 'string' ? port.name : undefined,
+          target: typeof port.target === 'number' ? port.target : undefined,
+          protocol: typeof port.protocol === 'string' ? port.protocol : "HTTP"
+        };
+        portObjects.push(normalizedPort);
+      } else {
+        throw new Error(`Invalid port type: ${typeof port}. Expected Port object or object with port properties.`);
+      }
+    } else {
+      throw new Error(`Invalid port type: ${typeof port}. Expected Port object or object with port properties.`);
+    }
+  }
+
+  return portObjects;
 }

--- a/tests/sandbox/create.ts
+++ b/tests/sandbox/create.ts
@@ -1,43 +1,103 @@
-import { SandboxInstance } from "@blaxel/core";
+import { SandboxCreateConfiguration, SandboxInstance } from "@blaxel/core";
 
 async function main() {
   try {
-    let sandbox = await SandboxInstance.create()
-    await sandbox.wait()
-    console.log(await sandbox.fs.ls('/blaxel'))
-    await SandboxInstance.delete(sandbox.metadata?.name!)
+    console.log("Test 1: Create default sandbox...");
+    let sandbox = await SandboxInstance.create();
+    await sandbox.wait();
+    console.log(`✅ Created sandbox with default name: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted default sandbox");
 
+    console.log("\nTest 2: Create sandbox with spec containing runtime image...");
     sandbox = await SandboxInstance.create(
       { spec: { runtime: { image: "blaxel/prod-base:latest" } } }
-    )
-    await sandbox.wait()
-    console.log(await sandbox.fs.ls('/blaxel'))
-    await SandboxInstance.delete(sandbox.metadata?.name!)
+    );
+    await sandbox.wait();
+    console.log(`✅ Created sandbox with spec: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted spec sandbox");
 
-    sandbox = await SandboxInstance.create({ name: "sandbox-with-name" })
-    await sandbox.wait()
-    console.log(await sandbox.fs.ls('/blaxel/'))
-    await SandboxInstance.delete(sandbox.metadata?.name!)
+    console.log("\nTest 3: Create sandbox with name...");
+    sandbox = await SandboxInstance.create({ name: "sandbox-with-name" });
+    await sandbox.wait();
+    console.log(`✅ Created sandbox with name: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel/'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted named sandbox");
 
-    sandbox = await SandboxInstance.createIfNotExists({ name: "sandbox-cine-name" })
-    await sandbox.wait()
-    console.log(await sandbox.fs.ls('/blaxel/'))
-    await SandboxInstance.delete(sandbox.metadata?.name!)
+    console.log("\nTest 4: Create sandbox with SandboxCreateConfiguration...");
+    const config: SandboxCreateConfiguration = {
+      name: "sandbox-config",
+      image: "blaxel/prod-base:latest",
+      memory: 2048
+    };
+    sandbox = await SandboxInstance.create(config);
+    await sandbox.wait();
+    console.log(`✅ Created sandbox with config: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel/'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted config sandbox");
 
-    sandbox = await SandboxInstance.createIfNotExists({ metadata: { name: "sandbox-cine-metadata" } })
-    await sandbox.wait()
-    console.log(await sandbox.fs.ls('/blaxel/'))
-    await SandboxInstance.delete(sandbox.metadata?.name!)
+    console.log("\nTest 5: Create sandbox if not exists with name...");
+    sandbox = await SandboxInstance.createIfNotExists({ name: "sandbox-cine-name" });
+    await sandbox.wait();
+    console.log(`✅ Created/found sandbox: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel/'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted create-if-not-exists sandbox");
+
+    console.log("\nTest 6: Create sandbox if not exists with metadata...");
+    sandbox = await SandboxInstance.createIfNotExists({ metadata: { name: "sandbox-cine-metadata" } });
+    await sandbox.wait();
+    console.log(`✅ Created/found sandbox with metadata: ${sandbox.metadata?.name}`);
+    console.log(await sandbox.fs.ls('/blaxel/'));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted metadata sandbox");
+
+    console.log("\nTest 7: Create sandbox with ports...");
+    const portsConfig: SandboxCreateConfiguration = {
+      name: "sandbox-with-ports",
+      image: "blaxel/prod-base:latest",
+      memory: 2048,
+      ports: [
+        { name: "web", target: 3000 }, // Will default to HTTP
+        { name: "api", target: 8080, protocol: "TCP" },
+      ],
+    };
+    sandbox = await SandboxInstance.create(portsConfig);
+    await sandbox.wait();
+    console.log(`✅ Created sandbox with ports: ${sandbox.metadata?.name}`);
+    console.log(`   Image: ${sandbox.spec?.runtime?.image}`);
+    console.log(`   Memory: ${sandbox.spec?.runtime?.memory}`);
+    sandbox = await SandboxInstance.get(sandbox.metadata?.name!);
+    if (sandbox.spec?.runtime?.ports) {
+      console.log(`   Ports: ${sandbox.spec.runtime.ports.length} configured`);
+      for (const port of sandbox.spec.runtime.ports) {
+        console.log(`     - ${port.name}: ${port.target} (${port.protocol})`);
+      }
+    }
+    console.log(await sandbox.fs.ls("/blaxel/"));
+    await SandboxInstance.delete(sandbox.metadata?.name!);
+    console.log("✅ Deleted ports sandbox");
+
+    console.log("\n🎉 All sandbox creation tests passed!");
   } catch (e) {
-    console.error("There was an error => ", e);
+    console.error("❌ There was an error => ", e);
+    import('util').then(util => {
+      console.error(util.inspect(e, { depth: null }));
+    });
+    process.exit(1);
   }
 }
 
 main()
   .catch((err) => {
-    console.error("There was an error => ", err);
+    console.error("❌ There was an error => ", err);
     process.exit(1);
   })
   .then(() => {
     process.exit(0);
-  })
+  });

--- a/tests/sandbox/process.ts
+++ b/tests/sandbox/process.ts
@@ -5,7 +5,7 @@ import { createOrGetSandbox } from "../utils.js";
 const SANDBOX_NAME = "sandbox-test-typescript-process-features";
 
 async function testWaitForCompletionWithLogs(sandbox: SandboxInstance) {
-  console.log("🔧 Testing wait_for_completion with logs...");
+  console.log("🔧 Testing waitForCompletion with logs...");
 
   // Create a process that outputs some logs
   const processRequest: ProcessRequest = {
@@ -14,7 +14,7 @@ async function testWaitForCompletionWithLogs(sandbox: SandboxInstance) {
     waitForCompletion: true,
   };
 
-  // Execute with wait_for_completion=true
+  // Execute with waitForCompletion=true
   const response = await sandbox.process.exec(processRequest);
 
   // Check that we got the response
@@ -24,7 +24,7 @@ async function testWaitForCompletionWithLogs(sandbox: SandboxInstance) {
 
   // Check that logs were added to the response
   console.assert("logs" in response, "Response should have logs");
-  const logs = (response as any).logs;
+  const logs = response.logs;
   console.assert(typeof logs === "string", "Logs should be a string");
   console.assert(logs.length > 0, "Logs should not be empty");
 
@@ -85,7 +85,7 @@ async function testOnLogCallback(sandbox: SandboxInstance) {
 }
 
 async function testCombinedFeatures(sandbox: SandboxInstance) {
-  console.log("🔧 Testing combined wait_for_completion and on_log...");
+  console.log("🔧 Testing combined waitForCompletion and on_log...");
 
   // Create a list to collect real-time logs
   const realtimeLogs: string[] = [];


### PR DESCRIPTION
Adds the ability to configure ports when creating a sandbox,
including target port, protocol, and name. This enables
more flexible and customized sandbox environments.

Normalizes port configurations to ensure consistent handling
and defaults to HTTP if no protocol is specified.

Adds new tests to validate the sandbox creation with different
configuration options and port configurations.
