### PR TITLE
Fix helper wait for deletion

### DIFF
--- a/tests/integration/sandbox/globalTeardown.ts
+++ b/tests/integration/sandbox/globalTeardown.ts
@@ -13,6 +13,9 @@ export default function globalSetup() {
     try {
       const sandboxes = await SandboxInstance.list()
       for (const sb of sandboxes) {
+        if (sb.status === "TERMINATED") {
+          continue
+        }
         const labels = sb.metadata.labels || {}
         if (labels["env"] === "integration-test") {
           try {

--- a/tests/integration/sandbox/helpers.ts
+++ b/tests/integration/sandbox/helpers.ts
@@ -57,7 +57,10 @@ export async function waitForSandboxDeletion(sandboxName: string, maxAttempts: n
 
   while (attempts < maxAttempts) {
     try {
-      await SandboxInstance.get(sandboxName)
+      let sbx = await SandboxInstance.get(sandboxName)
+      if (sbx.status === "TERMINATED") {
+        return true
+      }
       // If we get here, sandbox still exists, wait and try again
       await sleep(1000)
       attempts++

--- a/tests/integration/sandbox/process.test.ts
+++ b/tests/integration/sandbox/process.test.ts
@@ -539,7 +539,7 @@ describe('Sandbox Process Operations', () => {
 })
 
 describe('Sandbox Process waitForPorts at scale', () => {
-  const SANDBOX_COUNT = 20
+  const SANDBOX_COUNT = 5 // Do not put to high number for this kind of test or we reach rate limit
   const sandboxes: { name: string; instance: SandboxInstance; runtime: "node" | "python" }[] = []
 
   const nodeServerCommand = `sleep 2 && node -e "
@@ -603,6 +603,7 @@ HTTPServer(('', 3000), H).serve_forever()
         })
 
         const response = await instance.fetch(3000)
+        console.log(response)
         expect(response.status).toBe(200)
         const body = await response.text()
         expect(body).toBe("OK")


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `waitForSandboxDeletion` to treat `TERMINATED` status as a successful deletion (instead of waiting for a 404), skips already-terminated sandboxes in global teardown, and reduces the scale test sandbox count to avoid rate limits.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9f20dfa0c63847bb7ad7d981206e317d5a0bd947.</sup>
<!-- /MENDRAL_SUMMARY -->