### PR TITLE
Refactors sandbox process and spec handling

### DIFF
--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -94,11 +94,8 @@ export class SandboxProcess extends SandboxAction {
     let result = data as PostProcessResponse;
 
     // Handle wait_for_completion with parallel log streaming
-    if (shouldWaitForCompletion) {
-      let streamControl: { close: () => void } | undefined;
-      if (onLog) {
-        streamControl = this.streamLogs(result.pid, { onLog });
-      }
+    if (shouldWaitForCompletion && onLog) {
+      const streamControl = this.streamLogs(result.pid, { onLog });
       try {
         // Wait for process completion
         result = await this.wait(result.pid, { interval: 500, maxWait: 1000 * 60 * 60 });

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -84,10 +84,10 @@ export class SandboxInstance {
 
     sandbox = sandbox as SandboxModel
     if (!sandbox.metadata) {
-      sandbox.metadata = { name: crypto.randomUUID().replace(/-/g, '') };
+      sandbox.metadata = { name: defaultName };
     }
     if (!sandbox.spec) {
-      sandbox.spec = { runtime: { image: "blaxel/prod-base:latest" } };
+      sandbox.spec = { runtime: { image: defaultImage, memory: defaultMemory } };
     }
     if (!sandbox.spec.runtime) {
       sandbox.spec.runtime = { image: defaultImage, memory: defaultMemory };


### PR DESCRIPTION
Improves log streaming by ensuring it only initializes if an `onLog` handler is provided.

Simplifies sandbox spec creation by setting default image and memory values directly within the spec, enhancing consistency.
