### PR TITLE
feat(tests): add defaultRegion support across sandbox tests

### DIFF
--- a/tests/integration/sandbox/codegen.test.ts
+++ b/tests/integration/sandbox/codegen.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion } from './helpers.js'
 
 describe('Sandbox Codegen Operations', () => {
   // These tests require RELACE_API_KEY or MORPH_API_KEY environment variables
@@ -15,6 +15,7 @@ describe('Sandbox Codegen Operations', () => {
       sandbox = await SandboxInstance.create({
         name: sandboxName,
         image: defaultImage,
+        region: defaultRegion,
         envs: [
           { name: "RELACE_API_KEY", value: process.env.RELACE_API_KEY! }
         ],
@@ -84,6 +85,7 @@ describe('Sandbox Codegen Operations', () => {
       sandbox = await SandboxInstance.create({
         name: sandboxName,
         image: defaultImage,
+        region: defaultRegion,
         envs: [
           { name: "MORPH_API_KEY", value: process.env.MORPH_API_KEY! }
         ],

--- a/tests/integration/sandbox/drives.test.ts
+++ b/tests/integration/sandbox/drives.test.ts
@@ -2,7 +2,7 @@ import { DriveInstance, SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, uniqueName, waitForSandboxDeletion } from './helpers.js'
 
-const defaultRegion = process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1' // Only region for drives right now
+const defaultRegion = process.env.BL_REGION || (process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1') // Only region for drives right now
 
 describe('Drive Operations', () => {
   const createdSandboxes: string[] = []

--- a/tests/integration/sandbox/extra-args.test.ts
+++ b/tests/integration/sandbox/extra-args.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, uniqueName } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from './helpers.js'
 
 describe('Sandbox extraArgs (kernel selection)', () => {
   const createdSandboxes: string[] = []
@@ -22,6 +22,7 @@ describe('Sandbox extraArgs (kernel selection)', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       extraArgs: { iptables: "enabled" },
       labels: defaultLabels,
     })
@@ -37,6 +38,7 @@ describe('Sandbox extraArgs (kernel selection)', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       extraArgs: { nvme: "enabled" },
       labels: defaultLabels,
     })
@@ -52,6 +54,7 @@ describe('Sandbox extraArgs (kernel selection)', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       extraArgs: { iptables: "enabled", nvme: "enabled" },
       labels: defaultLabels,
     })
@@ -67,6 +70,7 @@ describe('Sandbox extraArgs (kernel selection)', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       labels: defaultLabels,
     })
     createdSandboxes.push(name)
@@ -82,6 +86,7 @@ describe('Sandbox extraArgs (kernel selection)', () => {
     await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       extraArgs: { iptables: "enabled" },
       labels: defaultLabels,
     })

--- a/tests/integration/sandbox/fast-operations.test.ts
+++ b/tests/integration/sandbox/fast-operations.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, uniqueName } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from './helpers.js'
 
 describe('Fast Sandbox Operations', () => {
   const createdSandboxes: string[] = []
@@ -24,6 +24,7 @@ describe('Fast Sandbox Operations', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       labels: defaultLabels,
     })
     const createTime = Date.now() - startTime
@@ -52,6 +53,7 @@ describe('Fast Sandbox Operations', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         labels: defaultLabels,
       })
       const createTime = Date.now() - createStart
@@ -82,6 +84,7 @@ describe('Fast Sandbox Operations', () => {
       const sandbox = await SandboxInstance.create({
         name: `${name}-${i}`,
         image: defaultImage,
+        region: defaultRegion,
         labels: defaultLabels,
       })
 

--- a/tests/integration/sandbox/filesystem.test.ts
+++ b/tests/integration/sandbox/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels, sleep } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep } from './helpers.js'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import { stat, readFile } from 'fs/promises'
@@ -17,6 +17,7 @@ describe('Sandbox Filesystem Operations', () => {
     sandbox = await SandboxInstance.create({
       name: sandboxName,
       image: defaultImage,
+      region: defaultRegion,
       memory: 2048,
       labels: defaultLabels,
     })

--- a/tests/integration/sandbox/helpers.ts
+++ b/tests/integration/sandbox/helpers.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
  * Environment-aware configuration
  */
 export const env = process.env.BL_ENV || "prod"
-export const defaultRegion = env === "dev" ? "eu-dub-1" : "us-was-1"
+export const defaultRegion = process.env.BL_REGION || (env === "dev" ? "eu-dub-1" : "us-was-1")
 export const defaultImage = "blaxel/base-image:latest"
 
 /**

--- a/tests/integration/sandbox/image.test.ts
+++ b/tests/integration/sandbox/image.test.ts
@@ -1,6 +1,6 @@
 import { createSandbox, SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultLabels, uniqueName, waitForSandboxDeletion } from './helpers.js'
+import { defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion } from './helpers.js'
 
 // Set to true to enable custom Docker image tests
 const ENABLE_CUSTOM_DOCKER_TESTS = process.env.ENABLE_CUSTOM_DOCKER_TESTS === 'true' || false
@@ -30,6 +30,7 @@ describe('Sandbox Image Tests', () => {
         body: {
           metadata: { name, labels: defaultLabels },
           spec: {
+            region: defaultRegion,
             runtime: {
               memory: 4096
               // Note: image is intentionally omitted here
@@ -58,6 +59,7 @@ describe('Sandbox Image Tests', () => {
       // When using the SDK's create method, it should automatically fill in a default image
       const sandbox = await SandboxInstance.create({
         name,
+        region: defaultRegion,
         labels: defaultLabels
         // Note: image is intentionally omitted here
       }, { safe: true })
@@ -84,6 +86,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "blaxel/base-image",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -105,6 +108,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "blaxel/base-image:latest",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -131,6 +135,7 @@ describe('Sandbox Image Tests', () => {
         SandboxInstance.create({
           name,
           image: randomImage,
+          region: defaultRegion,
           labels: defaultLabels
         }, { safe: true })
       ).rejects.toThrow()
@@ -149,23 +154,26 @@ describe('Sandbox Image Tests', () => {
         SandboxInstance.create({
           name,
           image: invalidImage,
+          region: defaultRegion,
           labels: defaultLabels
         }, { safe: true })
       ).rejects.toThrow()
     })
 
-    it('fails with non-existent registry', async () => {
-      const name = uniqueName("bad-registry")
-      const badRegistryImage = "fake-registry.example.com/image:latest"
+    // This is working now, as we allow to build a sandbox from an external registry
+    // it('fails with non-existent registry', async () => {
+    //   const name = uniqueName("bad-registry")
+    //   const badRegistryImage = "fake-registry.example.com/image:latest"
 
-      await expect(
-        SandboxInstance.create({
-          name,
-          image: badRegistryImage,
-          labels: defaultLabels
-        }, { safe: true })
-      ).rejects.toThrow()
-    })
+    //   await expect(
+    //     SandboxInstance.create({
+    //       name,
+    //       image: badRegistryImage,
+    //       region: defaultRegion,
+    //       labels: defaultLabels
+    //     }, { safe: true })
+    //   ).rejects.toThrow()
+    // })
 
     it('fails with blaxel/base-image:notexistingtag', async () => {
       const name = uniqueName("bad-tag")
@@ -175,6 +183,7 @@ describe('Sandbox Image Tests', () => {
         SandboxInstance.create({
           name,
           image: invalidTagImage,
+          region: defaultRegion,
           labels: defaultLabels
         }, { safe: true })
       ).rejects.toThrow()
@@ -193,6 +202,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "docker",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -214,6 +224,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "docker:latest",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -235,6 +246,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "docker:lqyszf5qx5pe",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -256,6 +268,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "sandbox/docker",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -277,6 +290,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "sandbox/docker:latest",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)
@@ -298,6 +312,7 @@ describe('Sandbox Image Tests', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: "sandbox/docker:lqyszf5qx5pe",
+        region: defaultRegion,
         labels: defaultLabels
       }, { safe: true })
       createdSandboxes.push(name)

--- a/tests/integration/sandbox/interpreter.test.ts
+++ b/tests/integration/sandbox/interpreter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { CodeInterpreter } from "@blaxel/core"
-import { uniqueName, defaultLabels } from './helpers.js'
+import { uniqueName, defaultLabels, defaultRegion } from './helpers.js'
 
 describe('CodeInterpreter Operations', () => {
   let interpreter: CodeInterpreter
@@ -9,6 +9,7 @@ describe('CodeInterpreter Operations', () => {
   beforeAll(async () => {
     interpreter = await CodeInterpreter.create({
       name: interpreterName,
+      region: defaultRegion,
       labels: defaultLabels,
     })
   }, 180000) // 3 minute timeout for interpreter creation
@@ -164,7 +165,7 @@ describe('CodeInterpreter Operations', () => {
       const name = uniqueName("ci-cine")
       cineNames.push(name)
 
-      const ci = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+      const ci = await CodeInterpreter.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
 
       expect(ci.metadata.name).toBe(name)
       expect(ci).toBeInstanceOf(CodeInterpreter)
@@ -174,8 +175,8 @@ describe('CodeInterpreter Operations', () => {
       const name = uniqueName("ci-cine-existing")
       cineNames.push(name)
 
-      const first = await CodeInterpreter.create({ name, labels: defaultLabels })
-      const second = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+      const first = await CodeInterpreter.create({ name, region: defaultRegion, labels: defaultLabels })
+      const second = await CodeInterpreter.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
 
       expect(second.metadata.name).toBe(first.metadata.name)
       expect(second).toBeInstanceOf(CodeInterpreter)
@@ -185,7 +186,7 @@ describe('CodeInterpreter Operations', () => {
       const name = uniqueName("ci-cine-run")
       cineNames.push(name)
 
-      const ci = await CodeInterpreter.createIfNotExists({ name, labels: defaultLabels })
+      const ci = await CodeInterpreter.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
 
       const stdoutLines: string[] = []
       await ci.runCode("print('hello from createIfNotExists')", {

--- a/tests/integration/sandbox/large-envs.test.ts
+++ b/tests/integration/sandbox/large-envs.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance, VolumeInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion } from './helpers.js'
 
 describe('Sandbox Large Environment Variables', () => {
   const createdSandboxes: string[] = []
@@ -69,6 +69,7 @@ describe('Sandbox Large Environment Variables', () => {
         const sandbox = await SandboxInstance.create({
           name,
           image: defaultImage,
+          region: defaultRegion,
           envs,
           labels: defaultLabels,
         })
@@ -128,6 +129,7 @@ describe('Sandbox Large Environment Variables', () => {
     const volume = await VolumeInstance.create({
       name: volumeName,
       size: 1024, // 1GB
+      region: defaultRegion,
       labels: defaultLabels,
     })
     createdVolumes.push(volumeName)
@@ -137,6 +139,7 @@ describe('Sandbox Large Environment Variables', () => {
     const sandbox1 = await SandboxInstance.create({
       name: sandboxName1,
       image: defaultImage,
+      region: defaultRegion,
       envs,
       volumes: [
         {
@@ -198,6 +201,7 @@ describe('Sandbox Large Environment Variables', () => {
     const sandbox2 = await SandboxInstance.create({
       name: sandboxName2,
       image: defaultImage,
+      region: defaultRegion,
       envs,
       volumes: [
         {
@@ -244,6 +248,7 @@ describe('Sandbox Large Environment Variables', () => {
     const sandbox = await SandboxInstance.create({
       name: sandboxName,
       image: defaultImage,
+      region: defaultRegion,
       envs,
       labels: defaultLabels,
     })
@@ -324,6 +329,7 @@ describe('Sandbox Large Environment Variables', () => {
     const sandbox = await SandboxInstance.create({
       name: sandboxName,
       image: defaultImage,
+      region: defaultRegion,
       envs: specialEnvs,
       labels: defaultLabels,
     })
@@ -360,6 +366,7 @@ describe('Sandbox Large Environment Variables', () => {
     const sandbox = await SandboxInstance.create({
       name,
       image: defaultImage,
+      region: defaultRegion,
       envs,
       labels: defaultLabels,
     })

--- a/tests/integration/sandbox/lifecycle.test.ts
+++ b/tests/integration/sandbox/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll } from 'vitest'
 import { SandboxInstance, updateSandbox, Sandbox } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels, sleep, waitForSandboxDeployed, retry } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep, waitForSandboxDeployed, retry } from './helpers.js'
 
 describe('Sandbox Lifecycle and Expiration', () => {
   const createdSandboxes: string[] = []
@@ -27,6 +27,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const firstSandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         ttl: "1s",
         labels: defaultLabels,
       })
@@ -43,7 +44,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       expect(retrievedSandbox.status).toBe("TERMINATED")
 
       // Create a new sandbox with the same name
-      const secondSandbox = await SandboxInstance.create({name, labels: defaultLabels})
+      const secondSandbox = await SandboxInstance.create({name, region: defaultRegion, labels: defaultLabels})
       expect(secondSandbox.metadata.name).toBe(name)
       createdSandboxes.push(name)
 
@@ -61,6 +62,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const firstSandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         expires: expiresAt,
         labels: defaultLabels,
       })
@@ -77,7 +79,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       expect(retrievedSandbox.status).toBe("TERMINATED")
 
       // Create a new sandbox with the same name
-      const secondSandbox = await SandboxInstance.create({name, labels: defaultLabels})
+      const secondSandbox = await SandboxInstance.create({name, region: defaultRegion, labels: defaultLabels})
       expect(secondSandbox.metadata.name).toBe(name)
       createdSandboxes.push(name)
 
@@ -93,6 +95,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const firstSandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         lifecycle: {
           expirationPolicies: [
             { type: "ttl-max-age", value: "1s", action: "delete" }
@@ -113,7 +116,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       expect(retrievedSandbox.status).toBe("TERMINATED")
 
       // Create a new sandbox with the same name
-      const secondSandbox = await SandboxInstance.create({name, labels: defaultLabels})
+      const secondSandbox = await SandboxInstance.create({name, region: defaultRegion, labels: defaultLabels})
       expect(secondSandbox.metadata.name).toBe(name)
       createdSandboxes.push(name)
 
@@ -129,6 +132,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const firstSandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         lifecycle: {
           expirationPolicies: [
             { type: "ttl-idle", value: "5s", action: "delete" }
@@ -149,7 +153,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       expect(retrievedSandbox.status).toBe("TERMINATED")
 
       // Create a new sandbox with the same name
-      const secondSandbox = await SandboxInstance.create({name, labels: defaultLabels})
+      const secondSandbox = await SandboxInstance.create({name, region: defaultRegion, labels: defaultLabels})
       expect(secondSandbox.metadata.name).toBe(name)
       createdSandboxes.push(name)
 
@@ -167,6 +171,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const firstSandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         lifecycle: {
           expirationPolicies: [
             { type: "date", value: expirationDate.toISOString(), action: "delete" }
@@ -187,7 +192,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       expect(retrievedSandbox.status).toBe("TERMINATED")
 
       // Create a new sandbox with the same name
-      const secondSandbox = await SandboxInstance.create({name, labels: defaultLabels})
+      const secondSandbox = await SandboxInstance.create({name, region: defaultRegion, labels: defaultLabels})
       expect(secondSandbox.metadata.name).toBe(name)
       createdSandboxes.push(name)
 
@@ -202,6 +207,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         snapshotEnabled: true,
         labels: defaultLabels,
       })
@@ -215,6 +221,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         snapshotEnabled: false,
         labels: defaultLabels,
       })
@@ -234,6 +241,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         ttl: "10m",
         labels: defaultLabels,
       })
@@ -272,6 +280,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         ttl: "5m",
         labels: defaultLabels,
       })
@@ -314,6 +323,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         lifecycle: {
           expirationPolicies: [
             { type: "ttl-max-age", value: "10m", action: "delete" }
@@ -361,6 +371,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         lifecycle: {
           expirationPolicies: [
             { type: "ttl-idle", value: "5m", action: "delete" }
@@ -402,6 +413,7 @@ describe('Sandbox Lifecycle and Expiration', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         envs: [
           { name: "TEST_VAR", value: "initial_value" }
         ],

--- a/tests/integration/sandbox/process.test.ts
+++ b/tests/integration/sandbox/process.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels, sleep } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep } from './helpers.js'
 
 const SKIP_KEEP_ALIVE = true
 
@@ -12,6 +12,7 @@ describe('Sandbox Process Operations', () => {
     sandbox = await SandboxInstance.create({
       name: sandboxName,
       image: defaultImage,
+      region: defaultRegion,
       memory: 2048,
       labels: defaultLabels,
     })
@@ -574,6 +575,7 @@ HTTPServer(('', 3000), H).serve_forever()
       const instance = await SandboxInstance.create({
         name,
         image,
+        region: defaultRegion,
         memory: 2048,
         ports: [{ target: 3000, protocol: "HTTP" }],
         labels: defaultLabels,

--- a/tests/integration/sandbox/region.test.ts
+++ b/tests/integration/sandbox/region.test.ts
@@ -4,8 +4,9 @@ import { defaultImage, defaultLabels, defaultRegion, env, uniqueName, waitForSan
 
 const backendDefaultRegion = env === "dev" ? "eu-dub-1" : "us-pdx-1"
 const alternateRegion = env === "dev" ? "eu-dub-2" : "eu-lon-1"
+const describeWhenRegionUnset = process.env.BL_REGION ? describe.skip : describe
 
-describe('BL_REGION Environment Variable Auto-Fill', () => {
+describeWhenRegionUnset('BL_REGION Environment Variable Auto-Fill', () => {
   const createdSandboxes: string[] = []
   const createdVolumes: string[] = []
   const originalRegion = process.env.BL_REGION

--- a/tests/integration/sandbox/sandbox-crud.test.ts
+++ b/tests/integration/sandbox/sandbox-crud.test.ts
@@ -20,7 +20,7 @@ describe('Sandbox CRUD Operations', () => {
 
   describe('create', () => {
     it('creates a sandbox with default settings', async () => {
-      const sandbox = await SandboxInstance.create({ labels: defaultLabels })
+      const sandbox = await SandboxInstance.create({ region: defaultRegion, labels: defaultLabels })
       if (sandbox.metadata.name) createdSandboxes.push(sandbox.metadata.name)
 
       expect(sandbox.metadata.name).toBeDefined()
@@ -29,7 +29,7 @@ describe('Sandbox CRUD Operations', () => {
 
     it('creates a sandbox with custom name', async () => {
       const name = uniqueName("custom")
-      const sandbox = await SandboxInstance.create({ name, labels: defaultLabels })
+      const sandbox = await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       expect(sandbox.metadata.name).toBe(name)
@@ -40,6 +40,7 @@ describe('Sandbox CRUD Operations', () => {
       const sandbox = await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         labels: defaultLabels,
       })
       createdSandboxes.push(name)
@@ -52,6 +53,7 @@ describe('Sandbox CRUD Operations', () => {
       await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         memory: 8192,
         labels: defaultLabels,
       })
@@ -65,6 +67,7 @@ describe('Sandbox CRUD Operations', () => {
       const name = uniqueName("labels-test")
       const labelsSandbox = await SandboxInstance.create({
         name,
+        region: defaultRegion,
         labels: { ...defaultLabels, "env": "test", "purpose": "integration" }
       })
       createdSandboxes.push(name)
@@ -78,6 +81,7 @@ describe('Sandbox CRUD Operations', () => {
       const config: SandboxCreateConfiguration = {
         name,
         image: defaultImage,
+        region: defaultRegion,
         memory: 2048,
         ports: [
           { name: "web", target: 3000 },
@@ -98,6 +102,7 @@ describe('Sandbox CRUD Operations', () => {
       await SandboxInstance.create({
         name,
         image: defaultImage,
+        region: defaultRegion,
         envs: [
           { name: "NODE_ENV", value: "test" },
           { name: "DEBUG", value: "true" },
@@ -129,7 +134,7 @@ describe('Sandbox CRUD Operations', () => {
       const concurrentCalls = 5
 
       const promises = Array.from({ length: concurrentCalls }, () =>
-        SandboxInstance.create({ name, labels: defaultLabels })
+        SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
           .then(sb => ({ sandbox: sb, error: null }))
           .catch((err: Error) => ({ sandbox: null, error: err }))
       )
@@ -158,7 +163,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('createIfNotExists', () => {
     it('creates a new sandbox if it does not exist', async () => {
       const name = uniqueName("cine")
-      const sandbox = await SandboxInstance.createIfNotExists({ name, labels: defaultLabels })
+      const sandbox = await SandboxInstance.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       expect(sandbox.metadata.name).toBe(name)
@@ -168,11 +173,11 @@ describe('Sandbox CRUD Operations', () => {
       const name = uniqueName("cine-existing")
 
       // Create first
-      const first = await SandboxInstance.create({ name, labels: defaultLabels })
+      const first = await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       // createIfNotExists should return the same sandbox
-      const second = await SandboxInstance.createIfNotExists({ name, labels: defaultLabels })
+      const second = await SandboxInstance.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
 
       expect(second.metadata.name).toBe(first.metadata.name)
     })
@@ -182,7 +187,7 @@ describe('Sandbox CRUD Operations', () => {
       const concurrentCalls = 5
 
       const promises = Array.from({ length: concurrentCalls }, () =>
-        SandboxInstance.createIfNotExists({ name, labels: defaultLabels })
+        SandboxInstance.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
           .then(sb => ({ sandbox: sb, error: null }))
           .catch((err: Error) => ({ sandbox: null, error: err }))
       )
@@ -205,13 +210,13 @@ describe('Sandbox CRUD Operations', () => {
       const name = uniqueName("cine-existing-concurrent")
 
       // First, create the sandbox
-      const originalSandbox = await SandboxInstance.create({ name, labels: defaultLabels })
+      const originalSandbox = await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       // Then send 5 concurrent createIfNotExists calls
       const concurrentCalls = 5
       const promises = Array.from({ length: concurrentCalls }, () =>
-        SandboxInstance.createIfNotExists({ name, labels: defaultLabels })
+        SandboxInstance.createIfNotExists({ name, region: defaultRegion, labels: defaultLabels })
       )
 
       const results = await Promise.all(promises)
@@ -228,7 +233,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('get', () => {
     it('retrieves an existing sandbox', async () => {
       const name = uniqueName("get-test")
-      await SandboxInstance.create({ name, labels: defaultLabels })
+      await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       const retrieved = await SandboxInstance.get(name)
@@ -245,7 +250,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('list', () => {
     it('lists all sandboxes', async () => {
       const name = uniqueName("list-test")
-      await SandboxInstance.create({ name, labels: defaultLabels })
+      await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       const sandboxes = await SandboxInstance.list()
@@ -259,7 +264,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('delete', () => {
     it('deletes an existing sandbox', async () => {
       const name = uniqueName("delete-test")
-      await SandboxInstance.create({ name, labels: defaultLabels })
+      await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
 
       await SandboxInstance.delete(name)
 
@@ -270,7 +275,7 @@ describe('Sandbox CRUD Operations', () => {
 
     it('can delete using instance method', async () => {
       const name = uniqueName("delete-instance")
-      const sandbox = await SandboxInstance.create({ name, labels: defaultLabels })
+      const sandbox = await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
 
       await sandbox.delete()
 
@@ -283,7 +288,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('updateMetadata', () => {
     it('updates sandbox labels', async () => {
       const name = uniqueName("update-meta")
-      await SandboxInstance.create({ name, labels: defaultLabels })
+      await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       const updated = await SandboxInstance.updateMetadata(name, {
@@ -295,7 +300,7 @@ describe('Sandbox CRUD Operations', () => {
 
     it('updates sandbox displayName', async () => {
       const name = uniqueName("update-display")
-      await SandboxInstance.create({ name, labels: defaultLabels })
+      await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
       const updated = await SandboxInstance.updateMetadata(name, {
@@ -309,7 +314,7 @@ describe('Sandbox CRUD Operations', () => {
   describe('wait', () => {
     it('waits for sandbox to be ready', async () => {
       const name = uniqueName("wait-test")
-      const sandbox = await SandboxInstance.create({ name, labels: defaultLabels })
+      const sandbox = await SandboxInstance.create({ name, region: defaultRegion, labels: defaultLabels })
       createdSandboxes.push(name)
 
 

--- a/tests/integration/sandbox/sessions.test.ts
+++ b/tests/integration/sandbox/sessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels, sleep } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep } from './helpers.js'
 
 describe('Sandbox Session Operations', () => {
   let sandbox: SandboxInstance
@@ -10,6 +10,7 @@ describe('Sandbox Session Operations', () => {
     sandbox = await SandboxInstance.create({
       name: sandboxName,
       image: defaultImage,
+      region: defaultRegion,
       memory: 2048,
       labels: defaultLabels,
     })


### PR DESCRIPTION
- Updated sandbox tests to include defaultRegion in the SandboxInstance.create() calls, ensuring consistent region handling.
- Modified helpers to allow for environment-specific region configuration.
- Enhanced test coverage for sandbox operations by integrating region parameter in various test scenarios.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Propagates `defaultRegion` (sourced from `BL_REGION` env var with a per-env fallback) to every `SandboxInstance.create()` / `CodeInterpreter.create()` call across integration tests, and skips the region auto-fill suite when `BL_REGION` is already set externally.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9e7c413a1a6e973a17e04c2c0b8f6ea3fea1a122.</sup>
<!-- /MENDRAL_SUMMARY -->