### PR TITLE
feat(versioning): send Blaxel-Version header on every request (ENG-2068)

### DIFF
--- a/@blaxel/core/src/common/settings.test.ts
+++ b/@blaxel/core/src/common/settings.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { env } from './env.js';
+
+describe('Settings.apiVersion', () => {
+  beforeEach(() => {
+    // Reset the module-level settings singleton between tests if needed
+  });
+
+  afterEach(() => {
+    delete (env as Record<string, unknown>).BL_API_VERSION;
+  });
+
+  it('defaults to 2026-04-16 when BL_API_VERSION is not set', async () => {
+    delete (env as Record<string, unknown>).BL_API_VERSION;
+    const { settings } = await import('./settings.js');
+    expect(settings.apiVersion).toBe('2026-04-16');
+  });
+
+  it('headers include Blaxel-Version set to the default', async () => {
+    delete (env as Record<string, unknown>).BL_API_VERSION;
+    const { settings } = await import('./settings.js');
+    expect(settings.headers['Blaxel-Version']).toBe('2026-04-16');
+  });
+});

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -35,6 +35,7 @@ export type Config = {
 const BUILD_VERSION = "__BUILD_VERSION__";
 const BUILD_COMMIT = "__BUILD_COMMIT__";
 const BUILD_SENTRY_DSN = "__BUILD_SENTRY_DSN__";
+const BLAXEL_API_VERSION = "2026-04-16";
 
 // Cache for config.yaml tracking value
 let configTrackingValue: boolean | null = null;
@@ -211,11 +212,16 @@ class Settings {
     return BUILD_SENTRY_DSN || "";
   }
 
+  get apiVersion(): string {
+    return env.BL_API_VERSION || BLAXEL_API_VERSION;
+  }
+
   get headers(): Record<string, string> {
     const osArch = getOsArch();
     return {
       "x-blaxel-authorization": this.authorization,
       "x-blaxel-workspace": this.workspace || "",
+      "Blaxel-Version": this.apiVersion,
       "User-Agent": `blaxel/sdk/typescript/${this.version} (${osArch}) blaxel/${this.commit}`,
     };
   }


### PR DESCRIPTION
## Summary
- Adds `BLAXEL_API_VERSION` constant + `apiVersion` getter (with `BL_API_VERSION` env override) to `Settings`.
- The `headers` getter now includes `Blaxel-Version` on every outgoing request.
- Vitest tests cover default and headers presence.

## Linear
Tracking ENG-2068. Pairs with controlplane PR (server-side middleware) and docs PR.

## Test plan
- [x] `pnpm test settings.test.ts` (passes)
- [x] Manual integration with controlplane (header echoed back in response)

## Notes
- This is a temporary hand-written addition. Once the SDK migrates to Stainless, the constant + headers entry will move to `client_settings.opts.api_version` in `stainless.yml`.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `Blaxel-Version` header to every outgoing SDK request using a hardcoded `BLAXEL_API_VERSION` constant (`"2026-04-16"`) with an optional `BL_API_VERSION` env override. The `apiVersion` getter is added to `Settings` and the header is injected in the existing `headers` getter. Two Vitest tests cover the default value and header presence.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4ab92155296939abe961abf128386bf224a0fb3b.</sup>
<!-- /MENDRAL_SUMMARY -->