### PR TITLE
Fix vitestconfig

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     globalTeardown: ['tests/integration/sandbox/globalTeardown.ts', 'tests/benchmarks/sandbox/teardown.ts'],
     env: {
       // Tests will use environment variables from shell
-      BL_ENV: "dev"
+      // BL_ENV: "dev"
     },
     benchmark: {
       include: ['tests/benchmarks/**/*.bench.ts'],


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Commenting out the hardcoded `BL_ENV: "dev"` environment variable in vitest config to allow tests to use shell environment variables instead
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1f16feda93358de0a27abad9dd1b9df98527e246.</sup>
<!-- /MENDRAL_SUMMARY -->