### PR TITLE
Set a limit to 10 task in parallel for test

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
     hookTimeout: 120000, // 2 minutes for setup/teardown
     globals: true,
     reporters: ['verbose'],
+    fileParallelism: true,
+    maxWorkers: 10,
+    sequence: {
+      concurrent: false,
+    },
     globalSetup: ['tests/integration/sandbox/globalTeardown.ts', 'tests/benchmarks/sandbox/teardown.ts'],
     env: {
     },

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     hookTimeout: 120000, // 2 minutes
     globals: true,
     reporters: ['verbose'],
+    fileParallelism: true,
+    maxWorkers: 10,
+    sequence: {
+      concurrent: false,
+    },
   },
 })
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `maxWorkers: 10` and `sequence: { concurrent: false }` to both `vitest.config.ts` and `vitest.e2e.config.ts` to cap parallel test file execution at 10 workers while keeping tests within each file sequential.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 06097f4b15fa0a2ec4e911de75c7c788fa874e34.</sup>
<!-- /MENDRAL_SUMMARY -->