### PR TITLE
Add fetch method to SandboxNetwork/SandboxInstance and scale waitForPorts test to 20 concurrent sandboxes

### DIFF
--- a/@blaxel/core/src/sandbox/network/network.ts
+++ b/@blaxel/core/src/sandbox/network/network.ts
@@ -1,8 +1,30 @@
 import { Sandbox } from "../../client/types.gen.js";
+import { settings } from "../../common/settings.js";
 import { SandboxAction } from "../action.js";
 
 export class SandboxNetwork extends SandboxAction {
   constructor(sandbox: Sandbox) {
     super(sandbox);
+  }
+
+  /**
+   * Fetch a resource served on a sandbox port.
+   * The request is proxied through the sandbox's `/port/{port}` endpoint.
+   *
+   * @param port - The port number inside the sandbox
+   * @param path - Optional path appended after the port (default: "/")
+   * @param init - Standard RequestInit options forwarded to fetch
+   */
+  async fetch(port: number, path = "/", init?: RequestInit): Promise<Response> {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const url = `${this.url}/port/${port}${normalizedPath}`;
+    const headers = this.sandbox.forceUrl ? this.sandbox.headers : settings.headers;
+    return this.h2Fetch(url, {
+      ...init,
+      headers: {
+        ...headers,
+        ...init?.headers,
+      },
+    });
   }
 }

