### PR TITLE
Adds labels support to sandbox configuration

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -63,7 +63,8 @@ export class SandboxInstance {
       'envs' in sandbox ||
       'volumes' in sandbox ||
       'lifecycle' in sandbox ||
-      'snapshotEnabled' in sandbox
+      'snapshotEnabled' in sandbox ||
+      'labels' in sandbox
     ) {
       if (!sandbox) sandbox = {} as SandboxCreateConfiguration
       if (!sandbox.name) sandbox.name = defaultName
@@ -80,7 +81,7 @@ export class SandboxInstance {
       const snapshotEnabled = sandbox.snapshotEnabled;
 
       sandbox = {
-        metadata: { name: sandbox.name },
+        metadata: { name: sandbox.name, labels: sandbox.labels },
         spec: {
           region: region,
           runtime: {

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -48,6 +48,7 @@ export type SandboxCreateConfiguration = {
   region?: string;
   lifecycle?: SandboxLifecycle;
   snapshotEnabled?: boolean;
+  labels?: Record<string, string>;
 }
 
 export function normalizePorts(ports?: (Port | Record<string, any>)[]): Port[] | undefined {

--- a/tests/sandbox/create.ts
+++ b/tests/sandbox/create.ts
@@ -1,4 +1,5 @@
 import { SandboxCreateConfiguration, SandboxInstance } from "@blaxel/core";
+import assert from "assert";
 
 async function main() {
   try {
@@ -19,8 +20,9 @@ async function main() {
     console.log("✅ Deleted spec sandbox");
 
     console.log("\nTest 3: Create sandbox with name...");
-    sandbox = await SandboxInstance.create({ name: "sandbox-with-name" });
-    console.log(`✅ Created sandbox with name: ${sandbox.metadata?.name}`);
+    sandbox = await SandboxInstance.create({ name: "sandbox-with-name", labels: { "test": "test" } });
+    console.log(`✅ Created sandbox with name: ${sandbox.metadata?.name}, labels: ${JSON.stringify(sandbox.metadata?.labels)}`);
+    assert.strictEqual(sandbox.metadata?.labels?.["test"], "test");
     console.log(await sandbox.fs.ls('/blaxel/'));
     await SandboxInstance.delete(sandbox.metadata?.name!);
     console.log("✅ Deleted named sandbox");


### PR DESCRIPTION
Enables the definition of labels when creating a sandbox.

This allows users to attach arbitrary key-value pairs to sandboxes, which can be useful for organization, filtering, and automation purposes.

Add assert for label in test
