### PR TITLE
Fix agent force url

### DIFF
--- a/@blaxel/core/src/agents/index.ts
+++ b/@blaxel/core/src/agents/index.ts
@@ -37,7 +37,7 @@ class BlAgent {
   }
 
   get forcedUrl() {
-    return getForcedUrl('function', this.agentName)
+    return getForcedUrl('agent', this.agentName)
   }
 
   get url() {


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a bug where `BlAgent.forcedUrl` was calling `getForcedUrl` with the wrong resource type `'function'` instead of `'agent'`, causing incorrect URL resolution for agents.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c914041435be0191071198b1594a9e2e23416390.</sup>
<!-- /MENDRAL_SUMMARY -->