### PR TITLE
fix(core): evict stale sandbox HTTP/2 sessions

### DIFF
--- a/@blaxel/core/fix-browser-imports.js
+++ b/@blaxel/core/fix-browser-imports.js
@@ -79,8 +79,8 @@ function replaceH2FilesWithStubs(buildDir) {
     },
     {
       name: 'h2fetch',
-      js: `// Browser stub - H2 fetch is Node.js only, falls back to global fetch\nexport function createH2Fetch(session) { return (input) => globalThis.fetch(input); }\nexport function createPoolBackedH2Fetch(pool, domain) { return (input) => globalThis.fetch(input); }\nexport function h2RequestDirect(session, url, init) { return globalThis.fetch(url, init); }\n`,
-      dts: `export declare function createH2Fetch(session: any): (input: Request) => Promise<Response>;\nexport declare function createPoolBackedH2Fetch(pool: any, domain: string): (input: Request) => Promise<Response>;\nexport declare function h2RequestDirect(session: any, url: string, init?: RequestInit): Promise<Response>;\n`,
+      js: `// Browser stub - H2 fetch is Node.js only, falls back to global fetch\nexport function createH2Fetch(session) { return (input) => globalThis.fetch(input); }\nexport function createPoolBackedH2Fetch(pool, domain) { return (input) => globalThis.fetch(input); }\nexport function h2RequestDirect(session, url, init) { return globalThis.fetch(url, init); }\nexport function h2RequestDirectFromPool(pool, domain, url, init) { return globalThis.fetch(url, init); }\n`,
+      dts: `export declare function createH2Fetch(session: any): (input: Request) => Promise<Response>;\nexport declare function createPoolBackedH2Fetch(pool: any, domain: string): (input: Request) => Promise<Response>;\nexport declare function h2RequestDirect(session: any, url: string, init?: RequestInit): Promise<Response>;\nexport declare function h2RequestDirectFromPool(pool: any, domain: string, url: string, init?: RequestInit): Promise<Response>;\n`,
     },
   ];
 

--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -1,6 +1,10 @@
 import http2 from "http2";
 import type { H2Pool } from "./h2pool.js";
 
