### PR TITLE
Fix stream logs test by adding headers/params support to agent calls and wait() to process stream

### DIFF
--- a/@blaxel/core/src/agents/index.ts
+++ b/@blaxel/core/src/agents/index.ts
@@ -48,17 +48,24 @@ class BlAgent {
 
   async call(
     url: URL,
-    input: Record<string, unknown> | string | undefined
+    input: Record<string, unknown> | string | undefined,
+    headers: Record<string, string> = {},
+    params: Record<string, string> = {}
   ): Promise<Response> {
     let body = input;
     if (typeof body != "string") {
       body = JSON.stringify(body);
     }
-    const response = await fetch(url, {
+    const fetchUrl = new URL(url.toString());
+    for (const [key, value] of Object.entries(params)) {
+      fetchUrl.searchParams.set(key, value);
+    }
+    const response = await fetch(fetchUrl, {
       method: "POST",
       headers: {
         ...settings.headers,
         "Content-Type": "application/json",
+        ...headers,
       },
       body,
     });
@@ -66,7 +73,9 @@ class BlAgent {
   }
 
   async run(
-    input: Record<string, unknown> | string | undefined
+    input: Record<string, unknown> | string | undefined,
+    headers: Record<string, string> = {},
+    params: Record<string, string> = {}
   ): Promise<string> {
     logger.debug(`Agent Calling: ${this.agentName}`);
 
@@ -80,7 +89,7 @@ class BlAgent {
     });
 
     try {
-      const response = await this.call(this.url, input);
+      const response = await this.call(this.url, input, headers, params);
       span.setAttribute("agent.run.result", await response.text());
       return await response.text();
     } catch (err: unknown) {
@@ -90,7 +99,7 @@ class BlAgent {
           throw err;
         }
         try {
-          const response = await this.call(this.fallbackUrl, input);
+          const response = await this.call(this.fallbackUrl, input, headers, params);
           span.setAttribute("agent.run.result", await response.text());
           return await response.text();
         } catch (err: unknown) {

--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -17,7 +17,7 @@ export class SandboxProcess extends SandboxAction {
       onStderr?: (stderr: string) => void,
       onError?: (error: Error) => void,
     } = {}
-  ): { close: () => void } {
+  ): { close: () => void, wait: () => Promise<void> } {
     const controller = new AbortController();
     const handleError = (err: Error) => {
       if (options.onError) {
@@ -27,7 +27,7 @@ export class SandboxProcess extends SandboxAction {
       }
     };
 
-    void (async () => {
+    const done = (async () => {
       try {
         const headers = this.sandbox.forceUrl ? this.sandbox.headers : settings.headers;
         const stream = await fetch(`${this.url}/process/${identifier}/logs/stream`, {
@@ -81,6 +81,7 @@ export class SandboxProcess extends SandboxAction {
 
     return {
       close: () => controller.abort(),
+      wait: () => done,
     };
   }
 

--- a/tests/integration/sandbox/process.test.ts
+++ b/tests/integration/sandbox/process.test.ts
@@ -125,7 +125,7 @@ describe('Sandbox Process Operations', () => {
 
       await sandbox.process.exec({
         name: "stdout-test",
-        command: "for i in $(seq 1 5); do sleep 0.5; echo tick $i; sleep 0.5; done && echo 'stderr here' >&2",
+        command: "for i in $(seq 1 5); do sleep 0.1; echo tick $i; sleep 0.1; done && echo 'stderr here' >&2",
         waitForCompletion: false
       })
 
@@ -141,8 +141,7 @@ describe('Sandbox Process Operations', () => {
         }
       })
 
-      await sandbox.process.wait("stdout-test")
-      stream.close()
+      await stream.wait()
 
       expect(stdoutLogs.join(' ')).toContain('tick 1')
       expect(stdoutLogs.join(' ')).toContain('tick 2')


### PR DESCRIPTION
- Added `headers` and `params` optional parameters to `BlAgent.call()` and `BlAgent.run()` methods, allowing custom headers and query parameters to be passed through agent invocations
- Added query param support by constructing a new URL with `searchParams` before fetching
- Fixed `SandboxProcess.streamLogs()` to return a `wait()` method alongside `close()`, enabling callers to await stream completion rather than using a separate `process.wait()` call
- Updated integration test to use `stream.wait()` instead of `sandbox.process.wait()` + `stream.close()` for cleaner stream lifecycle management
- Reduced sleep intervals in test command from 0.5s to 0.1s to speed up test execution

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds optional `headers` and `params` parameters to `BlAgent.call()` and `BlAgent.run()`, enabling custom headers and query parameters in agent invocations. Also refactors `SandboxProcess.streamLogs()` to return a `wait()` method so callers can await stream completion directly, replacing the previous pattern of calling `process.wait()` + `stream.close()` separately.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 28fd8a5a4ee82faf79c14a87c331bca820af708b.</sup>
<!-- /MENDRAL_SUMMARY -->