### PR TITLE
Fixes workspace dependency resolution for bun

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,7 @@ jobs:
         run: |
           bun install
           bun run build
+          node scripts/replace-workspace-versions.js
           if [ "$DEPLOY_ENV" == "production" ]; then
             npm publish --workspaces --access public --tag latest
           elif [ "$DEPLOY_ENV" == "staging" ]; then

--- a/scripts/replace-workspace-versions.js
+++ b/scripts/replace-workspace-versions.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * This script replaces `workspace:*` dependencies with actual versions
+ * before publishing to npm. npm doesn't handle workspace protocol,
+ * so we need to resolve these manually.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Get all workspace package.json files
+const workspaces = ['core', 'telemetry', 'langgraph', 'llamaindex', 'vercel', 'mastra'];
+
+// Build a map of package name -> version
+const packageVersions = new Map();
+
+for (const workspace of workspaces) {
+  const pkgPath = join(rootDir, '@blaxel', workspace, 'package.json');
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    packageVersions.set(pkg.name, pkg.version);
+    console.log(`Found ${pkg.name}@${pkg.version}`);
+  } catch (err) {
+    console.error(`Failed to read ${pkgPath}:`, err.message);
+    process.exit(1);
+  }
+}
+
+// Now replace workspace:* in all package.json files
+let modified = 0;
+
+for (const workspace of workspaces) {
+  const pkgPath = join(rootDir, '@blaxel', workspace, 'package.json');
+  const pkgContent = readFileSync(pkgPath, 'utf-8');
+  const pkg = JSON.parse(pkgContent);
+  let changed = false;
+
+  // Check all dependency types
+  for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    if (!pkg[depType]) continue;
+
+    for (const [dep, version] of Object.entries(pkg[depType])) {
+      if (version === 'workspace:*') {
+        const actualVersion = packageVersions.get(dep);
+        if (actualVersion) {
+          pkg[depType][dep] = actualVersion;
+          const suffix = depType === 'dependencies' ? '' : ` (${depType.replace('Dependencies', '')})`;
+          console.log(`  ${pkg.name}: ${dep} -> ${actualVersion}${suffix}`);
+          changed = true;
+        } else {
+          console.error(`  ${pkg.name}: Could not find version for ${dep}`);
+          process.exit(1);
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, '\t') + '\n');
+    modified++;
+  }
+}
+
+console.log(`\nReplaced workspace:* in ${modified} package(s)`);


### PR DESCRIPTION
Addresses an issue where bun doesn't correctly handle
workspace dependencies when publishing packages.

Introduces a script that replaces `workspace:*` dependencies
with their actual versions in package.json files before
publishing. This ensures that published packages have
explicit version numbers, resolving the dependency resolution
problem.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a pre-publish script to replace `workspace:*` dependencies with actual version numbers in package.json files, addressing bun's workspace dependency resolution issue when publishing to npm.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 438f92e50837874b01a98ee2f33bbc5646aa0fbf.</sup>
<!-- /MENDRAL_SUMMARY -->