### PR TITLE
Sentry - Use process.once instead of process.on

### DIFF
--- a/@blaxel/core/src/common/sentry.ts
+++ b/@blaxel/core/src/common/sentry.ts
@@ -238,8 +238,8 @@ export function initSentry() {
           }
         };
 
-        process.on("SIGTERM", signalHandler);
-        process.on("SIGINT", signalHandler);
+        process.once("SIGTERM", signalHandler);
+        process.once("SIGINT", signalHandler);
         process.on("uncaughtExceptionMonitor", uncaughtExceptionMonitorHandler);
 
         // Intercept console.error to capture SDK errors that are caught and logged


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Switches SIGTERM and SIGINT signal handlers from `process.on` to `process.once` to ensure the `signalHandler` fires at most once per signal, preventing potential duplicate Sentry flushes if the handler were ever registered more than once.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0bc42698b3f0fac7ad89550072cf8f5d2d93b155.</sup>
<!-- /MENDRAL_SUMMARY -->