### PR TITLE
fix: add Cache-Control header to prevent response transformation by p…

### DIFF
--- a/@blaxel/vercel/src/model.ts
+++ b/@blaxel/vercel/src/model.ts
@@ -84,10 +84,12 @@ export const blModel = async (
     delete existingHeaders['Authorization'];
 
     const headers = {
+      // Prevent proxies from transforming/compressing the response
+      // We had an issue with APICallError [AI_APICallError]: Invalid JSON response
+      // It's due to a compression error through our gateway proxy, when some compression header are set.
+      'Cache-Control': 'no-transform',
       ...existingHeaders,
       ...settings.headers,
-      // Prevent proxies (like Cloudflare) from transforming/compressing the response
-      'Cache-Control': 'no-transform',
     };
 
     return fetch(input, {


### PR DESCRIPTION
…roxies

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Add Cache-Control: no-transform header to prevent proxy transformation issues causing Brotli decompression errors
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7aa3a29d9f3c375a9c012dfbeb8e5071d9e4376c.</sup>
<!-- /MENDRAL_SUMMARY -->