+type H2SendOptions = {
+  onH2RequestCreated?: () => void;
+};
+
 /**
  * Creates a fetch()-compatible function that sends requests over an existing
  * HTTP/2 session. Falls back to globalThis.fetch() only when the session is
@@ -34,10 +38,17 @@ export function createPoolBackedH2Fetch(
   return async (input: Request): Promise<Response> => {
     const session = await pool.get(domain);
     if (session) {
+      let h2RequestCreated = false;
       try {
-        return await _h2Request(session, input);
+        return await _h2Request(session, input, {
+          onH2RequestCreated: () => {
+            h2RequestCreated = true;
+          },
+        });
       } catch (err) {
-        pool.evictSession(domain, session);
+        if (h2RequestCreated) {
+          pool.evictSession(domain, session);
+        }
         throw err;
       }
     }
@@ -53,10 +64,17 @@ export async function h2RequestDirectFromPool(
 ): Promise<Response> {
   const session = await pool.get(domain);
   if (session) {
+    let h2RequestCreated = false;
     try {
-      return await h2RequestDirect(session, url, init);
+      return await h2RequestDirectInternal(session, url, init, {
+        onH2RequestCreated: () => {
+          h2RequestCreated = true;
+        },
+      });
     } catch (err) {
-      pool.evictSession(domain, session);
+      if (h2RequestCreated) {
+        pool.evictSession(domain, session);
+      }
       throw err;
     }
   }
@@ -71,6 +89,15 @@ export function h2RequestDirect(
   session: http2.ClientHttp2Session,
   url: string,
   init?: RequestInit,
+): Promise<Response> {
+  return h2RequestDirectInternal(session, url, init);
+}
+
+function h2RequestDirectInternal(
+  session: http2.ClientHttp2Session,
+  url: string,
+  init?: RequestInit,
+  options?: H2SendOptions,
 ): Promise<Response> {
   if (session.closed || session.destroyed) {
     return globalThis.fetch(url, init);
@@ -118,12 +145,13 @@ export function h2RequestDirect(
     }
   }
 
-  return _h2Send(session, h2Headers, body, init?.signal ?? null, url, init);
+  return _h2Send(session, h2Headers, body, init?.signal ?? null, url, init, options);
 }
 
 async function _h2Request(
   session: http2.ClientHttp2Session,
   input: Request,
+  options?: H2SendOptions,
 ): Promise<Response> {
   const url = new URL(input.url);
   const method = input.method || "GET";
@@ -147,12 +175,20 @@ async function _h2Request(
     }
   }
 
-  return _h2Send(session, h2Headers, body, input.signal, input.url, {
-    method,
-    headers: input.headers,
+  return _h2Send(
+    session,
+    h2Headers,
     body,
-    signal: input.signal,
-  });
+    input.signal,
+    input.url,
+    {
+      method,
+      headers: input.headers,
+      body,
+      signal: input.signal,
+    },
+    options,
+  );
 }
 
 function _h2Send(
@@ -162,6 +198,7 @@ function _h2Send(
   signal: AbortSignal | null,
   fallbackUrl: string,
   fallbackInit?: RequestInit,
+  options?: H2SendOptions,
 ): Promise<Response> {
   return new Promise<Response>((resolve, reject) => {
     let settled = false;
@@ -178,6 +215,7 @@ function _h2Send(
       globalThis.fetch(fallbackUrl, fallbackInit).then(resolve, reject);
       return;
     }
+    options?.onH2RequestCreated?.();
 
     const cleanupBeforeResponseListeners = () => {
       session.off("close", onSessionClose);

--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -5,6 +5,9 @@ type H2SendOptions = {
   onH2RequestCreated?: () => void;
 };
 
+const MIN_H2_SESSION_MAX_LISTENERS = 64;
+const sessionsWithListenerBudget = new WeakSet<http2.ClientHttp2Session>();
+
 /**
  * Creates a fetch()-compatible function that sends requests over an existing
  * HTTP/2 session. Falls back to globalThis.fetch() only when the session is
@@ -216,6 +219,7 @@ function _h2Send(
       return;
     }
     options?.onH2RequestCreated?.();
+    ensureH2SessionListenerBudget(session);
 
     const cleanupBeforeResponseListeners = () => {
       session.off("close", onSessionClose);
@@ -325,4 +329,14 @@ function _h2Send(
       req.end();
     }
   });
+}
+
+function ensureH2SessionListenerBudget(session: http2.ClientHttp2Session): void {
+  if (sessionsWithListenerBudget.has(session)) return;
+  sessionsWithListenerBudget.add(session);
+
+  const currentMax = session.getMaxListeners();
+  if (currentMax > 0 && currentMax < MIN_H2_SESSION_MAX_LISTENERS) {
+    session.setMaxListeners(MIN_H2_SESSION_MAX_LISTENERS);
+  }
 }

--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -1,5 +1,5 @@
 import http2 from "http2";
-import type { h2Pool as H2PoolType } from "./h2pool.js";
+import type { H2Pool } from "./h2pool.js";
 
 /**
  * Creates a fetch()-compatible function that sends requests over an existing
@@ -23,22 +23,44 @@ export function createH2Fetch(
 /**
  * Creates a fetch()-compatible function backed by the H2 session pool.
  *
- * Non-blocking: checks the pool cache synchronously. If a warm session is
- * available it's used immediately; otherwise the request goes through
- * regular fetch with zero delay (the pool keeps warming in the background
- * so subsequent calls get H2).
+ * The pool validates idle sessions before reuse. If no usable H2 session is
+ * available, the request falls back to regular fetch before any H2 frames
+ * are sent.
  */
 export function createPoolBackedH2Fetch(
-  pool: typeof H2PoolType,
+  pool: H2Pool,
   domain: string,
 ): (input: Request) => Promise<Response> {
-  return (input: Request): Promise<Response> => {
-    const session = pool.tryGet(domain);
+  return async (input: Request): Promise<Response> => {
+    const session = await pool.get(domain);
     if (session) {
-      return _h2Request(session, input);
+      try {
+        return await _h2Request(session, input);
+      } catch (err) {
+        pool.evictSession(domain, session);
+        throw err;
+      }
     }
     return globalThis.fetch(input);
   };
+}
+
+export async function h2RequestDirectFromPool(
+  pool: H2Pool,
+  domain: string,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const session = await pool.get(domain);
+  if (session) {
+    try {
+      return await h2RequestDirect(session, url, init);
+    } catch (err) {
+      pool.evictSession(domain, session);
+      throw err;
+    }
+  }
+  return globalThis.fetch(url, init);
 }
 
 /**
@@ -146,8 +168,8 @@ function _h2Send(
     let responded = false;
     let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
     let streamClosed = false;
+    let req: http2.ClientHttp2Stream | null = null;
 
-    let req: http2.ClientHttp2Stream;
     try {
       req = session.request(h2Headers);
     } catch {
@@ -157,12 +179,41 @@ function _h2Send(
       return;
     }
 
+    const cleanupBeforeResponseListeners = () => {
+      session.off("close", onSessionClose);
+      session.off("goaway", onSessionGoaway);
+      session.off("error", onSessionError);
+    };
+
+    const rejectBeforeResponse = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanupBeforeResponseListeners();
+      req?.close();
+      reject(err);
+    };
+
+    const onSessionClose = () => {
+      rejectBeforeResponse(new Error("HTTP/2 session closed before response"));
+    };
+    const onSessionGoaway = () => {
+      rejectBeforeResponse(new Error("HTTP/2 session sent GOAWAY before response"));
+    };
+    const onSessionError = (err: Error) => {
+      rejectBeforeResponse(err);
+    };
+
+    session.once("close", onSessionClose);
+    session.once("goaway", onSessionGoaway);
+    session.once("error", onSessionError);
+
     const abort = () => {
-      req.close();
+      req?.close();
       const abortError = new DOMException("The operation was aborted.", "AbortError");
       if (!responded) {
         if (!settled) {
           settled = true;
+          cleanupBeforeResponseListeners();
           reject(abortError);
         }
         return;
@@ -176,6 +227,7 @@ function _h2Send(
     if (signal) {
       if (signal.aborted) {
         req.close();
+        cleanupBeforeResponseListeners();
         settled = true;
         reject(new DOMException("The operation was aborted.", "AbortError"));
         return;
@@ -187,6 +239,7 @@ function _h2Send(
       if (settled) return;
       settled = true;
       responded = true;
+      cleanupBeforeResponseListeners();
 
       const status = (headers[":status"] as number) ?? 200;
       const resHeaders = new Headers();
@@ -205,12 +258,14 @@ function _h2Send(
           req.on("end", () => {
             if (!streamClosed) {
               streamClosed = true;
+              signal?.removeEventListener("abort", abort);
               controller.close();
             }
           });
           req.on("error", (err) => {
             if (!streamClosed) {
               streamClosed = true;
+              signal?.removeEventListener("abort", abort);
               controller.error(err);
             }
           });
@@ -222,6 +277,7 @@ function _h2Send(
     req.on("error", (err: Error) => {
       if (settled) return;
       settled = true;
+      cleanupBeforeResponseListeners();
       reject(err);
     });
 

--- a/@blaxel/core/src/common/h2pool.ts
+++ b/@blaxel/core/src/common/h2pool.ts
@@ -1,6 +1,21 @@
 import type http2 from "http2";
 
 type EstablishFn = (hostname: string) => Promise<http2.ClientHttp2Session>;
+type NowFn = () => number;
+
+type H2PoolEntry = {
+  session: http2.ClientHttp2Session;
+  lastUsedAt: number;
+};
+
+export type H2PoolOptions = {
+  maxIdleMs?: number;
+  pingTimeoutMs?: number;
+  now?: NowFn;
+};
+
+const DEFAULT_MAX_IDLE_MS = 5_000;
+const DEFAULT_PING_TIMEOUT_MS = 500;
 
 /**
  * Singleton H2 session pool keyed by edge domain.
@@ -11,9 +26,18 @@ type EstablishFn = (hostname: string) => Promise<http2.ClientHttp2Session>;
  * - Closed / destroyed sessions are automatically evicted.
  */
 export class H2Pool {
-  private sessions = new Map<string, http2.ClientHttp2Session>();
+  private sessions = new Map<string, H2PoolEntry>();
   private inflight = new Map<string, Promise<http2.ClientHttp2Session | null>>();
   private _establish: EstablishFn | null = null;
+  private readonly maxIdleMs: number;
+  private readonly pingTimeoutMs: number;
+  private readonly now: NowFn;
+
+  constructor(options: H2PoolOptions = {}) {
+    this.maxIdleMs = options.maxIdleMs ?? DEFAULT_MAX_IDLE_MS;
+    this.pingTimeoutMs = options.pingTimeoutMs ?? DEFAULT_PING_TIMEOUT_MS;
+    this.now = options.now ?? Date.now;
+  }
 
   /**
    * Lazily resolve the establish function so the http2 / tls / dns modules
@@ -41,7 +65,7 @@ export class H2Pool {
     const evict = () => {
       // Only evict if this specific session is still the cached one.
       // A newer session may have taken its place after reconnect.
-      if (this.sessions.get(domain) === session) {
+      if (this.sessions.get(domain)?.session === session) {
         this.sessions.delete(domain);
       }
     };
@@ -50,18 +74,97 @@ export class H2Pool {
     session.on("close", evict);
   }
 
+  private isClosed(session: http2.ClientHttp2Session): boolean {
+    return session.closed || session.destroyed;
+  }
+
+  private isIdle(entry: H2PoolEntry): boolean {
+    return this.now() - entry.lastUsedAt > this.maxIdleMs;
+  }
+
+  private cache(domain: string, session: http2.ClientHttp2Session): void {
+    this.sessions.set(domain, {
+      session,
+      lastUsedAt: this.now(),
+    });
+  }
+
+  private markUsed(domain: string, session: http2.ClientHttp2Session): void {
+    const entry = this.sessions.get(domain);
+    if (entry?.session === session) {
+      entry.lastUsedAt = this.now();
+    }
+  }
+
+  private evict(domain: string, session?: http2.ClientHttp2Session): void {
+    const entry = this.sessions.get(domain);
+    if (!entry) return;
+    if (session && entry.session !== session) return;
+    this.sessions.delete(domain);
+    if (!entry.session.closed && !entry.session.destroyed) {
+      entry.session.close();
+    }
+  }
+
+  private ping(session: http2.ClientHttp2Session): Promise<boolean> {
+    if (this.isClosed(session)) return Promise.resolve(false);
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (ok: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(ok);
+      };
+
+      const timer = setTimeout(() => finish(false), this.pingTimeoutMs);
+
+      try {
+        const sent = session.ping((err?: Error | null) => {
+          finish(!err && !this.isClosed(session));
+        });
+        if (!sent) finish(false);
+      } catch {
+        finish(false);
+      }
+    });
+  }
+
+  private async validateEntry(
+    domain: string,
+    entry: H2PoolEntry | undefined,
+  ): Promise<http2.ClientHttp2Session | null> {
+    if (!entry) return null;
+    const { session } = entry;
+    if (this.isClosed(session)) {
+      this.evict(domain, session);
+      return null;
+    }
+    if (!this.isIdle(entry)) {
+      this.markUsed(domain, session);
+      return session;
+    }
+    if (await this.ping(session)) {
+      this.markUsed(domain, session);
+      return session;
+    }
+    this.evict(domain, session);
+    return null;
+  }
+
   /**
    * Fire-and-forget background warming. Safe to call multiple times for
    * the same domain — only one connection attempt per domain at a time.
    */
   warm(domain: string): void {
-    const existing = this.sessions.get(domain);
-    if (existing && !existing.closed && !existing.destroyed) return;
+    const existing = this.tryGet(domain);
+    if (existing) return;
     if (this.inflight.has(domain)) return;
 
     const p = this.establish(domain)
       .then((session) => {
-        this.sessions.set(domain, session);
+        this.cache(domain, session);
         return session;
       })
       .catch(() => null)
@@ -78,8 +181,43 @@ export class H2Pool {
    */
   tryGet(domain: string): http2.ClientHttp2Session | null {
     const cached = this.sessions.get(domain);
-    if (cached && !cached.closed && !cached.destroyed) return cached;
-    this.sessions.delete(domain);
+    if (!cached) return null;
+    if (this.isClosed(cached.session) || this.isIdle(cached)) {
+      this.evict(domain, cached.session);
+      return null;
+    }
+    this.markUsed(domain, cached.session);
+    return cached.session;
+  }
+
+  async getFresh(domain: string): Promise<http2.ClientHttp2Session | null> {
+    const session = await this.validateEntry(domain, this.sessions.get(domain));
+    if (session) return session;
+    return this.get(domain);
+  }
+
+  markSessionUsed(domain: string, session: http2.ClientHttp2Session): void {
+    this.markUsed(domain, session);
+  }
+
+  isUsable(session: http2.ClientHttp2Session): boolean {
+    return !this.isClosed(session);
+  }
+
+  evictSession(domain: string, session: http2.ClientHttp2Session): void {
+    this.evict(domain, session);
+  }
+
+  async validateSession(
+    domain: string,
+    session: http2.ClientHttp2Session,
+  ): Promise<http2.ClientHttp2Session | null> {
+    const cached = this.sessions.get(domain);
+    if (cached?.session === session) {
+      return this.validateEntry(domain, cached);
+    }
+    if (this.isClosed(session)) return null;
+    if (await this.ping(session)) return session;
     return null;
   }
 
@@ -88,14 +226,17 @@ export class H2Pool {
    * joins an in-flight warming, or starts a new one.
    */
   async get(domain: string): Promise<http2.ClientHttp2Session | null> {
-    const fast = this.tryGet(domain);
+    const fast = await this.validateEntry(domain, this.sessions.get(domain));
     if (fast) return fast;
 
     // Join in-flight warming if one exists
     const pending = this.inflight.get(domain);
     if (pending) {
       const session = await pending;
-      if (session && !session.closed && !session.destroyed) return session;
+      if (session && this.isUsable(session)) {
+        this.markUsed(domain, session);
+        return session;
+      }
     }
     // Start fresh, deduplicating concurrent callers via inflight
     // Re-check: another caller may have started a fresh one while we awaited
@@ -107,7 +248,7 @@ export class H2Pool {
 
     const p = this.establish(domain)
       .then((session) => {
-        this.sessions.set(domain, session);
+        this.cache(domain, session);
         return session;
       })
       .catch(() => null)
@@ -119,8 +260,8 @@ export class H2Pool {
   }
   /** Close all sessions (for cleanup). */
   closeAll(): void {
-    for (const [, session] of this.sessions) {
-      if (!session.closed && !session.destroyed) session.close();
+    for (const [, entry] of this.sessions) {
+      if (!entry.session.closed && !entry.session.destroyed) entry.session.close();
     }
     this.sessions.clear();
     this.inflight.clear();

--- a/@blaxel/core/src/common/h2pool.ts
+++ b/@blaxel/core/src/common/h2pool.ts
@@ -190,35 +190,12 @@ export class H2Pool {
     return cached.session;
   }
 
-  async getFresh(domain: string): Promise<http2.ClientHttp2Session | null> {
-    const session = await this.validateEntry(domain, this.sessions.get(domain));
-    if (session) return session;
-    return this.get(domain);
-  }
-
-  markSessionUsed(domain: string, session: http2.ClientHttp2Session): void {
-    this.markUsed(domain, session);
-  }
-
   isUsable(session: http2.ClientHttp2Session): boolean {
     return !this.isClosed(session);
   }
 
   evictSession(domain: string, session: http2.ClientHttp2Session): void {
     this.evict(domain, session);
-  }
-
-  async validateSession(
-    domain: string,
-    session: http2.ClientHttp2Session,
-  ): Promise<http2.ClientHttp2Session | null> {
-    const cached = this.sessions.get(domain);
-    if (cached?.session === session) {
-      return this.validateEntry(domain, cached);
-    }
-    if (this.isClosed(session)) return null;
-    if (await this.ping(session)) return session;
-    return null;
   }
 
   /**

--- a/@blaxel/core/src/common/lazyInit.ts
+++ b/@blaxel/core/src/common/lazyInit.ts
@@ -47,7 +47,7 @@ export function ensureAutoloaded(): void {
   /* eslint-disable */
   const isBrowser = typeof globalThis !== "undefined" && (globalThis as any)?.window !== undefined;
 
-  if (isNode && !isBrowser) {
+  if (isNode && !isBrowser && !settings.disableH2) {
     try {
       // Pre-warm edge H2 for the configured region so the first
       // SandboxInstance.create() gets an instant session via the pool.

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -19,6 +19,7 @@ export type Config = {
   proxy?: string;
   apikey?: string;
   workspace?: string;
+  disableH2?: boolean;
   /**
    * Client credentials for OAuth2 client_credentials flow.
    *
@@ -274,6 +275,15 @@ class Settings {
 
   get region() {
     return env.BL_REGION || undefined;
+  }
+
+  get disableH2(): boolean {
+    if (typeof this.config.disableH2 === "boolean") {
+      return this.config.disableH2;
+    }
+    const value = env.BL_DISABLE_H2;
+    if (!value) return false;
+    return ["1", "true", "yes", "on"].includes(value.toLowerCase());
   }
 
   async authenticate() {

--- a/@blaxel/core/src/sandbox/action.ts
+++ b/@blaxel/core/src/sandbox/action.ts
@@ -1,7 +1,8 @@
 import { createClient, type Client } from "@hey-api/client-fetch";
 import { interceptors } from "../client/interceptors.js";
 import { responseInterceptors } from "../client/responseInterceptor.js";
-import { createH2Fetch, h2RequestDirect } from "../common/h2fetch.js";
+import { createPoolBackedH2Fetch, h2RequestDirectFromPool } from "../common/h2fetch.js";
+import { h2Pool } from "../common/h2pool.js";
 import { getForcedUrl, getGlobalUniqueHash } from "../common/internal.js";
 import { settings } from "../common/settings.js";
 import { client as defaultClient } from "./client/client.gen.js";
@@ -28,6 +29,7 @@ export class ResponseError extends Error {
 
 export class SandboxAction {
   private _h2Client: Client | null = null;
+  private _h2ClientDomain: string | null = null;
 
   constructor(protected sandbox: SandboxConfiguration) {}
 
@@ -59,12 +61,13 @@ export class SandboxAction {
       })
     }
 
-    const session = this.sandbox.h2Session;
-    if (session && !session.closed && !session.destroyed) {
-      if (!this._h2Client) {
+    const h2Domain = this.sandbox.h2Domain;
+    if (h2Domain) {
+      if (!this._h2Client || this._h2ClientDomain !== h2Domain) {
         this._h2Client = createClient({
-          fetch: createH2Fetch(session),
+          fetch: createPoolBackedH2Fetch(h2Pool, h2Domain),
         });
+        this._h2ClientDomain = h2Domain;
         for (const interceptor of interceptors) {
           // @ts-expect-error - Interceptor is not typed
           this._h2Client.interceptors.request.use(interceptor);
@@ -76,8 +79,9 @@ export class SandboxAction {
       return this._h2Client;
     }
 
-    // Invalidate cached H2 client when session is no longer usable
+    // Invalidate cached H2 client when the sandbox no longer has an H2 domain.
     this._h2Client = null;
+    this._h2ClientDomain = null;
 
     return defaultClient
   }
@@ -87,9 +91,9 @@ export class SandboxAction {
    * globalThis.fetch. Uses a direct H2 path that avoids Request allocation.
    */
   protected h2Fetch(input: string | URL, init?: RequestInit): Promise<Response> {
-    const session = this.sandbox.h2Session;
-    if (session && !session.closed && !session.destroyed) {
-      return h2RequestDirect(session, input.toString(), init);
+    const h2Domain = this.sandbox.h2Domain;
+    if (h2Domain) {
+      return h2RequestDirectFromPool(h2Pool, h2Domain, input.toString(), init);
     }
     return globalThis.fetch(input, init);
   }

--- a/@blaxel/core/src/sandbox/interpreter.ts
+++ b/@blaxel/core/src/sandbox/interpreter.ts
@@ -1,5 +1,6 @@
 import { Port, Sandbox, SandboxLifecycle } from "../client/types.gen.js";
-import { h2RequestDirect } from "../common/h2fetch.js";
+import { h2RequestDirectFromPool } from "../common/h2fetch.js";
+import { h2Pool } from "../common/h2pool.js";
 import { logger } from "../common/logger.js";
 import { settings } from "../common/settings.js";
 import { SandboxInstance } from "./sandbox.js";
@@ -31,6 +32,7 @@ export class CodeInterpreter extends SandboxInstance {
       status: base.status,
       events: base.events,
       h2Session: base.h2Session,
+      h2Domain: base.h2Domain,
     };
     return new CodeInterpreter(config);
   }
@@ -81,6 +83,7 @@ export class CodeInterpreter extends SandboxInstance {
       status: baseInstance.status,
       events: baseInstance.events,
       h2Session: baseInstance.h2Session,
+      h2Domain: baseInstance.h2Domain,
     };
     // Preserve forceUrl, headers, and params from input if provided
     if (sandbox && typeof sandbox === "object" && !Array.isArray(sandbox)) {
@@ -106,9 +109,9 @@ export class CodeInterpreter extends SandboxInstance {
   }
 
   private _fetch(input: string | URL, init?: RequestInit): Promise<Response> {
-    const session = this._sandboxConfig.h2Session;
-    if (session && !session.closed && !session.destroyed) {
-      return h2RequestDirect(session, input.toString(), init);
+    const h2Domain = this._sandboxConfig.h2Domain;
+    if (h2Domain) {
+      return h2RequestDirectFromPool(h2Pool, h2Domain, input.toString(), init);
     }
     return globalThis.fetch(input, init);
   }
@@ -524,4 +527,3 @@ export class CodeInterpreter extends SandboxInstance {
     }
   }
 }
-

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -211,7 +211,10 @@ export class SandboxInstance {
     if (safe) {
       try {
         await instance.fs.ls('/')
-      } catch {}
+      } catch (err) {
+        await SandboxInstance.delete(instance.metadata.name!).catch(() => {});
+        throw err;
+      }
     }
     return instance;
   }

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+import type http2 from "http2";
 import { createSandbox, deleteSandbox, getSandbox, listSandboxes, SandboxLifecycle, Sandbox as SandboxModel, updateSandbox } from "../client/index.js";
 import { logger } from "../common/logger.js";
 import { settings } from "../common/settings.js";
@@ -21,8 +22,7 @@ export class SandboxInstance {
   codegen: SandboxCodegen;
   system: SandboxSystem;
   drives: SandboxDrive;
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  h2Session: any;
+  h2Session: http2.ClientHttp2Session | null;
 
   constructor(private sandbox: SandboxConfiguration) {
     this.process = new SandboxProcess(sandbox);
@@ -56,24 +56,33 @@ export class SandboxInstance {
     return this.sandbox.lastUsedAt;
   }
 
+  get h2Domain() {
+    return this.sandbox.h2Domain ?? null;
+  }
+
   /**
    * Warm and attach an H2 session based on the sandbox's region.
    * Shared by create(), get(), list(), and update helpers.
    */
   private static async attachH2Session(instance: SandboxInstance): Promise<SandboxInstance> {
-    const region = instance.spec?.region;
-    if (!region) return instance;
-    const edgeSuffix = settings.env === "prod" ? "bl.run" : "runv2.blaxel.dev";
-    const edgeDomain = `any.${region}.${edgeSuffix}`;
+    const edgeDomain = SandboxInstance.edgeDomainForRegion(instance.spec?.region);
+    if (!edgeDomain || settings.disableH2) return instance;
     try {
       const { h2Pool } = await import("../common/h2pool.js");
       const h2Session = await h2Pool.get(edgeDomain);
       instance.h2Session = h2Session;
       instance.sandbox.h2Session = h2Session;
+      instance.sandbox.h2Domain = edgeDomain;
     } catch {
       // H2 warming is best-effort; fall back to regular fetch
     }
     return instance;
+  }
+
+  private static edgeDomainForRegion(region?: string): string | null {
+    if (!region) return null;
+    const edgeSuffix = settings.env === "prod" ? "bl.run" : "runv2.blaxel.dev";
+    return `any.${region}.${edgeSuffix}`;
   }
 
   get expiresIn() {
@@ -179,11 +188,10 @@ export class SandboxInstance {
     sandbox.spec.runtime.image = sandbox.spec.runtime.image || defaultImage;
     sandbox.spec.runtime.memory = sandbox.spec.runtime.memory || defaultMemory;
 
-    const edgeSuffix = settings.env === "prod" ? "bl.run" : "runv2.blaxel.dev";
-    const edgeDomain = sandbox.spec?.region ? `any.${sandbox.spec.region}.${edgeSuffix}` : null;
+    const edgeDomain = SandboxInstance.edgeDomainForRegion(sandbox.spec?.region);
 
     // Kick off warming so h2Pool.get() can join it during the API call
-    if (edgeDomain) {
+    if (edgeDomain && !settings.disableH2) {
       import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.warm(edgeDomain)).catch(() => {});
     }
 
@@ -192,10 +200,10 @@ export class SandboxInstance {
         body: sandbox,
         throwOnError: true,
       }),
-      edgeDomain ? import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.get(edgeDomain)).catch(() => null) : Promise.resolve(null),
+      edgeDomain && !settings.disableH2 ? import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.get(edgeDomain)).catch(() => null) : Promise.resolve(null),
     ]);
     // Inject the H2 session into the config so subsystems can use it
-    const config = { ...data, h2Session } as SandboxConfiguration;
+    const config = { ...data, h2Session, h2Domain: settings.disableH2 ? null : edgeDomain } as SandboxConfiguration;
     const instance = new SandboxInstance(config);
     instance.h2Session = h2Session;
     // Note: H2 session already attached via Promise.all above, no need for attachH2Session()
@@ -238,6 +246,8 @@ export class SandboxInstance {
   async delete() {
     // Don't close the H2 session — it's shared via h2Pool
     this.h2Session = null;
+    this.sandbox.h2Session = null;
+    this.sandbox.h2Domain = null;
     return await SandboxInstance.delete(this.metadata.name!);
   }
 

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -31,6 +31,7 @@ export type SandboxConfiguration = {
   headers?: Record<string, string>;
   params?: Record<string, string>;
   h2Session?: http2.ClientHttp2Session | null;
+  h2Domain?: string | null;
 } & Sandbox;
 
 export type SandboxUpdateMetadata = {

--- a/tests/integration/common/h2fetch.test.ts
+++ b/tests/integration/common/h2fetch.test.ts
@@ -193,6 +193,24 @@ describe('h2fetch: no silent retry after session.request()', () => {
     await expect(promise).rejects.toThrow('HTTP/2 session sent GOAWAY before response');
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('raises the session listener budget for concurrent request lifecycle listeners', async () => {
+    const session = new MockSession();
+
+    const promise = h2RequestDirect(
+      asSession(session),
+      'http://example.com/resource',
+      { method: 'POST', body: 'payload' },
+    );
+
+    expect(session.getMaxListeners()).toBeGreaterThan(10);
+
+    session.lastStream!.emit('response', { ':status': 200 });
+    session.lastStream!.emit('end');
+
+    const response = await promise;
+    expect(response.status).toBe(200);
+  });
 });
 
 describe('h2fetch: pre-flight fallback still works', () => {

--- a/tests/integration/common/h2fetch.test.ts
+++ b/tests/integration/common/h2fetch.test.ts
@@ -3,9 +3,11 @@ import type http2 from 'http2';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createH2Fetch,
+  h2RequestDirectFromPool,
   h2RequestDirect,
 } from '../../../@blaxel/core/src/common/h2fetch.js';
-import { H2Pool } from '../../../@blaxel/core/src/common/h2pool.js';
+import { H2Pool, h2Pool } from '../../../@blaxel/core/src/common/h2pool.js';
+import { SandboxAction } from '../../../@blaxel/core/src/sandbox/action.js';
 
 /**
  * Minimal ClientHttp2Stream stand-in. Supports the subset of the API that
@@ -18,7 +20,7 @@ class MockStream extends EventEmitter {
     this.closed = true;
   }
 
-  end(_chunk?: unknown): void {
+  end(): void {
     // no-op; tests drive the response lifecycle by emitting events directly
   }
 }
@@ -31,16 +33,36 @@ class MockSession extends EventEmitter {
   public closed = false;
   public destroyed = false;
   public lastStream: MockStream | null = null;
+  public pingMode: 'ok' | 'fail' | 'hang' = 'ok';
 
-  request(_headers: http2.OutgoingHttpHeaders): MockStream {
+  request(): MockStream {
     const stream = new MockStream();
     this.lastStream = stream;
     return stream;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.emit('close');
+  }
+
+  ping(callback: (err?: Error | null) => void): boolean {
+    if (this.pingMode === 'hang') return true;
+    setImmediate(() => {
+      callback(this.pingMode === 'fail' ? new Error('ping failed') : null);
+    });
+    return true;
   }
 }
 
 function asSession(mock: MockSession): http2.ClientHttp2Session {
   return mock as unknown as http2.ClientHttp2Session;
+}
+
+class H2ProbeAction extends SandboxAction {
+  fetchWithH2(input: string): Promise<Response> {
+    return this.h2Fetch(input);
+  }
 }
 
 describe('h2fetch: no silent retry after session.request()', () => {
@@ -132,6 +154,44 @@ describe('h2fetch: no silent retry after session.request()', () => {
       vi.useRealTimers();
     }
   });
+
+  it('rejects when the session closes before a response arrives', async () => {
+    const session = new MockSession();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('from fetch'));
+
+    const promise = h2RequestDirect(
+      asSession(session),
+      'http://example.com/resource',
+      { method: 'POST', body: 'payload' },
+    );
+
+    expect(session.lastStream).not.toBeNull();
+    session.emit('close');
+
+    await expect(promise).rejects.toThrow('HTTP/2 session closed before response');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the session sends GOAWAY before a response arrives', async () => {
+    const session = new MockSession();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('from fetch'));
+
+    const promise = h2RequestDirect(
+      asSession(session),
+      'http://example.com/resource',
+      { method: 'POST', body: 'payload' },
+    );
+
+    expect(session.lastStream).not.toBeNull();
+    session.emit('goaway');
+
+    await expect(promise).rejects.toThrow('HTTP/2 session sent GOAWAY before response');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('h2fetch: pre-flight fallback still works', () => {
@@ -213,7 +273,7 @@ describe('h2pool: self-healing eviction on session events', () => {
   function installMockEstablish(
     pool: H2Pool,
   ): (domain: string) => Promise<MockSession> {
-    const establish = vi.fn(async (_domain: string) => new MockSession());
+    const establish = vi.fn(() => Promise.resolve(new MockSession()));
     // Access the private lazy-load slot via a cast; the eviction listeners
     // are wired inside establish() wrapper, which preserves this behavior.
     (pool as unknown as { _establish: typeof establish })._establish = establish;
@@ -261,10 +321,10 @@ describe('h2pool: self-healing eviction on session events', () => {
     const pool = new H2Pool();
     const sessions: MockSession[] = [];
     (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
-      async (_domain: string) => {
+      () => {
         const s = new MockSession();
         sessions.push(s);
-        return s;
+        return Promise.resolve(s);
       };
 
     const first = await pool.get('edge.example.com');
@@ -288,5 +348,145 @@ describe('h2pool: self-healing eviction on session events', () => {
     // Emitting a stale event on the *old* session must not touch the fresh one.
     sessions[0].emit('close');
     expect(pool.tryGet('edge.example.com')).toBe(sessions[1]);
+  });
+
+  it('pings an idle cached session before reusing it', async () => {
+    let now = 0;
+    const pool = new H2Pool({
+      maxIdleMs: 5,
+      now: () => now,
+    });
+    installMockEstablish(pool);
+
+    const session = await pool.get('edge.example.com');
+    expect(session).not.toBeNull();
+
+    now = 10;
+    const reused = await pool.get('edge.example.com');
+
+    expect(reused).toBe(session);
+  });
+
+  it('evicts an idle cached session when ping fails and opens a fresh one', async () => {
+    let now = 0;
+    const pool = new H2Pool({
+      maxIdleMs: 5,
+      now: () => now,
+    });
+    const sessions: MockSession[] = [];
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => {
+        const s = new MockSession();
+        sessions.push(s);
+        return Promise.resolve(s);
+      };
+
+    const first = await pool.get('edge.example.com');
+    expect(first).toBe(sessions[0]);
+
+    sessions[0].pingMode = 'fail';
+    now = 10;
+
+    const fresh = await pool.get('edge.example.com');
+
+    expect(fresh).toBe(sessions[1]);
+    expect(sessions[0].closed).toBe(true);
+    expect(pool.tryGet('edge.example.com')).toBe(sessions[1]);
+  });
+
+  it('evicts an idle cached session when ping times out', async () => {
+    let now = 0;
+    const pool = new H2Pool({
+      maxIdleMs: 5,
+      pingTimeoutMs: 1,
+      now: () => now,
+    });
+    const sessions: MockSession[] = [];
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => {
+        const s = new MockSession();
+        sessions.push(s);
+        return Promise.resolve(s);
+      };
+
+    const first = await pool.get('edge.example.com');
+    expect(first).toBe(sessions[0]);
+
+    sessions[0].pingMode = 'hang';
+    now = 10;
+
+    const fresh = await pool.get('edge.example.com');
+
+    expect(fresh).toBe(sessions[1]);
+    expect(sessions[0].closed).toBe(true);
+  });
+
+  it('evicts a pooled session when an H2 request errors before response', async () => {
+    const pool = new H2Pool();
+    const sessions: MockSession[] = [];
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => {
+        const s = new MockSession();
+        sessions.push(s);
+        return Promise.resolve(s);
+      };
+
+    const promise = h2RequestDirectFromPool(
+      pool,
+      'edge.example.com',
+      'http://example.com/resource',
+      { method: 'POST', body: 'payload' },
+    );
+
+    await new Promise((r) => setImmediate(r));
+    expect(sessions[0].lastStream).not.toBeNull();
+    sessions[0].lastStream!.emit('error', new Error('stream dead'));
+
+    await expect(promise).rejects.toThrow('stream dead');
+
+    const fresh = await pool.get('edge.example.com');
+    expect(fresh).toBe(sessions[1]);
+    expect(sessions[0].closed).toBe(true);
+  });
+});
+
+describe('sandbox actions: pool-backed H2 routing', () => {
+  afterEach(() => {
+    h2Pool.closeAll();
+    vi.restoreAllMocks();
+  });
+
+  it('does not reuse the raw session attached at sandbox creation', async () => {
+    const staleAttachedSession = new MockSession();
+    const staleRequestSpy = vi.spyOn(staleAttachedSession, 'request');
+    const freshSession = new MockSession();
+    const freshRequestSpy = vi.spyOn(freshSession, 'request');
+
+    h2Pool.closeAll();
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(freshSession);
+
+    const action = new H2ProbeAction({
+      metadata: {
+        name: 'sandbox-test',
+        url: 'http://example.com',
+      },
+      spec: {},
+      h2Session: asSession(staleAttachedSession),
+      h2Domain: 'edge.example.com',
+    });
+
+    const responsePromise = action.fetchWithH2('http://example.com/resource');
+    await new Promise((r) => setImmediate(r));
+
+    expect(staleRequestSpy).not.toHaveBeenCalled();
+    expect(freshRequestSpy).toHaveBeenCalledTimes(1);
+    expect(freshSession.lastStream).not.toBeNull();
+
+    freshSession.lastStream!.emit('response', { ':status': 200 });
+    freshSession.lastStream!.emit('end');
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
   });
 });

--- a/tests/integration/common/h2fetch.test.ts
+++ b/tests/integration/common/h2fetch.test.ts
@@ -3,6 +3,7 @@ import type http2 from 'http2';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createH2Fetch,
+  createPoolBackedH2Fetch,
   h2RequestDirectFromPool,
   h2RequestDirect,
 } from '../../../@blaxel/core/src/common/h2fetch.js';
@@ -447,6 +448,48 @@ describe('h2pool: self-healing eviction on session events', () => {
     const fresh = await pool.get('edge.example.com');
     expect(fresh).toBe(sessions[1]);
     expect(sessions[0].closed).toBe(true);
+  });
+
+  it('keeps a pooled session when pre-flight fallback fetch fails', async () => {
+    const pool = new H2Pool();
+    const session = new MockSession();
+    vi.spyOn(session, 'request').mockImplementation(() => {
+      throw new Error('max concurrent streams');
+    });
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fallback failed'));
+
+    await expect(
+      h2RequestDirectFromPool(
+        pool,
+        'edge.example.com',
+        'http://example.com/resource',
+      ),
+    ).rejects.toThrow('fallback failed');
+
+    expect(pool.tryGet('edge.example.com')).toBe(session);
+    expect(session.closed).toBe(false);
+  });
+
+  it('keeps a pooled fetch session when pre-flight fallback fetch fails', async () => {
+    const pool = new H2Pool();
+    const session = new MockSession();
+    vi.spyOn(session, 'request').mockImplementation(() => {
+      throw new Error('max concurrent streams');
+    });
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fallback failed'));
+
+    const h2fetch = createPoolBackedH2Fetch(pool, 'edge.example.com');
+
+    await expect(
+      h2fetch(new Request('http://example.com/resource')),
+    ).rejects.toThrow('fallback failed');
+
+    expect(pool.tryGet('edge.example.com')).toBe(session);
+    expect(session.closed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- add HTTP/2 pool liveness checks before reusing idle sandbox sessions
- evict stale sessions on ping failure/timeout, close, GOAWAY, or pre-response request errors
- route sandbox actions through the pool-backed HTTP/2 path instead of reusing a raw attached session
- add `disableH2` / `BL_DISABLE_H2` as a mitigation switch, while keeping HTTP/2 as the normal path

## Root cause

Sandbox creation could attach a raw HTTP/2 session and later reuse it after it had gone stale during a longer first model call or other external work. When the stale session failed before a response, the request path could hang or bypass the pool's self-healing behavior.

## Validation

- `bunx vitest run tests/integration/common/h2fetch.test.ts --reporter=verbose`
- `cd @blaxel/core && npm run build`
- `cd @blaxel/core && node node_modules/eslint/bin/eslint.js src/common/h2fetch.ts src/common/h2pool.ts src/common/lazyInit.ts src/common/settings.ts src/sandbox/action.ts src/sandbox/interpreter.ts src/sandbox/sandbox.ts src/sandbox/types.ts`
- `@blaxel/core/node_modules/.bin/eslint tests/integration/common/h2fetch.test.ts`
- `git diff --check`
- live Blaxel repro with fresh short-lived token: create sandbox, wait past idle threshold, first `process.exec` completed with marker, cleanup requested
- no-leak audit found no matching `agents-integ-*` / `calibrator-*` sandboxes afterward

## Notes

- The focused test run's global cleanup hook printed a sandbox-listing warning when no live credentials were present; the 18 focused HTTP/2 tests passed.
- This PR intentionally does not include the separate OpenAI Agents JS parity issues tracked by ENG-2423 through ENG-2426.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Routes all sandbox HTTP/2 traffic through a pool-backed path (`createPoolBackedH2Fetch` / `h2RequestDirectFromPool`) keyed by a new `h2Domain` field on `SandboxConfiguration`, replacing direct raw-session reuse. Adds idle-time tracking and ping validation to `H2Pool` so stale sessions are evicted before reuse, and hardens `_h2Send` with pre-response session event listeners (`close`, `goaway`, `error`) and proper cleanup. Adds `disableH2`/`BL_DISABLE_H2` as an escape hatch, and removes unused pool methods in the final commit.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 17b8db1f8a82fd61ad0a67596609eb8ae7cafdf7.</sup>
<!-- /MENDRAL_SUMMARY -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sandbox transport behavior by routing requests through the HTTP/2 pool and proactively evicting sessions on idle/ping and pre-response failures; regressions could affect request reliability/latency in Node environments.
> 
> **Overview**
> Fixes stale sandbox HTTP/2 session reuse by making `H2Pool` track idle time and **ping/evict** sessions before reuse (and on `close`/`goaway`/`error`), plus adding explicit `evictSession` hooks for callers.
> 
> Updates sandbox request paths to use **pool-backed H2** (`createPoolBackedH2Fetch` / `h2RequestDirectFromPool`) keyed by a new `h2Domain` on `SandboxConfiguration`, rather than reusing a raw attached session; adds a `disableH2`/`BL_DISABLE_H2` switch to skip warming/usage.
> 
> Hardens `h2fetch` by rejecting when the session closes/GOAWAYs before response, increasing session listener limits, cleaning up abort/listeners correctly, and adds integration tests covering idle ping, eviction, and sandbox routing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010ec7560dca9b1d1b19626562c1624083ae6b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->