### PR TITLE
Add CI/CD trigger for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: TS SDK build
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - "main"

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -142,7 +142,6 @@ class Settings {
     return this.credentials.authorization;
   }
 
-  
   get token(): string {
     if(this.config.apikey) {
       return this.config.apikey;


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `workflow_dispatch` trigger to the TS SDK build workflow, allowing manual runs in addition to pull request triggers. Also removes a trailing blank line in `settings.ts`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 907c4d697e526d1a2bab66340d8d2433e6cedbdf.</sup>
<!-- /MENDRAL_SUMMARY -->