### PR TITLE
Fix region test

### DIFF
--- a/tests/integration/sandbox/region.test.ts
+++ b/tests/integration/sandbox/region.test.ts
@@ -282,6 +282,7 @@ describe('BL_REGION Environment Variable Auto-Fill', () => {
       const volume1Name = uniqueName("mixed-vol1")
       const volume2Name = uniqueName("mixed-vol2")
 
+
       // Volume 1: auto-filled from BL_REGION
       const volume1 = await VolumeInstance.create({
         name: volume1Name,
@@ -299,7 +300,7 @@ describe('BL_REGION Environment Variable Auto-Fill', () => {
       })
       createdVolumes.push(volume2Name)
 
-      expect(volume1.spec.region).toBe(defaultRegion)
+      expect(volume1.spec.region).toBe(process.env.BL_REGION)
       expect(volume2.spec.region).toBe(explicitRegion)
     })
   })
@@ -307,7 +308,8 @@ describe('BL_REGION Environment Variable Auto-Fill', () => {
   describe('BL_REGION changes during runtime', () => {
     it('respects BL_REGION changes between create calls', async () => {
       // Create first resource with region1
-      process.env.BL_REGION = process.env.BL_ENV === "dev" ? "eu-dub-1" : "us-was-1"
+      let region1 = process.env.BL_ENV === "dev" ? "eu-dub-1" : "us-was-1"
+      process.env.BL_REGION = region1
       const name1 = uniqueName("region1")
       const sandbox1 = await SandboxInstance.create({
         name: name1,
@@ -316,10 +318,11 @@ describe('BL_REGION Environment Variable Auto-Fill', () => {
       })
       createdSandboxes.push(name1)
 
-      expect(sandbox1.spec.region).toBe(defaultRegion)
+      expect(sandbox1.spec.region).toBe(process.env.BL_REGION)
 
       // Change BL_REGION and create second resource
-      process.env.BL_REGION = process.env.BL_ENV === "dev" ? "eu-dub-2" : "us-was-1"
+      let region2 = process.env.BL_ENV === "dev" ? "eu-dub-1" : "eu-lon-1"
+      process.env.BL_REGION = region2
       const name2 = uniqueName("region2")
       const sandbox2 = await SandboxInstance.create({
         name: name2,
@@ -328,10 +331,7 @@ describe('BL_REGION Environment Variable Auto-Fill', () => {
       })
       createdSandboxes.push(name2)
 
-      expect(sandbox2.spec.region).toBe(defaultRegion)
-
-      // Verify both sandboxes have different regions
-      expect(sandbox1.spec.region).not.toBe(process.env.BL_REGION)
+      expect(sandbox2.spec.region).toBe(region2)
     })
   })
 })


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fix region test assertions to use `process.env.BL_REGION` instead of `defaultRegion` constant, and refactor region assignment logic
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4134a544b773464ebb8b87a67e115a6c4c3d745b.</sup>
<!-- /MENDRAL_SUMMARY -->