--- a/@blaxel/core/src/sandbox/network/network.ts
+++ b/@blaxel/core/src/sandbox/network/network.ts
@@ -18,12 +18,24 @@ export class SandboxNetwork extends SandboxAction {
   async fetch(port: number, path = "/", init?: RequestInit): Promise<Response> {
     const normalizedPath = path.startsWith("/") ? path : `/${path}`;
     const url = `${this.url}/port/${port}${normalizedPath}`;
-    const headers = this.sandbox.forceUrl ? this.sandbox.headers : settings.headers;
+    const headers = (this.sandbox.forceUrl ? this.sandbox.headers : undefined) ?? settings.headers;
+    const initHeaders: Record<string, string> = {};
+    if (init?.headers) {
+      const entries =
+        init.headers instanceof Headers
+          ? init.headers.entries()
+          : Array.isArray(init.headers)
+            ? (init.headers as [string, string][]).values()
+            : Object.entries(init.headers as Record<string, string>).values();
+      for (const [key, value] of entries) {
+        initHeaders[key] = value;
+      }
+    }
     return this.h2Fetch(url, {
       ...init,
       headers: {
         ...headers,
-        ...init?.headers,
+        ...initHeaders,
       },
     });
   }

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -80,6 +80,17 @@ export class SandboxInstance {
     return this.sandbox.expiresIn;
   }
 
+  /**
+   * Fetch a resource served on a sandbox port.
+   *
+   * @param port - The port number inside the sandbox
+   * @param path - Optional path appended after the port (default: "/")
+   * @param init - Standard RequestInit options forwarded to fetch
+   */
+  async fetch(port: number, path = "/", init?: RequestInit): Promise<Response> {
+    return this.network.fetch(port, path, init);
+  }
+
   /* eslint-disable */
   async wait({maxWait = 60000, interval = 1000}: {maxWait?: number, interval?: number} = {}) {
     logger.warn("⚠️  Warning: sandbox.wait() is deprecated. You don't need to wait for the sandbox to be deployed anymore.");

--- a/tests/integration/sandbox/process.test.ts
+++ b/tests/integration/sandbox/process.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
 import { uniqueName, defaultImage, defaultLabels, sleep } from './helpers.js'
 
-let SKIP_KEEP_ALIVE = true
+const SKIP_KEEP_ALIVE = true
 
 describe('Sandbox Process Operations', () => {
   let sandbox: SandboxInstance
@@ -538,45 +538,11 @@ describe('Sandbox Process Operations', () => {
   })
 })
 
-describe('Sandbox Process waitForPorts', () => {
-  let sandbox: SandboxInstance
-  const sandboxName = uniqueName("waitforports")
+describe('Sandbox Process waitForPorts at scale', () => {
+  const SANDBOX_COUNT = 20
+  const sandboxes: { name: string; instance: SandboxInstance; runtime: "node" | "python" }[] = []
 
-  beforeAll(async () => {
-    sandbox = await SandboxInstance.create({
-      name: sandboxName,
-      image: "blaxel/node:latest",
-      memory: 2048,
-      ports: [
-        { target: 3000, protocol: "HTTP" }
-      ],
-      labels: defaultLabels,
-    })
-  })
-
-  afterAll(async () => {
-    try {
-      await sandbox.delete()
-    } catch {
-      // Ignore
-    }
-  })
-
-  it('waits for port to be ready before returning', async () => {
-    const preview = await sandbox.previews.createIfNotExists({
-      metadata: {
-        name: "waitforports-preview"
-      },
-      spec: {
-        port: 3000,
-        public: true
-      }
-    })
-
-    const previewUrl = preview.spec.url
-    expect(previewUrl).toBeDefined()
-
-    const nodeServerCommand = `sleep 2 && node -e "
+  const nodeServerCommand = `sleep 2 && node -e "
 const http = require('http');
 const server = http.createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -585,15 +551,76 @@ const server = http.createServer((req, res) => {
 server.listen(3000);
 "`
 
-    await sandbox.process.exec({
-      name: "node-server",
-      command: nodeServerCommand,
-      waitForPorts: [3000]
+  const pythonServerCommand = `sleep 2 && python3 -c "
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'OK')
+    def log_message(self, *args):
+        pass
+
+HTTPServer(('', 3000), H).serve_forever()
+"`
+
+  beforeAll(async () => {
+    const createPromises = Array.from({ length: SANDBOX_COUNT }, async (_, i) => {
+      const runtime = i % 2 === 0 ? "node" as const : "python" as const
+      const image = runtime === "node" ? "blaxel/node:latest" : "blaxel/py-app:latest"
+      const name = uniqueName(`wfp-${runtime}-${i}`)
+      const instance = await SandboxInstance.create({
+        name,
+        image,
+        memory: 2048,
+        ports: [{ target: 3000, protocol: "HTTP" }],
+        labels: defaultLabels,
+      })
+      return { name, instance, runtime }
     })
 
-    const response = await fetch(previewUrl!)
-    expect(response.status).toBe(200)
-    const body = await response.text()
-    expect(body).toBe("OK")
-  })
+    const results = await Promise.all(createPromises)
+    sandboxes.push(...results)
+  }, 5 * 60 * 1000)
+
+  afterAll(async () => {
+    await Promise.allSettled(
+      sandboxes.map(({ instance }) => instance.delete().catch(() => {}))
+    )
+  }, 5 * 60 * 1000)
+
+  it('waits for port to be ready on all sandboxes concurrently', async () => {
+    const results = await Promise.allSettled(
+      sandboxes.map(async ({ name, instance, runtime }, i) => {
+        const command = runtime === "node" ? nodeServerCommand : pythonServerCommand
+
+        await instance.process.exec({
+          name: `server-${i}`,
+          command,
+          waitForPorts: [3000],
+        })
+
+        const response = await instance.fetch(3000)
+        expect(response.status).toBe(200)
+        const body = await response.text()
+        expect(body).toBe("OK")
+
+        return { sandbox: name, runtime, success: true }
+      })
+    )
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled")
+    const rejected = results.filter((r) => r.status === "rejected")
+
+    if (rejected.length > 0) {
+      const errors = rejected.map((r, i) =>
+        `Sandbox #${i}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`
+      )
+      console.error("Failed sandboxes:\n" + errors.join("\n"))
+    }
+
+    expect(fulfilled.length).toBe(SANDBOX_COUNT)
+  }, 5 * 60 * 1000)
 })


### PR DESCRIPTION
- Added a `fetch(port, path, init)` method to `SandboxNetwork` that proxies HTTP requests to a sandbox port via the `/port/{port}` endpoint, with proper header forwarding
- Exposed `fetch` as a convenience method on `SandboxInstance`, delegating to `network.fetch`
- Replaced the single-sandbox `waitForPorts` integration test with a scaled test that spins up 20 concurrent sandboxes (alternating Node.js and Python runtimes) to validate `waitForPorts` reliability at scale
- Updated the scaled test to use `instance.fetch()` instead of a public preview URL, simplifying port access verification
- Fixed `SKIP_KEEP_ALIVE` from `let` to `const` since it is never reassigned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `fetch(port, path, init)` method to `SandboxNetwork` and `SandboxInstance` for proxied port access via `/port/{port}`, and replaces the single-sandbox `waitForPorts` test with a scaled 20-sandbox concurrent test using both Node.js and Python runtimes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9d872704310000e376878a01e083b0136c0bf45c.</sup>
<!-- /MENDRAL_SUMMARY -->