### PR TITLE
Rename tracking constant

### DIFF
--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -204,8 +204,9 @@ class Settings {
 
   get tracking(): boolean {
     // Environment variable has highest priority
-    if (env.BL_TRACKING !== undefined) {
-      return env.BL_TRACKING === "true";
+    if (env.DO_NOT_TRACK !== undefined) {
+      // DO_NOT_TRACK has inverted semantics: true means tracking disabled
+      return env.DO_NOT_TRACK !== "true" && env.DO_NOT_TRACK !== "1";
     }
     // Then check config.yaml
     const configValue = getConfigTracking();


### PR DESCRIPTION
Rename `BL_TRACKING` to `DO_NOT_TRACK` and invert tracking logic in `sdk-typescript` to align with new semantics.

---
Linear Issue: [ENG-1749](https://linear.app/blaxel/issue/ENG-1749/rename-bl-tracking-to-do-not-track)

<a href="https://cursor.com/background-agent?bcId=bc-e6eaaa48-5bb4-4fbd-b6ac-38bf7eac0e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6eaaa48-5bb4-4fbd-b6ac-38bf7eac0e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

