### PR TITLE
fix(core): reduce multipart upload concurrency

### DIFF
--- a/@blaxel/core/src/sandbox/filesystem/filesystem.test.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { MultipartInitiateResponse, MultipartPartInfo, MultipartUploadPartResponse, SuccessResponse } from "../client/index.js";
+import { SandboxFileSystem } from "./filesystem.js";
+
+type MultipartUploadHarness = {
+  uploadWithMultipart: (path: string, blob: Blob, permissions?: string) => Promise<SuccessResponse>;
+  initiateMultipartUpload: (path: string, permissions?: string) => Promise<MultipartInitiateResponse>;
+  uploadPart: (uploadId: string, partNumber: number, fileBlob: Blob) => Promise<MultipartUploadPartResponse>;
+  completeMultipartUpload: (uploadId: string, parts: Array<MultipartPartInfo>) => Promise<SuccessResponse>;
+  abortMultipartUpload: (uploadId: string) => Promise<SuccessResponse>;
+};
+
+const waitForPartUpload = () => new Promise((resolve) => setTimeout(resolve, 5));
+
+describe("SandboxFileSystem multipart upload", () => {
+  it("limits concurrent part uploads", async () => {
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const uploadedParts: number[] = [];
+    let completedParts: Array<MultipartPartInfo> = [];
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-1" });
+    filesystem.uploadPart = async (_uploadId, partNumber) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await waitForPartUpload();
+      uploadedParts.push(partNumber);
+      inFlight -= 1;
+      return { partNumber, etag: `etag-${partNumber}` };
+    };
+    filesystem.completeMultipartUpload = (_uploadId, parts) => {
+      completedParts = parts;
+      return Promise.resolve({ message: "ok" });
+    };
+    filesystem.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+
+    const blob = new Blob([new Uint8Array(16 * 1024 * 1024)]);
+
+    await filesystem.uploadWithMultipart("/tmp/large-file.bin", blob);
+
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(uploadedParts.sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    expect(completedParts.map((part) => part.partNumber)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -9,7 +9,7 @@ import { CopyResponse, FilesystemFindOptions, FilesystemGrepOptions, FilesystemS
 // Multipart upload constants
 const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB
 const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB per part
-const MAX_PARALLEL_UPLOADS = 20; // Number of parallel part uploads
+const MAX_PARALLEL_UPLOADS = 3; // Number of parallel part uploads
 
 export class SandboxFileSystem extends SandboxAction {
   constructor(sandbox: Sandbox, private process: SandboxProcess) {


### PR DESCRIPTION
## Summary
- Reduces multipart upload part concurrency from 20 to 3 to avoid HTTP/2 stream rejection during large uploads.
- Adds focused coverage that verifies multipart uploads keep at most 3 part uploads in flight and complete parts in order.

## Verification
- `bun run --filter @blaxel/core test src/sandbox/filesystem/filesystem.test.ts`
- `bun run --filter @blaxel/core test`
- `bun run --filter @blaxel/core build`
- `git diff --check`
- `bun eslint src/sandbox/filesystem/filesystem.ts src/sandbox/filesystem/filesystem.test.ts` from `@blaxel/core`
- Local tarball install smoke: ESM import and CJS require both pass
- Live check: 120 MB `sandbox.fs.writeBinary()` upload succeeded in `calibrator`; remote size verified as `125829120`; sandbox deleted; final `bl get sandboxes -o json` returned `[]`

## Notes
- Linear: ENG-2547
- Full `@blaxel/core` lint still has unrelated existing issues in `src/image/image.ts` and `src/sandbox/preview.ts`.
- Customer or released-package confirmation should happen after this lands and publishes.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reduces `MAX_PARALLEL_UPLOADS` from 20 to 3 to prevent HTTP/2 stream rejection during large file uploads, and adds a concurrency-limit test that verifies at most 3 parts are in-flight at once.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 31f138164e256b2d3b158ba9385a2d3f672a1dcd.</sup>
<!-- /MENDRAL_SUMMARY -->