### PR TITLE
Adds a delete method to sandbox instances

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -158,6 +158,10 @@ export class SandboxInstance {
     return data;
   }
 
+  async delete() {
+    return await SandboxInstance.delete(this.metadata?.name!);
+  }
+
   static async updateMetadata(sandboxName: string, metadata: SandboxUpdateMetadata) {
     const sandbox = await SandboxInstance.get(sandboxName);
     const body = { ...sandbox.sandbox, metadata: { ...sandbox.metadata, ...metadata } } as SandboxModel

--- a/@blaxel/core/src/volume/index.ts
+++ b/@blaxel/core/src/volume/index.ts
@@ -114,6 +114,10 @@ export class VolumeInstance {
     return data;
   }
 
+  async delete() {
+    return await VolumeInstance.delete(this.metadata?.name ?? "");
+  }
+
   static async createIfNotExists(config: VolumeCreateConfiguration | Volume) {
     try {
       return await VolumeInstance.create(config);


### PR DESCRIPTION
Adds a `delete` method to the `SandboxInstance` class, allowing
for the deletion of a sandbox instance by its name. This provides a
convenient way to remove sandbox instances directly from an instance
object.

Add instance function to delete volume
