### PR TITLE
ci: gate image build test behind IMAGE_BUILD env var

### DIFF
--- a/tests/integration/sandbox/image-build.test.ts
+++ b/tests/integration/sandbox/image-build.test.ts
@@ -10,7 +10,9 @@ import { describe, it, expect, afterAll } from 'vitest'
 import { ImageInstance, SandboxInstance, deleteSandbox } from "@blaxel/core"
 import { uniqueName, waitForSandboxDeletion } from './helpers'
 
-describe('Image Build Integration', () => {
+const IMAGE_BUILD = process.env.IMAGE_BUILD === 'true'
+
+describe.skipIf(!IMAGE_BUILD)('Image Build Integration', () => {
   const createdSandboxes: string[] = []
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- Skip the Image Build Integration test suite unless `IMAGE_BUILD=true` environment variable is set
- Uses `describe.skipIf(!IMAGE_BUILD)` to conditionally skip the entire test block

## Test plan
- [ ] Run tests without `IMAGE_BUILD` set - image build tests should be skipped
- [ ] Run tests with `IMAGE_BUILD=true` - image build tests should execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Gates the Image Build Integration test suite behind an `IMAGE_BUILD=true` environment variable using Vitest's `describe.skipIf` to avoid running expensive/slow image build tests by default.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b798dc0c55ba171fe1e8bda904b4a44080ad4350.</sup>
<!-- /MENDRAL_SUMMARY -->