### PR TITLE
Enables updating sandbox metadata

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -1,12 +1,12 @@
 import { v4 as uuidv4 } from "uuid";
-import { createSandbox, deleteSandbox, getSandbox, listSandboxes, Sandbox as SandboxModel } from "../client/index.js";
+import { createSandbox, deleteSandbox, getSandbox, listSandboxes, Sandbox as SandboxModel, updateSandbox } from "../client/index.js";
 import { logger } from "../common/logger.js";
 import { SandboxFileSystem } from "./filesystem/index.js";
 import { SandboxNetwork } from "./network/index.js";
 import { SandboxPreviews } from "./preview.js";
 import { SandboxProcess } from "./process/index.js";
 import { SandboxSessions } from "./session.js";
-import { normalizeEnvs, normalizePorts, SandboxConfiguration, SandboxCreateConfiguration, SessionWithToken } from "./types.js";
+import { normalizeEnvs, normalizePorts, SandboxConfiguration, SandboxCreateConfiguration, SandboxUpdateMetadata, SessionWithToken } from "./types.js";
 
 export class SandboxInstance {
   fs: SandboxFileSystem;
@@ -130,6 +130,18 @@ export class SandboxInstance {
       throwOnError: true,
     });
     return data;
+  }
+
+  static async updateMetadata(sandboxName: string, metadata: SandboxUpdateMetadata) {
+    const sandbox = await SandboxInstance.get(sandboxName);
+    const body = { ...sandbox.sandbox, metadata: { ...sandbox.metadata, ...metadata } } as SandboxModel
+    const { data } = await updateSandbox({
+      path: { sandboxName },
+      body,
+      throwOnError: true,
+    });
+    const instance = new SandboxInstance(data);
+    return instance;
   }
 
   static async createIfNotExists(sandbox: SandboxModel | SandboxCreateConfiguration) {

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -25,6 +25,11 @@ export type SandboxConfiguration = {
   params?: Record<string, string>;
 } & Sandbox;
 
+export type SandboxUpdateMetadata = {
+  labels?: Record<string, string>;
+  displayName?: string;
+}
+
 export type SandboxCreateConfiguration = {
   name?: string;
   image?: string;

--- a/tests/sandbox/updatemetadata.ts
+++ b/tests/sandbox/updatemetadata.ts
@@ -1,0 +1,63 @@
+import { SandboxInstance } from "@blaxel/core";
+
+async function main() {
+  try {
+    console.log("Test 1: Create default sandbox...");
+    let sandbox = await SandboxInstance.create();
+    console.log(
+      "Metadata:\n  labels: ",
+      sandbox.metadata?.labels,
+      "\n  displayName: ",
+      sandbox.metadata?.displayName,
+      "\n  name: ",
+      sandbox.metadata?.name,
+      "\n  createdAt: ",
+      sandbox.metadata?.createdAt,
+      "\n  updatedAt: ",
+      sandbox.metadata?.updatedAt,
+      "\n  createdBy: ",
+      sandbox.metadata?.createdBy,
+      "\n  updatedBy: ",
+      sandbox.metadata?.updatedBy,
+    )
+
+    console.log("Test 2: Update metadata...");
+    sandbox = await SandboxInstance.updateMetadata(sandbox.metadata?.name!, {
+      labels: { test: "test" },
+      displayName: "test"
+    })
+    console.log(
+      "Metadata:\n  labels: ",
+      sandbox.metadata?.labels,
+      "\n  displayName: ",
+      sandbox.metadata?.displayName,
+      "\n  name: ",
+      sandbox.metadata?.name,
+      "\n  createdAt: ",
+      sandbox.metadata?.createdAt,
+      "\n  updatedAt: ",
+      sandbox.metadata?.updatedAt,
+      "\n  createdBy: ",
+      sandbox.metadata?.createdBy,
+      "\n  updatedBy: ",
+      sandbox.metadata?.updatedBy,
+    )
+
+    await sandbox.fs.ls("/")
+  } catch (e) {
+    console.error("❌ There was an error => ", e);
+    import('util').then(util => {
+      console.error(util.inspect(e, { depth: null }));
+    });
+    process.exit(1);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("❌ There was an error => ", err);
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });


### PR DESCRIPTION
Adds functionality to update a sandbox's metadata,
including labels and display name.

This allows users to modify sandbox properties
after creation, enhancing flexibility and management.
