### PR TITLE
sandbox: handle creation races

### DIFF
--- a/@blaxel/core/src/sandbox/interpreter.ts
+++ b/@blaxel/core/src/sandbox/interpreter.ts
@@ -39,7 +39,7 @@ export class CodeInterpreter extends SandboxInstance {
 
   static async create(
     sandbox?: Sandbox | SandboxCreateConfiguration | Record<string, any> | null,
-    { safe = true }: { safe?: boolean } = {}
+    { safe = true, createIfNotExist = false }: { safe?: boolean, createIfNotExist?: boolean } = {}
   ): Promise<CodeInterpreter> {
     // Build a SandboxCreateConfiguration with CodeInterpreter defaults
     const defaults: SandboxCreateConfiguration = {
@@ -74,7 +74,7 @@ export class CodeInterpreter extends SandboxInstance {
       merged = defaults;
     }
 
-    const baseInstance = await super.create(merged, { safe });
+    const baseInstance = await super.create(merged, { safe, createIfNotExist });
 
     // Create config from the instance
     const config: SandboxConfiguration = {

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -13,6 +13,14 @@ import { SandboxSessions } from "./session.js";
 import { SandboxSystem } from "./system.js";
 import { normalizeEnvs, normalizePorts, normalizeVolumes, SandboxConfiguration, SandboxCreateConfiguration, SandboxUpdateMetadata, SessionWithToken } from "./types.js";
 
+const NON_REUSABLE_SANDBOX_STATUSES = new Set([
+  "FAILED",
+  "TERMINATED",
+  "TERMINATING",
+  "DELETING",
+  "DEACTIVATING",
+]);
+
 export class SandboxInstance {
   fs: SandboxFileSystem;
   network: SandboxNetwork;
@@ -306,8 +314,8 @@ export class SandboxInstance {
           // Get the existing sandbox to check its status
           const sandboxInstance = await this.get(name);
 
-          // If the sandbox is TERMINATED, treat it as not existing and retry creation
-          if (sandboxInstance.status !== "TERMINATED") {
+          // Recreate instead of returning sandbox records that cannot be reused.
+          if (!NON_REUSABLE_SANDBOX_STATUSES.has(sandboxInstance.status ?? "")) {
             return sandboxInstance;
           }
 
@@ -317,7 +325,7 @@ export class SandboxInstance {
         throw e;
       }
     }
-    throw new Error(`Unable to create sandbox after ${ATTEMPTS} retries.`);
+    throw new Error(`Unable to create sandbox after ${ATTEMPTS} attempts.`);
   }
 
   /* eslint-disable */

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -101,7 +101,7 @@ export class SandboxInstance {
   }
 
   /* eslint-disable */
-  async wait({maxWait = 60000, interval = 1000}: {maxWait?: number, interval?: number} = {}) {
+  async wait({ maxWait = 60000, interval = 1000 }: { maxWait?: number, interval?: number } = {}) {
     logger.warn("⚠️  Warning: sandbox.wait() is deprecated. You don't need to wait for the sandbox to be deployed anymore.");
     return this;
   }
@@ -192,7 +192,7 @@ export class SandboxInstance {
 
     // Kick off warming so h2Pool.get() can join it during the API call
     if (edgeDomain && !settings.disableH2) {
-      import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.warm(edgeDomain)).catch(() => {});
+      import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.warm(edgeDomain)).catch(() => { });
     }
 
     const [{ data }, h2Session] = await Promise.all([
@@ -212,7 +212,7 @@ export class SandboxInstance {
       try {
         await instance.fs.ls('/')
       } catch (err) {
-        await SandboxInstance.delete(instance.metadata.name!).catch(() => {});
+        await SandboxInstance.delete(instance.metadata.name!).catch(() => { });
         throw err;
       }
     }
@@ -231,7 +231,7 @@ export class SandboxInstance {
   }
 
   static async list() {
-    const { data } = await listSandboxes({throwOnError: true}) as { response: Response; data: SandboxModel[] };
+    const { data } = await listSandboxes({ throwOnError: true }) as { response: Response; data: SandboxModel[] };
     const instances = data.map((sandbox) => new SandboxInstance(sandbox));
     return Promise.all(instances.map((instance) => SandboxInstance.attachH2Session(instance)));
   }
@@ -292,29 +292,32 @@ export class SandboxInstance {
 
 
   static async createIfNotExists(sandbox: SandboxModel | SandboxCreateConfiguration) {
-    try {
-      return await this.create(sandbox);
-    } catch (e) {
-      if (typeof e === "object" && e !== null && "code" in e && (e.code === 409 || e.code === 'SANDBOX_ALREADY_EXISTS')) {
-        const name = 'name' in sandbox ? sandbox.name : (sandbox as SandboxModel).metadata.name
-        if (!name) {
-          throw new Error("Sandbox name is required");
-        }
-
-        // Get the existing sandbox to check its status
-        const sandboxInstance = await this.get(name);
-
-          // If the sandbox is TERMINATED, treat it as not existing
-          if (sandboxInstance.status === "TERMINATED") {
-            // Create a new sandbox - backend will handle cleanup of the terminated one
-            return await this.create(sandbox);
+    const ATTEMPTS = 3;
+    for (let i = 0; i < ATTEMPTS; ++i) {
+      try {
+        return await this.create(sandbox);
+      } catch (e) {
+        if (typeof e === "object" && e !== null && "code" in e && (e.code === 409 || e.code === 'SANDBOX_ALREADY_EXISTS')) {
+          const name = 'name' in sandbox ? sandbox.name : (sandbox as SandboxModel).metadata.name
+          if (!name) {
+            throw new Error("Sandbox name is required");
           }
 
-        // Otherwise return the existing running sandbox
-        return sandboxInstance;
+          // Get the existing sandbox to check its status
+          const sandboxInstance = await this.get(name);
+
+          // If the sandbox is TERMINATED, treat it as not existing and retry creation
+          if (sandboxInstance.status !== "TERMINATED") {
+            return sandboxInstance;
+          }
+
+          // Retry creation. We want the same error handling on the retry as creates can race.
+          continue;
+        }
+        throw e;
       }
-      throw e;
     }
+    throw new Error(`Unable to create sandbox after ${ATTEMPTS} retries.`);
   }
 
   /* eslint-disable */

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -114,7 +114,7 @@ export class SandboxInstance {
     return this;
   }
 
-  static async create(sandbox?: SandboxModel | SandboxCreateConfiguration, { safe = false }: { safe?: boolean } = {}) {
+  static async create(sandbox?: SandboxModel | SandboxCreateConfiguration, { safe = false, createIfNotExist = false }: { safe?: boolean, createIfNotExist?: boolean } = {}) {
     const defaultName = `sandbox-${uuidv4().replace(/-/g, '').substring(0, 8)}`
     const defaultImage = `blaxel/base-image:latest`
     const defaultMemory = 4096
@@ -206,6 +206,7 @@ export class SandboxInstance {
     const [{ data }, h2Session] = await Promise.all([
       createSandbox({
         body: sandbox,
+        query: createIfNotExist ? { createIfNotExist } : undefined,
         throwOnError: true,
       }),
       edgeDomain && !settings.disableH2 ? import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.get(edgeDomain)).catch(() => null) : Promise.resolve(null),
@@ -303,7 +304,7 @@ export class SandboxInstance {
     const ATTEMPTS = 3;
     for (let i = 0; i < ATTEMPTS; ++i) {
       try {
-        return await this.create(sandbox);
+        return await this.create(sandbox, { createIfNotExist: true });
       } catch (e) {
         if (typeof e === "object" && e !== null && "code" in e && (e.code === 409 || e.code === 'SANDBOX_ALREADY_EXISTS')) {
           const name = 'name' in sandbox ? sandbox.name : (sandbox as SandboxModel).metadata.name

--- a/tests/unit/sandbox-create-if-not-exists.test.ts
+++ b/tests/unit/sandbox-create-if-not-exists.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SandboxInstance } from "@blaxel/core";
+import { CodeInterpreter, SandboxInstance } from "@blaxel/core";
 
 const conflict = () => Object.assign(new Error("already exists"), { code: 409 });
 
@@ -96,5 +96,38 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
     await expect(
       SandboxInstance.createIfNotExists({ name: "stuck" }),
     ).rejects.toThrow("Unable to create sandbox after 3 attempts.");
+  });
+
+  it("forwards createIfNotExist through CodeInterpreter.create", async () => {
+    const create = vi.spyOn(SandboxInstance, "create").mockResolvedValueOnce(
+      sandbox("interpreter", "DEPLOYED"),
+    );
+
+    await expect(
+      CodeInterpreter.create(
+        { name: "interpreter" },
+        { safe: false, createIfNotExist: true },
+      ),
+    ).resolves.toBeInstanceOf(CodeInterpreter);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "interpreter" }),
+      { safe: false, createIfNotExist: true },
+    );
+  });
+
+  it("uses the server-side createIfNotExist parameter for CodeInterpreter.createIfNotExists", async () => {
+    const create = vi.spyOn(SandboxInstance, "create").mockResolvedValueOnce(
+      sandbox("interpreter-existing", "DEPLOYED"),
+    );
+
+    await expect(
+      CodeInterpreter.createIfNotExists({ name: "interpreter-existing" }),
+    ).resolves.toBeInstanceOf(CodeInterpreter);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "interpreter-existing" }),
+      { safe: true, createIfNotExist: true },
+    );
   });
 });

--- a/tests/unit/sandbox-create-if-not-exists.test.ts
+++ b/tests/unit/sandbox-create-if-not-exists.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SandboxInstance } from "@blaxel/core";
+
+const conflict = () => Object.assign(new Error("already exists"), { code: 409 });
+
+const sandbox = (name: string, status: string) =>
+  new SandboxInstance({
+    metadata: { name },
+    spec: {},
+    status,
+  } as any);
+
+describe("SandboxInstance.createIfNotExists retry handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the existing reusable sandbox after a create conflict", async () => {
+    const existing = sandbox("existing", "DEPLOYED");
+    vi.spyOn(SandboxInstance, "create").mockRejectedValueOnce(conflict());
+    vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(existing);
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "existing" }),
+    ).resolves.toBe(existing);
+  });
+
+  it.each([
+    "FAILED",
+    "TERMINATED",
+    "TERMINATING",
+    "DELETING",
+    "DEACTIVATING",
+  ])("retries creation when the conflicting sandbox is %s", async (status) => {
+    const replacement = sandbox("stale", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockResolvedValueOnce(replacement);
+    vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(sandbox("stale", status));
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "stale" }),
+    ).resolves.toBe(replacement);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles a recreate race after first seeing a terminated sandbox", async () => {
+    const winner = sandbox("race", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockRejectedValueOnce(conflict());
+    vi.spyOn(SandboxInstance, "get")
+      .mockResolvedValueOnce(sandbox("race", "TERMINATED"))
+      .mockResolvedValueOnce(winner);
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "race" }),
+    ).resolves.toBe(winner);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after the bounded attempt budget when only stale sandboxes are seen", async () => {
+    vi.spyOn(SandboxInstance, "create").mockRejectedValue(conflict());
+    vi.spyOn(SandboxInstance, "get").mockResolvedValue(sandbox("stuck", "TERMINATED"));
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "stuck" }),
+    ).rejects.toThrow("Unable to create sandbox after 3 attempts.");
+  });
+});

