### PR TITLE
Adds stream closing to background processes

### DIFF
--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -1,5 +1,5 @@
 import { Port, Sandbox } from "../client/types.gen";
-import { ProcessRequest } from "./client";
+import { PostProcessResponse, ProcessRequest } from "./client";
 
 export interface SessionCreateOptions {
   expiresAt?: Date;
@@ -86,4 +86,8 @@ export function normalizeEnvs(envs?: EnvVar[]): EnvVar[] | undefined {
 
 export type ProcessRequestWithLog = ProcessRequest & {
   onLog?: (log: string) => void;
+}
+
+export type ProcessResponseWithLog = PostProcessResponse & {
+  close: () => void;
 }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ install:
 	cd @blaxel/core && pnpm install
 
 sdk-sandbox:
-	cp ../../sandbox/sandbox-api/docs/openapi.yml ./definition.yml
+	@echo "Downloading sandbox definition from blaxel-ai/sandbox"
+	@curl -H "Authorization: token $$(gh auth token)" \
+		-H "Accept: application/vnd.github.v3.raw" \
+		-o ./definition.yml \
+		https://api.github.com/repos/blaxel-ai/sandbox/contents/sandbox-api/docs/openapi.yml?ref=main
 	rm -rf @blaxel/core/src/sandbox/client/types.gen.ts @blaxel/core/src/sandbox/client/sdk.gen.ts
 	npx @hey-api/openapi-ts@0.66.0 -i ./definition.yml -o ./tmp/ -c @hey-api/client-fetch
 	cp -r ./tmp/* @blaxel/core/src/sandbox/client
@@ -19,7 +23,11 @@ sdk-sandbox:
 	rm definition.yml
 
 sdk-controlplane:
-	cp ../../controlplane/api/api/definitions/controlplane.yml ./definition.yml
+	@echo "Downloading controlplane definition from blaxel-ai/controlplane"
+	@curl -H "Authorization: token $$(gh auth token)" \
+		-H "Accept: application/vnd.github.v3.raw" \
+		-o ./definition.yml \
+		https://api.github.com/repos/blaxel-ai/controlplane/contents/api/api/definitions/controlplane.yml?ref=main
 	rm -rf @blaxel/core/src/client/types.gen.ts @blaxel/core/src/client/sdk.gen.ts
 	npx @hey-api/openapi-ts@0.66.0 -i ./definition.yml -o ./tmp/ -c @hey-api/client-fetch
 	cp -r ./tmp/* @blaxel/core/src/client


### PR DESCRIPTION
Enables explicit closing of log streams for non-blocking process executions.

- Introduces a `close` method to the process response for processes with log streams.
- This allows users to stop receiving logs from background processes without terminating the process itself.
- Increases the default timeout for processes to 1 hour.