### PR TITLE
Enables updating TTL and lifecycle of sandboxes

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { createSandbox, deleteSandbox, getSandbox, listSandboxes, Sandbox as SandboxModel, updateSandbox } from "../client/index.js";
+import { createSandbox, deleteSandbox, getSandbox, listSandboxes, SandboxLifecycle, Sandbox as SandboxModel, updateSandbox } from "../client/index.js";
 import { logger } from "../common/logger.js";
 import { SandboxCodegen } from "./codegen/index.js";
 import { SandboxFileSystem } from "./filesystem/index.js";
@@ -164,6 +164,30 @@ export class SandboxInstance {
   static async updateMetadata(sandboxName: string, metadata: SandboxUpdateMetadata) {
     const sandbox = await SandboxInstance.get(sandboxName);
     const body = { ...sandbox.sandbox, metadata: { ...sandbox.metadata, ...metadata } } as SandboxModel
+    const { data } = await updateSandbox({
+      path: { sandboxName },
+      body,
+      throwOnError: true,
+    });
+    const instance = new SandboxInstance(data);
+    return instance;
+  }
+
+  static async updateTTL(sandboxName: string, ttl: string) {
+    const sandbox = await SandboxInstance.get(sandboxName);
+    const body = { ...sandbox.sandbox, spec: { ...sandbox.spec, runtime: { ...sandbox.spec.runtime, ttl } } } as SandboxModel
+    const { data } = await updateSandbox({
+      path: { sandboxName },
+      body,
+      throwOnError: true,
+    });
+    const instance = new SandboxInstance(data);
+    return instance;
+  }
+
+  static async updateLifecycle(sandboxName: string, lifecycle: SandboxLifecycle) {
+    const sandbox = await SandboxInstance.get(sandboxName);
+    const body = { ...sandbox.sandbox, spec: { ...sandbox.spec, lifecycle } } as SandboxModel
     const { data } = await updateSandbox({
       path: { sandboxName },
       body,

--- a/tests/integration/sandbox/helpers.ts
+++ b/tests/integration/sandbox/helpers.ts
@@ -25,6 +25,28 @@ export function uniqueName(prefix: string = "test"): string {
 }
 
 /**
+ * Waits for a sandbox to be deployed by polling until status is DEPLOYED
+ * @param sandboxName The name of the sandbox to wait for
+ * @param maxAttempts Maximum number of attempts to wait (default: 30 seconds)
+ * @returns Promise<boolean> - true if deployed, false if timeout
+ */
+export async function waitForSandboxDeployed(sandboxName: string, maxAttempts: number = 30): Promise<boolean> {
+  let attempts = 0
+
+  while (attempts < maxAttempts) {
+    const sandbox = await SandboxInstance.get(sandboxName)
+    if (sandbox.status === "DEPLOYED") {
+      return true
+    }
+    await sleep(1000)
+    attempts++
+  }
+
+  console.warn(`Timeout waiting for ${sandboxName} to be deployed`)
+  return false
+}
+
+/**
  * Waits for a sandbox deletion to fully complete by polling until the sandbox no longer exists
  * @param sandboxName The name of the sandbox to wait for deletion
  * @param maxAttempts Maximum number of attempts to wait (default: 30 seconds)


### PR DESCRIPTION
Adds functionality to update the TTL and lifecycle of existing sandboxes without recreating them, preserving their state.

Includes a utility function to wait for sandbox deployment.

Also fixes a bug where updating environment variables was not triggering a reboot, thus ephemeral state was not being cleared.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds functionality to update the TTL and lifecycle of existing sandboxes without recreating them, preserving their state. Includes a utility function to wait for sandbox deployment. Also fixes a bug where updating environment variables was not triggering a reboot, thus ephemeral state was not being cleared.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7c26c6e1d13a5ec834d7fa2b6cb02aa8e1611c38.</sup>
<!-- /MENDRAL_SUMMARY -->