### PR TITLE
Update SDK auto

### DIFF
--- a/@blaxel/core/src/client/types.gen.ts
+++ b/@blaxel/core/src/client/types.gen.ts
@@ -776,10 +776,6 @@ export type FunctionSpec = {
      * When true, the function is publicly accessible without authentication. Only available for mk3 generation.
      */
     public?: boolean;
-    /**
-     * Base64-encoded API reference for MCP code mode
-     */
-    reference?: string;
     revision?: RevisionConfiguration;
     runtime?: FunctionRuntime;
     triggers?: Triggers;
@@ -799,10 +795,6 @@ export type FunctionSpecWritable = {
      * When true, the function is publicly accessible without authentication. Only available for mk3 generation.
      */
     public?: boolean;
-    /**
-     * Base64-encoded API reference for MCP code mode
-     */
-    reference?: string;
     revision?: RevisionConfiguration;
     runtime?: FunctionRuntime;
     triggers?: TriggersWritable;


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the `reference` field (Base64-encoded API reference for MCP code mode) from both `FunctionSpec` and `FunctionSpecWritable` types in the auto-generated SDK types file.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9055eff05dbb9246336d79aac7dbc84e3557ef2c.</sup>
<!-- /MENDRAL_SUMMARY -->