### PR TITLE
Enables passing log callback in process request

### DIFF
--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "../../client/types.gen.js";
 import { settings } from "../../common/settings.js";
 import { SandboxAction } from "../action.js";
 import { DeleteProcessByIdentifierKillResponse, DeleteProcessByIdentifierResponse, GetProcessByIdentifierResponse, GetProcessResponse, PostProcessResponse, ProcessRequest, deleteProcessByIdentifier, deleteProcessByIdentifierKill, getProcess, getProcessByIdentifier, getProcessByIdentifierLogs, postProcess } from "../client/index.js";
+import { ProcessRequestWithLog } from "../types.js";
 
 export class SandboxProcess extends SandboxAction {
   constructor(sandbox: Sandbox) {
@@ -67,9 +68,14 @@ export class SandboxProcess extends SandboxAction {
   }
 
   async exec(
-    process: ProcessRequest,
-    onLog?: (log: string) => void
+    process: ProcessRequest | ProcessRequestWithLog,
   ): Promise<PostProcessResponse> {
+    let onLog: ((log: string) => void) | undefined;
+    if ('onLog' in process && process.onLog) {
+      onLog = process.onLog;
+      delete process.onLog;
+    }
+
     // Store original wait_for_completion setting
     const shouldWaitForCompletion = process.waitForCompletion;
 

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -1,4 +1,5 @@
 import { Port, Sandbox } from "../client/types.gen";
+import { ProcessRequest } from "./client";
 
 export interface SessionCreateOptions {
   expiresAt?: Date;
@@ -81,4 +82,8 @@ export function normalizeEnvs(envs?: EnvVar[]): EnvVar[] | undefined {
   }
 
   return envObjects;
+}
+
+export type ProcessRequestWithLog = ProcessRequest & {
+  onLog?: (log: string) => void;
 }

--- a/tests/sandbox/process.ts
+++ b/tests/sandbox/process.ts
@@ -1,4 +1,4 @@
-import { SandboxInstance } from "@blaxel/core";
+import { ProcessRequestWithLog, SandboxInstance } from "@blaxel/core";
 import { ProcessRequest } from "../../@blaxel/core/src/sandbox/client/index.js";
 import { createOrGetSandbox } from "../utils.js";
 
@@ -51,12 +51,13 @@ async function testOnLogCallback(sandbox: SandboxInstance) {
   }
 
   // Create a process that outputs logs over time
-  const processRequest: ProcessRequest = {
-    command: 'sh -c "echo First message; sleep 1; echo Second message; sleep 1; echo Third message"'
+  const processRequest: ProcessRequestWithLog = {
+    command: 'sh -c "echo First message; sleep 1; echo Second message; sleep 1; echo Third message"',
+    onLog: logCollector,
   };
 
   // Execute with on_log callback (name will be auto-generated)
-  const response = await sandbox.process.exec(processRequest, logCollector);
+  const response = await sandbox.process.exec(processRequest);
 
   // Check that a name was generated
   console.assert(response.name !== null, "Process name should be generated");
@@ -95,14 +96,15 @@ async function testCombinedFeatures(sandbox: SandboxInstance) {
   }
 
   // Create a process with a specific name
-  const processRequest: ProcessRequest = {
+  const processRequest: ProcessRequestWithLog = {
     name: "combined-test",
     command: 'sh -c "echo Starting combined test; sleep 1; echo Middle of test; sleep 1; echo Test completed"',
     waitForCompletion: true,
+    onLog: realtimeCollector,
   };
 
   // Execute with both features
-  const response = await sandbox.process.exec(processRequest, realtimeCollector);
+  const response = await sandbox.process.exec(processRequest);
 
   // Check the response
   console.assert(response.name === "combined-test", "Process name should match");
@@ -140,12 +142,13 @@ async function testOnLogWithoutName(sandbox: SandboxInstance) {
   }
 
   // Process without name
-  const processDict: ProcessRequest = {
-    command: "echo 'Testing auto name generation'"
+  const processDict: ProcessRequestWithLog = {
+    command: "echo 'Testing auto name generation'",
+    onLog: countLogs,
   };
 
   // Execute with on_log (should auto-generate name)
-  const response = await sandbox.process.exec(processDict, countLogs);
+  const response = await sandbox.process.exec(processDict);
 
   // Check that name was generated
   console.assert(response.name !== null, "Name should be generated");


### PR DESCRIPTION
Allows users to pass an `onLog` callback directly within the process request object.

This simplifies the process execution by integrating the logging functionality directly into the request.
It removes the need to pass the callback separately, resulting in a cleaner and more intuitive API.