--- a/tests/unit/sandbox-create-if-not-exists.test.ts
+++ b/tests/unit/sandbox-create-if-not-exists.test.ts
@@ -15,14 +15,34 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
     vi.restoreAllMocks();
   });
 
+  it("uses the server-side createIfNotExist parameter first", async () => {
+    const existing = sandbox("existing", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create").mockResolvedValueOnce(existing);
+    const get = vi.spyOn(SandboxInstance, "get");
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "existing" }),
+    ).resolves.toBe(existing);
+
+    expect(create).toHaveBeenCalledWith(
+      { name: "existing" },
+      { createIfNotExist: true },
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
   it("returns the existing reusable sandbox after a create conflict", async () => {
     const existing = sandbox("existing", "DEPLOYED");
-    vi.spyOn(SandboxInstance, "create").mockRejectedValueOnce(conflict());
+    const create = vi.spyOn(SandboxInstance, "create").mockRejectedValueOnce(conflict());
     vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(existing);
 
     await expect(
       SandboxInstance.createIfNotExists({ name: "existing" }),
     ).resolves.toBe(existing);
+    expect(create).toHaveBeenCalledWith(
+      { name: "existing" },
+      { createIfNotExist: true },
+    );
   });
 
   it.each([
@@ -42,6 +62,16 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
       SandboxInstance.createIfNotExists({ name: "stale" }),
     ).resolves.toBe(replacement);
     expect(create).toHaveBeenCalledTimes(2);
+    expect(create).toHaveBeenNthCalledWith(
+      1,
+      { name: "stale" },
+      { createIfNotExist: true },
+    );
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      { name: "stale" },
+      { createIfNotExist: true },
+    );
   });
 
   it("handles a recreate race after first seeing a terminated sandbox", async () => {


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a 3-attempt retry loop to `createIfNotExists` to handle concurrent creation races on terminal sandboxes. Introduces a `NON_REUSABLE_SANDBOX_STATUSES` set with inverted logic to return existing sandboxes only when reusable. Delegates the idempotency check server-side via a `createIfNotExist` query parameter, with a client-side 409 fallback for residual races. The latest commit (`c658ac4`) threads `createIfNotExist` through `CodeInterpreter.create` and adds test coverage.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c658ac47488b12acfa19d40fed8733bad84e027a.</sup>
<!-- /MENDRAL_SUMMARY -->