### PR TITLE
docs: update READMEs

### DIFF
--- a/@blaxel/core/README.md
+++ b/@blaxel/core/README.md
@@ -310,19 +310,19 @@ import { blModel } from "@blaxel/core";
 
 // With Vercel AI SDK
 import { blModel } from "@blaxel/vercel";
-const model = await blModel("gpt-4o-mini");
+const model = await blModel("gpt-5-mini");
 
 // With LangChain
 import { blModel } from "@blaxel/langgraph";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 
 // With LlamaIndex
 import { blModel } from "@blaxel/llamaindex";
-const model = await blModel("gpt-4o");
+const model = await blModel("gpt-5-mini");
 
 // With Mastra
 import { blModel } from "@blaxel/mastra";
-const model = await blModel("gpt-4o-mini");
+const model = await blModel("gpt-5-mini");
 ```
 
 #### MCP tool use
@@ -334,19 +334,38 @@ The SDK includes a helper function that retrieves and returns tool definitions f
 ```typescript
 // With Vercel AI SDK
 import { blTools } from "@blaxel/vercel";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With Mastra
 import { blTools } from "@blaxel/mastra";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With LlamaIndex
 import { blTools } from "@blaxel/llamaindex";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With LangChain
 import { blTools } from "@blaxel/langgraph";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
+```
+
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by Vercel's AI SDK:
+
+```typescript
+import { SandboxInstance } from "@blaxel/core";
+import { blTools } from "@blaxel/vercel";
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry

--- a/@blaxel/langgraph/README.md
+++ b/@blaxel/langgraph/README.md
@@ -76,7 +76,7 @@ This package includes a helper function that creates a reference to a model depl
 ```typescript
 // With LangChain
 import { blModel } from "@blaxel/langgraph";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 ```
 
 ### MCP tool use
@@ -85,10 +85,23 @@ Blaxel lets you deploy and host Model Context Protocol (MCP) servers, accessible
 
 This package includes a helper function that retrieves and returns tool definitions from a Blaxel-hosted MCP server in the format required by specific frameworks.
 
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by LangGraph:
+
 ```typescript
-// With LangChain
+import { SandboxInstance } from "@blaxel/core";
 import { blTools } from "@blaxel/langgraph";
-const tools = await blTools(['blaxel-search'])
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry

--- a/@blaxel/llamaindex/README.md
+++ b/@blaxel/llamaindex/README.md
@@ -74,7 +74,7 @@ This package includes a helper function that creates a reference to a model depl
 ```typescript
 // With LlamaIndex
 import { blModel } from "@blaxel/llamaindex";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 ```
 
 ### MCP tool use
@@ -83,10 +83,23 @@ Blaxel lets you deploy and host Model Context Protocol (MCP) servers, accessible
 
 This package includes a helper function that retrieves and returns tool definitions from a Blaxel-hosted MCP server in the format required by specific frameworks.
 
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by LlamaIndex:
+
 ```typescript
-// With LlamaIndex
+import { SandboxInstance } from "@blaxel/core";
 import { blTools } from "@blaxel/llamaindex";
-const tools = await blTools(['blaxel-search'])
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry

--- a/@blaxel/mastra/README.md
+++ b/@blaxel/mastra/README.md
@@ -79,7 +79,7 @@ This package includes a helper function that creates a reference to a model depl
 ```typescript
 // With Mastra
 import { blModel } from "@blaxel/mastra";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 ```
 
 ### MCP tool use
@@ -88,10 +88,23 @@ Blaxel lets you deploy and host Model Context Protocol (MCP) servers, accessible
 
 This package includes a helper function that retrieves and returns tool definitions from a Blaxel-hosted MCP server in the format required by specific frameworks.
 
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by Mastra:
+
 ```typescript
-// With Mastra
+import { SandboxInstance } from "@blaxel/core";
 import { blTools } from "@blaxel/mastra";
-const tools = await blTools(['blaxel-search'])
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry

--- a/@blaxel/vercel/README.md
+++ b/@blaxel/vercel/README.md
@@ -74,7 +74,7 @@ This package includes a helper function that creates a reference to a model depl
 ```typescript
 // With Vercel AI
 import { blModel } from "@blaxel/vercel";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 ```
 
 ### MCP tool use
@@ -83,10 +83,23 @@ Blaxel lets you deploy and host Model Context Protocol (MCP) servers, accessible
 
 This package includes a helper function that retrieves and returns tool definitions from a Blaxel-hosted MCP server in the format required by specific frameworks.
 
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by Vercel's AI SDK:
+
 ```typescript
-// With Vercel AI
+import { SandboxInstance } from "@blaxel/core";
 import { blTools } from "@blaxel/vercel";
-const tools = await blTools(['blaxel-search'])
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry

--- a/README.md
+++ b/README.md
@@ -310,19 +310,19 @@ import { blModel } from "@blaxel/core";
 
 // With Vercel AI SDK
 import { blModel } from "@blaxel/vercel";
-const model = await blModel("gpt-4o-mini");
+const model = await blModel("gpt-5-mini");
 
 // With LangChain
 import { blModel } from "@blaxel/langgraph";
-const model = await blModel("claude-3-5-sonnet");
+const model = await blModel("gpt-5-mini");
 
 // With LlamaIndex
 import { blModel } from "@blaxel/llamaindex";
-const model = await blModel("gpt-4o");
+const model = await blModel("gpt-5-mini");
 
 // With Mastra
 import { blModel } from "@blaxel/mastra";
-const model = await blModel("gpt-4o-mini");
+const model = await blModel("gpt-5-mini");
 ```
 
 #### MCP tool use
@@ -334,19 +334,38 @@ The SDK includes a helper function that retrieves and returns tool definitions f
 ```typescript
 // With Vercel AI SDK
 import { blTools } from "@blaxel/vercel";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With Mastra
 import { blTools } from "@blaxel/mastra";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With LlamaIndex
 import { blTools } from "@blaxel/llamaindex";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
 
 // With LangChain
 import { blTools } from "@blaxel/langgraph";
-const tools = await blTools(['blaxel-search'])
+const tools = await blTools(['sandbox/my-sandbox'])
+```
+
+Here is an example of retrieving tool definitions from a Blaxel sandbox's MCP server in the format required by Vercel's AI SDK:
+
+```typescript
+import { SandboxInstance } from "@blaxel/core";
+import { blTools } from "@blaxel/vercel";
+
+// Create a new sandbox
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  memory: 4096,
+  region: "us-pdx-1",
+  ttl: "24h"
+});
+
+// Get sandbox tools
+const tools = await blTools(['sandbox/my-sandbox'])
 ```
 
 ### Telemetry


### PR DESCRIPTION
Update model names, add MCP tool use example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes documentation across root and package READMEs to align examples with current recommendations.
> 
> - Updates `blModel` examples to use `"gpt-5-mini"` across `core`, `vercel`, `langgraph`, `llamaindex`, and `mastra`
> - Replaces MCP tool examples from `"blaxel-search"` to `"sandbox/my-sandbox"`
> - Adds end-to-end examples showing sandbox creation via `SandboxInstance.createIfNotExists(...)` and retrieving tools with `blTools(['sandbox/my-sandbox'])` for each integration package
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba3dbf77b8d0b33b8e151924345336289ebcd1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates README documentation to use consistent model names (gpt-5-mini) across all framework examples and adds expanded MCP tool usage examples with sandbox creation code
> 
> <sup>Written by [Mendral](https://mendral.com) for commit aba3dbf77b8d0b33b8e151924345336289ebcd1b.</sup>
<!-- /MENDRAL_SUMMARY -->