### PR TITLE
Refactors client credentials for auto-refresh

### DIFF
--- a/@blaxel/core/src/authentication/clientcredentials.ts
+++ b/@blaxel/core/src/authentication/clientcredentials.ts
@@ -40,10 +40,15 @@ export class ClientCredentials extends Credentials {
   }
 
   async authenticate() {
-    if (!this.needRefresh()) {
-      return this.currentPromise || Promise.resolve();
+    if (this.currentPromise) {
+      return this.currentPromise;
     }
-    this.currentPromise = this.processWithRetry();
+    if (!this.needRefresh()) {
+      return Promise.resolve();
+    }
+    this.currentPromise = this.processWithRetry().finally(() => {
+      this.currentPromise = null;
+    });
     return this.currentPromise;
   }
 
@@ -76,7 +81,6 @@ export class ClientCredentials extends Credentials {
       throw new Error(response.error.error);
     }
     this.accessToken = response.data?.access_token || "";
-    this.currentPromise = null;
   }
 
   get authorization() {

--- a/@blaxel/core/src/common/autoload.ts
+++ b/@blaxel/core/src/common/autoload.ts
@@ -32,6 +32,9 @@ export function initialize(config: Config) {
   client.setConfig({
     baseUrl: settings.baseUrl,
   });
+  clientSandbox.setConfig({
+    baseUrl: settings.baseUrl,
+  });
 }
 
 export function authenticate() {

--- a/tests/integration/common/client-credentials-refresh.test.ts
+++ b/tests/integration/common/client-credentials-refresh.test.ts
@@ -1,0 +1,70 @@
+import { initialize, SandboxInstance, settings } from "@blaxel/core"
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { ClientCredentials } from '../../../@blaxel/core/src/authentication/clientcredentials.js'
+
+const skipTest = !process.env.BL_CLIENT_CREDENTIALS
+
+interface ClientCredentialsTestable {
+  accessToken: string
+  currentPromise: Promise<void> | null
+  token: string
+}
+
+function createExpiredJwt(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ exp: 1000000000, iat: 999999900, sub: "test" })).toString('base64url')
+  return `${header}.${payload}.fakesig`
+}
+
+describe.skipIf(skipTest)('ClientCredentials token auto-refresh', () => {
+  const originalCredentials = settings.credentials
+
+  beforeAll(() => {
+    initialize({})
+    settings.credentials = new ClientCredentials({
+      clientCredentials: process.env.BL_CLIENT_CREDENTIALS!,
+      workspace: process.env.BL_WORKSPACE,
+    })
+  })
+
+  afterAll(() => {
+    settings.credentials = originalCredentials
+  })
+
+  it('refreshes an expired token before making the next API call', async () => {
+    const creds = settings.credentials as unknown as ClientCredentialsTestable
+    const authenticateSpy = vi.spyOn(settings.credentials, 'authenticate')
+    const needRefreshSpy = vi.spyOn(ClientCredentials.prototype, 'needRefresh')
+    const processWithRetrySpy = vi.spyOn(ClientCredentials.prototype as never, 'processWithRetry')
+
+    const list1 = await SandboxInstance.list()
+    expect(Array.isArray(list1)).toBe(true)
+
+    expect(creds.token).toBeTruthy()
+    expect(authenticateSpy).toHaveBeenCalled()
+    expect(needRefreshSpy).toHaveBeenCalled()
+    expect(needRefreshSpy).toHaveReturnedWith(true)
+    expect(processWithRetrySpy).toHaveBeenCalled()
+
+    authenticateSpy.mockClear()
+    needRefreshSpy.mockClear()
+    processWithRetrySpy.mockClear()
+
+    creds.accessToken = createExpiredJwt()
+    creds.currentPromise = null
+
+    const list2 = await SandboxInstance.list()
+    expect(Array.isArray(list2)).toBe(true)
+
+    expect(authenticateSpy).toHaveBeenCalled()
+    expect(needRefreshSpy).toHaveBeenCalled()
+    expect(needRefreshSpy).toHaveReturnedWith(true)
+    expect(processWithRetrySpy).toHaveBeenCalled()
+    expect(creds.token).toBeTruthy()
+    expect(creds.token).not.toBe(createExpiredJwt())
+
+    authenticateSpy.mockRestore()
+    needRefreshSpy.mockRestore()
+    processWithRetrySpy.mockRestore()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,7 @@
+import dotenv from 'dotenv'
 import { defineConfig } from 'vitest/config'
+
+dotenv.config()
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Ensures token auto-refresh before API calls by managing the `currentPromise` to prevent concurrent refresh attempts.

Adds an integration test to verify the auto-refresh mechanism.

Updates the client sandbox to use the base URL.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors `ClientCredentials.authenticate()` to prevent concurrent token refresh attempts by checking `currentPromise` upfront and clearing it via `.finally()`. Also fixes `clientSandbox` missing `baseUrl` in `initialize()`, and adds an integration test for the auto-refresh flow.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6846c0b5bee571967f4bf5c545cf96c8ee58b41c.</sup>
<!-- /MENDRAL_SUMMARY -->