### PR TITLE
Fixes browser compatibility issues

### DIFF
--- a/@blaxel/core/fix-browser-imports.js
+++ b/@blaxel/core/fix-browser-imports.js
@@ -63,6 +63,33 @@ function replaceNodeWithBrowser(buildDir) {
   }
 }
 
+function replaceSentryWithBrowser(buildDir) {
+  // File paths for both sentry and sentry-browser files
+  const sentryPath = path.join(buildDir, 'common', 'sentry.js');
+  const sentryTypesPath = path.join(buildDir, 'common', 'sentry.d.ts');
+  const sentryBrowserPath = path.join(buildDir, 'common', 'sentry-browser.js');
+  const sentryBrowserTypesPath = path.join(buildDir, 'common', 'sentry-browser.d.ts');
+
+  // Replace sentry.js with sentry-browser.js content
+  if (fs.existsSync(sentryBrowserPath) && fs.existsSync(sentryPath)) {
+    // Delete the original sentry.js
+    fs.unlinkSync(sentryPath);
+    // Rename sentry-browser.js to sentry.js (keep the same filename for imports)
+    fs.renameSync(sentryBrowserPath, sentryPath);
+    console.log(`  ✅ Replaced sentry.js with sentry-browser.js content`);
+  } else if (!fs.existsSync(sentryBrowserPath)) {
+    console.error(`  ⚠️  Warning: sentry-browser.js not found in ${buildDir}/common/`);
+    console.error(`     Make sure sentry-browser.ts is compiled in the regular build first.`);
+  }
+
+  // Replace sentry.d.ts with sentry-browser.d.ts if they exist
+  if (fs.existsSync(sentryBrowserTypesPath) && fs.existsSync(sentryTypesPath)) {
+    fs.unlinkSync(sentryTypesPath);
+    fs.renameSync(sentryBrowserTypesPath, sentryTypesPath);
+    console.log(`  ✅ Replaced sentry.d.ts with sentry-browser.d.ts content`);
+  }
+}
+
 // Create browser-specific builds
 const builds = ['dist/esm-browser', 'dist/cjs-browser'];
 
@@ -89,6 +116,9 @@ builds.forEach(buildDir => {
 
     // Replace node.js with browser.js content
     replaceNodeWithBrowser(buildDir);
+
+    // Replace sentry.js with sentry-browser.js content
+    replaceSentryWithBrowser(buildDir);
 
     // Note: We don't need to fix imports since node.js now contains browser.js content
     // All imports to node.js will get the browser-safe version

--- a/@blaxel/core/package.json
+++ b/@blaxel/core/package.json
@@ -66,7 +66,6 @@
 	"dependencies": {
 		"@hey-api/client-fetch": "^0.10.0",
 		"@modelcontextprotocol/sdk": "^1.20.0",
-		"@sentry/node": "^10.27.0",
 		"axios": "^1.9.0",
 		"dotenv": "^16.5.0",
 		"form-data": "^4.0.2",
@@ -76,6 +75,9 @@
 		"ws": "^8.18.2",
 		"yaml": "^2.7.1",
 		"zod": "^3.24.3"
+	},
+	"optionalDependencies": {
+		"@sentry/node": "^10.27.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.26.0",

--- a/@blaxel/core/src/common/browser.ts
+++ b/@blaxel/core/src/common/browser.ts
@@ -4,6 +4,7 @@
 // In browser environments, Node.js built-in modules are not available
 
 // All Node.js modules are null in browser
+export const crypto: any = null;
 export const fs: any = null;
 export const os: any = null;
 export const path: any = null;

--- a/@blaxel/core/src/common/node.ts
+++ b/@blaxel/core/src/common/node.ts
@@ -4,6 +4,7 @@
 import * as fsImport from "fs";
 import * as osImport from "os";
 import * as pathImport from "path";
+import * as cryptoImport from "crypto";
 
 // Detect environments
 const isNode =
@@ -17,6 +18,7 @@ const isBrowser = typeof globalThis !== "undefined" && (globalThis as any)?.wind
 let fs: typeof import("fs") | null = null;
 let os: typeof import("os") | null = null;
 let path: typeof import("path") | null = null;
+let crypto: typeof import("crypto") | null = null;
 let dotenv: typeof import("dotenv") | null = null;
 let ws: any = null; // Used internally by getWebSocket() for caching
 
@@ -25,6 +27,7 @@ if (isNode && !isBrowser) {
   fs = fsImport;
   os = osImport;
   path = pathImport;
+  crypto = cryptoImport;
 
   // Try to load optional dependencies
   try {
@@ -73,5 +76,5 @@ export async function getWebSocket(): Promise<any> {
   }
 }
 
-export { dotenv, fs, os, path };
+export { crypto, dotenv, fs, os, path };
 

--- a/@blaxel/core/src/common/sentry-browser.ts
+++ b/@blaxel/core/src/common/sentry-browser.ts
@@ -1,0 +1,26 @@
+/* eslint-disable */
+
+// Browser/Edge-compatible exports for Sentry
+// In browser/edge environments, @sentry/node is not available
+// All functions are no-ops
+
+/**
+ * Initialize Sentry - no-op in browser/edge environments.
+ */
+export function initSentry(): void {
+  // No-op in browser/edge environments
+}
+
+/**
+ * Flush pending Sentry events - no-op in browser/edge environments.
+ */
+export async function flushSentry(_timeout = 2000): Promise<void> {
+  // No-op in browser/edge environments
+}
+
+/**
+ * Check if Sentry is initialized - always returns false in browser/edge environments.
+ */
+export function isSentryInitialized(): boolean {
+  return false;
+}

--- a/@blaxel/core/src/common/webhook.ts
+++ b/@blaxel/core/src/common/webhook.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from 'crypto';
+import { crypto } from './node.js';
 
 /**
  * Webhook signature verification for async-sidecar callbacks
@@ -72,6 +72,11 @@ export function verifyWebhookSignature(options: WebhookVerificationOptions): boo
     return false;
   }
 
+  // crypto is only available in Node.js environments
+  if (!crypto) {
+    throw new Error('verifyWebhookSignature is only available in Node.js environments');
+  }
+
   try {
     // Verify timestamp if provided (prevents replay attacks)
     if (timestamp) {
@@ -88,12 +93,12 @@ export function verifyWebhookSignature(options: WebhookVerificationOptions): boo
     const expectedSignature = signature.replace('sha256=', '');
 
     // Compute HMAC-SHA256 signature
-    const hmac = createHmac('sha256', secret);
+    const hmac = crypto.createHmac('sha256', secret);
     hmac.update(body);
     const computedSignature = hmac.digest('hex');
 
     // Timing-safe comparison to prevent timing attacks
-    return timingSafeEqual(
+    return crypto.timingSafeEqual(
       Buffer.from(expectedSignature, 'hex'),
       Buffer.from(computedSignature, 'hex')
     );


### PR DESCRIPTION
Updates the build process to correctly replace Node.js-specific code with browser-compatible alternatives for Sentry and other modules. This resolves issues encountered in browser environments, particularly when using Vercel, by ensuring that Node.js dependencies are properly handled.

Specifically:
- Replaces `@sentry/node` with a browser-compatible version.
- Makes `@sentry/node` an optional dependency.
- Excludes Node.js built-in modules in the browser build.
