### PR TITLE
fix: remove process.exit() from Sentry signal handlers

### DIFF
--- a/@blaxel/core/src/common/sentry.ts
+++ b/@blaxel/core/src/common/sentry.ts
@@ -222,15 +222,12 @@ export function initSentry() {
 
       // Node.js specific handlers
       if (typeof process !== "undefined" && typeof process.on === "function") {
-        // For SIGTERM/SIGINT, flush before exit
-        const signalHandler = (signal: NodeJS.Signals) => {
-          flushSentry(500)
-            .catch(() => {
-              // Silently fail
-            })
-            .finally(() => {
-              process.exit(signal === "SIGTERM" ? 143 : 130);
-            });
+        // Flush Sentry on termination signals without calling process.exit(),
+        // so the host application retains control over its own shutdown lifecycle.
+        const signalHandler = () => {
+          flushSentry(500).catch(() => {
+            // Silently fail
+          });
         };
 
         // Monitor uncaught exceptions to capture SDK errors without
@@ -241,8 +238,8 @@ export function initSentry() {
           }
         };
 
-        process.on("SIGTERM", () => signalHandler("SIGTERM"));
-        process.on("SIGINT", () => signalHandler("SIGINT"));
+        process.on("SIGTERM", signalHandler);
+        process.on("SIGINT", signalHandler);
         process.on("uncaughtExceptionMonitor", uncaughtExceptionMonitorHandler);
 
         // Intercept console.error to capture SDK errors that are caught and logged


### PR DESCRIPTION
## Summary
- Remove `process.exit()` calls from SIGTERM/SIGINT signal handlers in the SDK's Sentry integration
- As a library, the SDK should not forcefully terminate the host process — this hijacks the application's shutdown lifecycle, preventing graceful cleanup (draining connections, finishing in-flight requests, closing DB connections, etc.)
- The handlers now just flush Sentry and let the host application control when to exit

## Context
Introduced in #204 (`@blaxel/core@0.2.4-dev4`, first stable in `0.2.59`). 

Minimal repro: https://github.com/iammerrick/blaxel-sigterm-poc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Node.js termination-signal handling in the Sentry integration; behavior on SIGTERM/SIGINT will no longer force an immediate exit, which could affect apps that implicitly relied on the SDK to terminate the process.
> 
> **Overview**
> Updates the SDK’s Sentry integration so `SIGTERM`/`SIGINT` handlers **only flush pending events** and no longer call `process.exit()`, leaving shutdown/exit control to the host application.
> 
> Also simplifies the signal handler signature and direct `process.on(...)` registrations while keeping the existing uncaught-exception monitoring and console interception behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fedf30de6a05b2a562b08f8b8bea3c133bfe546. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes `process.exit()` from SIGTERM/SIGINT signal handlers in the Sentry integration. Previously the SDK forcefully terminated the host process after flushing, hijacking the application's shutdown lifecycle. Now the handlers only flush Sentry and return, letting the host application control when to exit.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0fedf30de6a05b2a562b08f8b8bea3c133bfe546.</sup>
<!-- /MENDRAL_SUMMARY -->