### PR TITLE
Fix CodeInterpreter to use super.create/createIfNotExists and simplify sandbox config merging

### DIFF
--- a/@blaxel/core/src/sandbox/interpreter.ts
+++ b/@blaxel/core/src/sandbox/interpreter.ts
@@ -39,56 +39,42 @@ export class CodeInterpreter extends SandboxInstance {
     sandbox?: Sandbox | SandboxCreateConfiguration | Record<string, any> | null,
     { safe = true }: { safe?: boolean } = {}
   ): Promise<CodeInterpreter> {
-    const payload: Record<string, any> = {
+    // Build a SandboxCreateConfiguration with CodeInterpreter defaults
+    const defaults: SandboxCreateConfiguration = {
       image: CodeInterpreter.DEFAULT_IMAGE,
       ports: CodeInterpreter.DEFAULT_PORTS,
       lifecycle: CodeInterpreter.DEFAULT_LIFECYCLE,
     };
 
-    const allowedCopyKeys = new Set(["name", "envs", "memory", "region", "headers", "labels"]);
+    let merged: Sandbox | SandboxCreateConfiguration;
 
-    if (sandbox && typeof sandbox === "object") {
-      if (Array.isArray(sandbox)) {
-        // Skip arrays
-      } else if ("metadata" in sandbox || "spec" in sandbox) {
-        // It's a Sandbox object
+    if (sandbox && typeof sandbox === "object" && !Array.isArray(sandbox)) {
+      if ("metadata" in sandbox || "spec" in sandbox) {
+        // It's a Sandbox object - inject defaults into spec
         const sandboxObj = sandbox as Sandbox;
-        if (sandboxObj.metadata.name) {
-          payload["name"] = sandboxObj.metadata.name;
-        }
-        if (sandboxObj.metadata.labels) {
-          payload["labels"] = sandboxObj.metadata.labels;
-        }
-        if (sandboxObj.spec.runtime) {
-          if (sandboxObj.spec.runtime.envs) {
-            payload["envs"] = sandboxObj.spec.runtime.envs;
-          }
-          if (sandboxObj.spec.runtime.memory) {
-            payload["memory"] = sandboxObj.spec.runtime.memory;
-          }
-        }
-        if (sandboxObj.spec.region) {
-          payload["region"] = sandboxObj.spec.region;
-        }
-      } else if ("name" in sandbox || "image" in sandbox || "memory" in sandbox) {
-        // It's a SandboxCreateConfiguration or dict-like object
-        const sandboxDict = sandbox as Record<string, unknown>;
-        for (const k of allowedCopyKeys) {
-          const value = sandboxDict[k];
-          if (value !== null && value !== undefined) {
-            payload[k] = value;
-          }
-        }
+        merged = {
+          ...sandboxObj,
+          spec: {
+            ...sandboxObj.spec,
+            runtime: {
+              image: defaults.image,
+              ports: defaults.ports,
+              ...sandboxObj.spec?.runtime,
+            },
+            lifecycle: sandboxObj.spec?.lifecycle || defaults.lifecycle,
+          },
+        } as Sandbox;
+      } else {
+        // It's a SandboxCreateConfiguration or dict-like object - merge with defaults
+        merged = { ...defaults, ...sandbox } as SandboxCreateConfiguration;
       }
+    } else {
+      merged = defaults;
     }
 
-    // Auto-fill region with BL_REGION if not set
-    if (!payload["region"] && settings.region) {
-      payload["region"] = settings.region;
-    }
+    const baseInstance = await super.create(merged, { safe });
 
-    const baseInstance = await SandboxInstance.create(payload, { safe });
-    // Create config from the instance - preserve any forceUrl/headers if provided in input
+    // Create config from the instance
     const config: SandboxConfiguration = {
       metadata: baseInstance.metadata,
       spec: baseInstance.spec,
@@ -96,7 +82,7 @@ export class CodeInterpreter extends SandboxInstance {
       events: baseInstance.events,
       h2Session: baseInstance.h2Session,
     };
-    // Preserve forceUrl and headers from input if it was a dict-like object
+    // Preserve forceUrl, headers, and params from input if provided
     if (sandbox && typeof sandbox === "object" && !Array.isArray(sandbox)) {
       if ("forceUrl" in sandbox && typeof sandbox.forceUrl === "string") {
         config.forceUrl = sandbox.forceUrl;
@@ -111,30 +97,8 @@ export class CodeInterpreter extends SandboxInstance {
     return new CodeInterpreter(config);
   }
 
-  static async createIfNotExists(sandbox: Sandbox | SandboxCreateConfiguration) {
-    try {
-      return await CodeInterpreter.create(sandbox);
-    } catch (e) {
-      if (typeof e === "object" && e !== null && "code" in e && (e.code === 409 || e.code === 'SANDBOX_ALREADY_EXISTS')) {
-        const name = 'name' in sandbox ? sandbox.name : (sandbox as Sandbox).metadata.name
-        if (!name) {
-          throw new Error("Name is required");
-        }
-
-        // Get the existing sandbox to check its status
-        const baseInstance = await CodeInterpreter.get(name);
-
-          // If the sandbox is TERMINATED, treat it as not existing
-          if (baseInstance.status === "TERMINATED") {
-            // Create a new sandbox - backend will handle cleanup of the terminated one
-            return await CodeInterpreter.create(sandbox);
-          }
-
-        // Otherwise return the existing running sandbox
-        return baseInstance;
-      }
-      throw e;
-    }
+  static async createIfNotExists(sandbox: Sandbox | SandboxCreateConfiguration): Promise<CodeInterpreter> {
+    return await super.createIfNotExists(sandbox) as CodeInterpreter;
   }
 
   get _jupyterUrl(): string {

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -265,7 +265,7 @@ export class SandboxInstance {
 
   static async createIfNotExists(sandbox: SandboxModel | SandboxCreateConfiguration) {
     try {
-      return await SandboxInstance.create(sandbox);
+      return await this.create(sandbox);
     } catch (e) {
       if (typeof e === "object" && e !== null && "code" in e && (e.code === 409 || e.code === 'SANDBOX_ALREADY_EXISTS')) {
         const name = 'name' in sandbox ? sandbox.name : (sandbox as SandboxModel).metadata.name
@@ -274,12 +274,12 @@ export class SandboxInstance {
         }
 
         // Get the existing sandbox to check its status
-        const sandboxInstance = await SandboxInstance.get(name);
+        const sandboxInstance = await this.get(name);
 
           // If the sandbox is TERMINATED, treat it as not existing
           if (sandboxInstance.status === "TERMINATED") {
             // Create a new sandbox - backend will handle cleanup of the terminated one
-            return await SandboxInstance.create(sandbox);
+            return await this.create(sandbox);
           }
 
         // Otherwise return the existing running sandbox

--- a/tests/integration/sandbox/interpreter.test.ts
+++ b/tests/integration/sandbox/interpreter.test.ts
@@ -144,4 +144,59 @@ describe('CodeInterpreter Operations', () => {
       expect(retrieved.metadata.name).toBe(interpreter.metadata.name)
     })
   })
+
+  describe('createIfNotExists', () => {
+    const cineNames: string[] = []
+
+    afterAll(async () => {
+      await Promise.all(
+        cineNames.map(async (name) => {
+          try {
+            await CodeInterpreter.delete(name)
+          } catch {
+            // Ignore cleanup errors
+          }
+        })
+      )
+    })
+
+    it('creates a new interpreter if it does not exist', async () => {
+      const name = uniqueName("ci-cine")
+      cineNames.push(name)
+
+      const ci = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+
+      expect(ci.metadata.name).toBe(name)
+      expect(ci).toBeInstanceOf(CodeInterpreter)
+    }, 180000)
+
+    it('returns existing interpreter if it already exists', async () => {
+      const name = uniqueName("ci-cine-existing")
+      cineNames.push(name)
+
+      const first = await CodeInterpreter.create({ name, labels: defaultLabels })
+      const second = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+
+      expect(second.metadata.name).toBe(first.metadata.name)
+      expect(second).toBeInstanceOf(CodeInterpreter)
+    }, 180000)
+
+    it('returned interpreter can run code', async () => {
+      const name = uniqueName("ci-cine-run")
+      cineNames.push(name)
+
+      const ci = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+
+      const stdoutLines: string[] = []
+      await ci.runCode("print('hello from createIfNotExists')", {
+        language: "python",
+        onStdout: (msg) => {
+          stdoutLines.push(msg.text)
+        },
+        timeout: 30.0,
+      })
+
+      expect(stdoutLines.join('')).toContain('hello from createIfNotExists')
+    }, 180000)
+  })
 })


### PR DESCRIPTION
- Refactored `CodeInterpreter.create` to use `super.create` instead of `SandboxInstance.create`, ensuring proper inheritance chain is respected
- Simplified sandbox configuration merging logic: instead of manually copying allowed keys, defaults are now spread-merged with the provided config, making the code cleaner and less error-prone
- Added `CodeInterpreter.createIfNotExists` static method that delegates to `super.createIfNotExists` and returns a properly typed `CodeInterpreter` instance
- Fixed `SandboxInstance.createIfNotExists` to use `this.create` and `this.get` instead of `SandboxInstance.create`/`SandboxInstance.get`, enabling subclass polymorphism
- Added integration tests for `createIfNotExists` covering: new interpreter creation, returning an existing interpreter, and verifying the returned instance can execute code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors `CodeInterpreter.create` to use `super.create` with spread-merged config instead of manually copying allowed keys, fixes `SandboxInstance.createIfNotExists` to use polymorphic `this.create`/`this.get`, and adds a `CodeInterpreter.createIfNotExists` override with integration tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 30b7bdf1ccebf8cca1a86cba9efc5a16f33d80c7.</sup>
<!-- /MENDRAL_SUMMARY -->