### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,30 @@ cd @blaxel/core && npm run build    # builds CJS + ESM + browser variants
 ```
 
 The build outputs to `dist/cjs/`, `dist/esm/`, `dist/cjs-browser/`, `dist/esm-browser/`. Tests and other packages import from the compiled output, not from source.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Package manager**: Bun v1.3.4 (installed at `~/.bun/bin/bun`). Ensure `PATH` includes `$HOME/.bun/bin`.
+- **Node.js**: v22 via nvm (pre-installed).
+- **No Docker** or external services required for SDK development.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `bun install` |
+| Build all | `bun run build` |
+| Lint | `bun run lint` |
+| Unit tests | `npx vitest run tests/unit --reporter=verbose` |
+| H2 fetch tests | `npx vitest run tests/integration/common/h2fetch.test.ts --reporter=verbose` |
+| Integration tests | `bun run test:integration` (requires `BL_WORKSPACE` + `BL_API_KEY`) |
+| Dev watch mode | `bun run dev` |
+
+### Gotchas
+
+- You must rebuild (`bun run build`) before running integration tests; tests import from `dist/`, not source.
+- The lint command reports pre-existing errors in `@blaxel/core/src/image/image.ts` (unnecessary type assertions). These are not regressions.
+- Unit tests (`tests/unit/`) and `tests/integration/common/h2fetch.test.ts` run without any API credentials. All other integration tests require `BL_WORKSPACE` and `BL_API_KEY`.
+- The global test cleanup hook always runs and logs warnings about listing sandboxes/volumes when credentials are absent — this is safe to ignore.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with:

- Environment details (Bun v1.3.4, Node.js v22)
- Key command reference table (install, build, lint, test, dev)
- Documented gotchas (rebuild before integration tests, pre-existing lint errors, tests that require API credentials vs those that don't)

This helps future cloud agents set up and develop in this repo without needing to rediscover these details.

**Verification log:**
[env_setup_verification.log](https://cursor.com/agents/bc-26a9a115-6dd6-455f-bfad-2f325dc03266/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_setup_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a9a115-6dd6-455f-bfad-2f325dc03266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a9a115-6dd6-455f-bfad-2f325dc03266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a Cursor Cloud-specific section to AGENTS.md documenting the environment setup (Bun, Node.js), key commands, and gotchas for future cloud agents working in this repo.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8d9bdd04bbc7382ea4408a888ead53f84396cab8.</sup>
<!-- /MENDRAL_SUMMARY -->