### PR TITLE
Improves sandbox creation and adds load tests

### DIFF
--- a/tests/sandbox/agent-test-mcp.ts
+++ b/tests/sandbox/agent-test-mcp.ts
@@ -28,7 +28,6 @@ async function getSandbox() {
       }
     }
   })
-  await sandbox.wait()
   return sandbox
 }
 async function main() {

--- a/tests/sandbox/create.ts
+++ b/tests/sandbox/create.ts
@@ -4,7 +4,6 @@ async function main() {
   try {
     console.log("Test 1: Create default sandbox...");
     let sandbox = await SandboxInstance.create();
-    await sandbox.wait();
     console.log(`✅ Created sandbox with default name: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -14,7 +13,6 @@ async function main() {
     sandbox = await SandboxInstance.create(
       { spec: { runtime: { image: "blaxel/prod-base:latest" } } }
     );
-    await sandbox.wait();
     console.log(`✅ Created sandbox with spec: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -22,7 +20,6 @@ async function main() {
 
     console.log("\nTest 3: Create sandbox with name...");
     sandbox = await SandboxInstance.create({ name: "sandbox-with-name" });
-    await sandbox.wait();
     console.log(`✅ Created sandbox with name: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel/'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -35,7 +32,6 @@ async function main() {
       memory: 2048
     };
     sandbox = await SandboxInstance.create(config);
-    await sandbox.wait();
     console.log(`✅ Created sandbox with config: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel/'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -43,7 +39,6 @@ async function main() {
 
     console.log("\nTest 5: Create sandbox if not exists with name...");
     sandbox = await SandboxInstance.createIfNotExists({ name: "sandbox-cine-name" });
-    await sandbox.wait();
     console.log(`✅ Created/found sandbox: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel/'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -51,7 +46,6 @@ async function main() {
 
     console.log("\nTest 6: Create sandbox if not exists with metadata...");
     sandbox = await SandboxInstance.createIfNotExists({ metadata: { name: "sandbox-cine-metadata" } });
-    await sandbox.wait();
     console.log(`✅ Created/found sandbox with metadata: ${sandbox.metadata?.name}`);
     console.log(await sandbox.fs.ls('/blaxel/'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
@@ -68,7 +62,6 @@ async function main() {
       ],
     };
     sandbox = await SandboxInstance.create(portsConfig);
-    await sandbox.wait();
     console.log(`✅ Created sandbox with ports: ${sandbox.metadata?.name}`);
     console.log(`   Image: ${sandbox.spec?.runtime?.image}`);
     console.log(`   Memory: ${sandbox.spec?.runtime?.memory}`);
@@ -97,7 +90,6 @@ async function main() {
       ],
     };
     sandbox = await SandboxInstance.create(envsConfig);
-    await sandbox.wait();
     console.log(`✅ Created sandbox with envs: ${sandbox.metadata?.name}`);
     console.log(`   Image: ${sandbox.spec?.runtime?.image}`);
     console.log(`   Memory: ${sandbox.spec?.runtime?.memory}`);
@@ -124,7 +116,6 @@ async function main() {
         { name: "VERSION", value: "1.0.0" },
       ]
     });
-    await sandbox.wait();
     console.log(`✅ Created sandbox with envs dict: ${sandbox.metadata?.name}`);
     console.log(`   Image: ${sandbox.spec?.runtime?.image}`);
     console.log(`   Memory: ${sandbox.spec?.runtime?.memory}`);

--- a/tests/sandbox/nextjs-sandbox-test/src/app/api/sandboxes/route.ts
+++ b/tests/sandbox/nextjs-sandbox-test/src/app/api/sandboxes/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
 
     // Create sandbox instance using Blaxel SDK
     const sandboxName = getName(`${user.email.split('@')[0]}-${name}`);
-    const sandboxCreated = await createOrGetSandbox({sandboxName, wait: false});
+    const sandboxCreated = await createOrGetSandbox({sandboxName});
 
     return NextResponse.json({
       sandbox: sandboxCreated,

--- a/tests/sandbox/nextjs-sandbox-test/src/lib/sandboxes/index.ts
+++ b/tests/sandbox/nextjs-sandbox-test/src/lib/sandboxes/index.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 
-export async function createOrGetSandbox({sandboxName, wait = true}: {sandboxName: string, wait?: boolean}) {
+export async function createOrGetSandbox({sandboxName }: {sandboxName: string}) {
   const envs = []
   if (process.env.MORPH_API_KEY) {
     envs.push({
@@ -39,8 +39,5 @@ export async function createOrGetSandbox({sandboxName, wait = true}: {sandboxNam
     }
   }
   const sandbox = await SandboxInstance.createIfNotExists(sandboxModel)
-  if (wait) {
-    await sandbox.wait({ maxWait: 120000, interval: 1000 })
-  }
   return sandbox
 }


### PR DESCRIPTION
Refactors sandbox creation logic to handle existing sandboxes more efficiently, preventing unnecessary re-creation. It also includes adding load tests for both sandboxes and agents creation, with corresponding endpoints.

- Updates SandboxInstance.createIfNotExists to reuse existing sandboxes.
- Adds load tests for sandboxes and agents using k6.
- Introduces an Express server for load testing to facilitate sandbox and agent creation and deletion.

Updates sandbox name for local testing

Updates the sandbox name to avoid conflicts and ensure proper isolation during local testing.

Logs the sandbox name being used to improve debugging and traceability during local development.

Add deprecation warning on sandbox.wait
