### PR TITLE
Add HTTP/2 reliability coverage

### DIFF
--- a/tests/integration/common/h2fetch.test.ts
+++ b/tests/integration/common/h2fetch.test.ts
@@ -367,6 +367,26 @@ describe('h2fetch: no silent retry after session.request()', () => {
     expect(session.unrefCalls).toBe(2);
     expect(session.lastStream!.closed).toBe(true);
   });
+
+  it('restores idle-unref when the response body errors', async () => {
+    const session = new MockSession();
+    markH2SessionIdleUnref(asSession(session));
+
+    const promise = h2RequestDirect(
+      asSession(session),
+      'http://example.com/resource',
+      { method: 'POST', body: 'payload' },
+    );
+
+    expect(session.refCalls).toBe(1);
+    session.lastStream!.emit('response', { ':status': 200 });
+    const response = await promise;
+
+    session.lastStream!.emit('error', new Error('body broke'));
+
+    await expect(response.text()).rejects.toThrow('body broke');
+    expect(session.unrefCalls).toBe(2);
+  });
 });
 
 describe('h2fetch: pre-flight fallback still works', () => {
@@ -440,6 +460,32 @@ describe('h2fetch: pre-flight fallback still works', () => {
 
     expect(requestSpy).not.toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await expect(response.text()).resolves.toBe('fallback');
+  });
+
+  it('falls back before creating an H2 stream for unsupported pooled direct bodies', async () => {
+    const pool = new H2Pool();
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, 'request');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('fallback'));
+    (pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+
+    const form = new FormData();
+    form.append('file', new Blob(['payload']), 'payload.txt');
+
+    const response = await h2RequestDirectFromPool(
+      pool,
+      'edge.example.com',
+      'http://example.com/resource',
+      { method: 'PUT', body: form },
+    );
+
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(pool.tryGet('edge.example.com')).toBe(session);
     await expect(response.text()).resolves.toBe('fallback');
   });
 });
@@ -705,5 +751,42 @@ describe('sandbox actions: pool-backed H2 routing', () => {
 
     const response = await responsePromise;
     expect(response.status).toBe(200);
+  });
+
+  it('uses global fetch when BL_DISABLE_H2 is set', async () => {
+    const previousDisableH2 = process.env.BL_DISABLE_H2;
+    process.env.BL_DISABLE_H2 = '1';
+
+    try {
+      const session = new MockSession();
+      const requestSpy = vi.spyOn(session, 'request');
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('fallback'));
+      (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+        () => Promise.resolve(session);
+
+      const action = new H2ProbeAction({
+        metadata: {
+          name: 'sandbox-test',
+          url: 'http://example.com',
+        },
+        spec: {},
+        h2Session: asSession(session),
+        h2Domain: 'edge.example.com',
+      });
+
+      const response = await action.fetchWithH2('http://example.com/resource');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(requestSpy).not.toHaveBeenCalled();
+      await expect(response.text()).resolves.toBe('fallback');
+    } finally {
+      if (previousDisableH2 === undefined) {
+        delete process.env.BL_DISABLE_H2;
+      } else {
+        process.env.BL_DISABLE_H2 = previousDisableH2;
+      }
+    }
   });
 });

--- a/tests/integration/sandbox/filesystem.test.ts
+++ b/tests/integration/sandbox/filesystem.test.ts
@@ -290,7 +290,7 @@ describe('Sandbox Filesystem Operations', () => {
       expect(result).toBe(content)
     })
 
-    it('uploads large text file (> 1MB) via multipart', async () => {
+    it('uploads medium text file below multipart threshold via regular upload', async () => {
       const content = "Large file content line. ".repeat(50000) // ~1.2MB
       const path = "/tmp/large-upload.txt"
 
@@ -301,7 +301,7 @@ describe('Sandbox Filesystem Operations', () => {
       expect(result).toBe(content)
     })
 
-    it('uploads large binary file via multipart', async () => {
+    it('uploads medium binary file below multipart threshold via regular upload', async () => {
       const size = 2 * 1024 * 1024 // 2MB
       const binaryContent = new Uint8Array(size)
       // Fill with pattern for verification
@@ -327,6 +327,25 @@ describe('Sandbox Filesystem Operations', () => {
 
       const result = await sandbox.fs.read(path)
       expect(result.length).toBe(content.length)
+    })
+
+    it('uploads binary file above multipart threshold with multiple parts', async () => {
+      const size = 6 * 1024 * 1024 // 6MB
+      const binaryContent = new Uint8Array(size)
+      for (let i = 0; i < size; i++) {
+        binaryContent[i] = i % 251
+      }
+      const path = "/tmp/very-large-binary-upload.bin"
+
+      await sandbox.fs.writeBinary(path, binaryContent)
+
+      const blob = await sandbox.fs.readBinary(path)
+      const result = new Uint8Array(await blob.arrayBuffer())
+
+      expect(result.length).toBe(size)
+      expect(result[0]).toBe(0)
+      expect(result[251]).toBe(0)
+      expect(result[size - 1]).toBe((size - 1) % 251)
     })
   })
 

--- a/tests/manual/h2-reliability-coverage.md
+++ b/tests/manual/h2-reliability-coverage.md
@@ -1,0 +1,14 @@
+# HTTP/2 Reliability Coverage Matrix
+
+| Failure mode | Current protection | Current coverage | New coverage in this branch | Owner / next action |
+| --- | --- | --- | --- | --- |
+| Stale pooled H2 session reuse | `H2Pool` evicts on `close`, `error`, `goaway`, and idle ping failure | `tests/integration/common/h2fetch.test.ts` pool eviction tests | Covered by existing focused contract tests | SDK transport |
+| Post-flight H2 stream failure after request creation | Reject the in-flight request. Do not retry non-idempotent work through fetch | `h2RequestDirect` post-flight rejection tests | Existing tests remain the guardrail | SDK transport |
+| Active request `ref` / idle `unref` lifecycle | `h2ref` refs idle-unref sessions while a response body is active | Existing end and cancel tests | Added response-body error cleanup coverage | SDK transport |
+| Unsupported request body in direct H2 path | Preflight fallback to `globalThis.fetch` before opening an H2 stream | Direct `FormData` fallback test | Added pooled direct fallback test that preserves the pooled session | SDK transport |
+| User mitigation path | `BL_DISABLE_H2` / `settings.disableH2` bypasses H2 | No sandbox-action routing contract test | Added sandbox action test proving global fetch is used | SDK transport |
+| Multipart upload part failure | Abort multipart upload and preserve the original part error | No local unit contract | Added abort-on-part-failure unit test | SDK filesystem |
+| True multipart binary threshold | SDK threshold is `> 5MB` | Some integration test names used 1.2MB and 2MB payloads | Renamed below-threshold tests and added 6MB binary integration coverage | SDK filesystem |
+| Live H2-on / H2-off high-risk SDK paths | Manual local verification only | Ad hoc targeted tests | Added `tests/manual/h2-reliability-matrix.mjs` for process streaming, port fetch, filesystem multipart, interpreter | SDK transport / sandbox |
+| `waitForPorts` 502 at scale | Not yet classified as SDK, platform, proxy, or CloudFront | Hosted Integration Tests flake | Added `tests/manual/h2-waitforports-diagnostics.mjs` with per-sandbox H2-on/off results | Separate triage lane |
+| Framework regressions through user paths | Hosted canaries in `bl-test` | OpenAI Agents SDK JS/Python scheduled jobs | Add `@blaxel/core` version override and Mastra stream canary in `bl-test` | Framework canaries |

--- a/tests/manual/h2-reliability-matrix.mjs
+++ b/tests/manual/h2-reliability-matrix.mjs
@@ -1,0 +1,230 @@
+import { CodeInterpreter, SandboxInstance } from "../../@blaxel/core/dist/esm/index.js";
+import { h2Pool } from "../../@blaxel/core/dist/esm/common/h2pool.js";
+
+const originalDisableH2 = process.env.BL_DISABLE_H2;
+const region = process.env.BL_REGION || "us-was-1";
+const image = process.env.H2_MATRIX_IMAGE || "blaxel/base-image:latest";
+const labels = {
+  env: "manual-reliability",
+  issue: "eng-2547",
+  "created-by": "codex",
+};
+const modes = [
+  { name: "h2-on", disableH2: false },
+  { name: "h2-off", disableH2: true },
+];
+
+function log(phase, details = {}) {
+  console.log(JSON.stringify({ phase, ...details }));
+}
+
+function assertEnv() {
+  const missing = ["BL_API_KEY", "BL_WORKSPACE"].filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(", ")}`);
+  }
+}
+
+function setH2Mode(mode) {
+  h2Pool.closeAll();
+  if (mode.disableH2) {
+    process.env.BL_DISABLE_H2 = "true";
+  } else {
+    delete process.env.BL_DISABLE_H2;
+  }
+}
+
+function restoreH2Mode() {
+  h2Pool.closeAll();
+  if (originalDisableH2 === undefined) {
+    delete process.env.BL_DISABLE_H2;
+  } else {
+    process.env.BL_DISABLE_H2 = originalDisableH2;
+  }
+}
+
+async function withTimeout(label, ms, fn) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([fn(), timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function assertStatus(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function deleteByName(klass, name) {
+  try {
+    await klass.delete(name);
+  } catch {
+    // Best-effort cleanup for resources that may not have been created.
+  }
+}
+
+async function runProcessStreamingProbe(sandbox, mode) {
+  let streamed = "";
+  const result = await withTimeout(`${mode.name}:process-stream`, 60_000, () =>
+    sandbox.process.exec({
+      command: "node -e \"setTimeout(() => console.log('h2-matrix-process-ok'), 500)\"",
+      waitForCompletion: true,
+      timeout: 30,
+      onStdout: (line) => {
+        streamed += line;
+      },
+    }),
+  );
+
+  assertStatus(result.exitCode === 0, `${mode.name}: process exit ${result.exitCode}`);
+  assertStatus(
+    `${streamed}${result.stdout || ""}`.includes("h2-matrix-process-ok"),
+    `${mode.name}: process stdout marker missing`,
+  );
+  log("process-stream:ok", { mode: mode.name, exitCode: result.exitCode });
+}
+
+async function runPortFetchProbe(sandbox, mode) {
+  await withTimeout(`${mode.name}:wait-for-port`, 90_000, () =>
+    sandbox.process.exec({
+      name: `h2-matrix-server-${mode.name}`,
+      command: "python3 -m http.server 3000 --bind 0.0.0.0",
+      waitForPorts: [3000],
+      keepAlive: true,
+      timeout: 120,
+    }),
+  );
+
+  const response = await withTimeout(`${mode.name}:port-fetch`, 30_000, () =>
+    sandbox.fetch(3000),
+  );
+  const body = await response.text();
+  assertStatus(response.status === 200, `${mode.name}: port fetch status ${response.status}`);
+  assertStatus(body.length > 0, `${mode.name}: port fetch body missing`);
+  log("port-fetch:ok", { mode: mode.name, status: response.status, bytes: body.length });
+}
+
+async function runFilesystemProbe(sandbox, mode) {
+  const size = 6 * 1024 * 1024;
+  const content = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    content[i] = i % 251;
+  }
+
+  const path = `/tmp/h2-matrix-${mode.name}.bin`;
+  await withTimeout(`${mode.name}:filesystem-write`, 90_000, () =>
+    sandbox.fs.writeBinary(path, content),
+  );
+  const blob = await withTimeout(`${mode.name}:filesystem-read`, 60_000, () =>
+    sandbox.fs.readBinary(path),
+  );
+  const result = new Uint8Array(await blob.arrayBuffer());
+
+  assertStatus(result.length === size, `${mode.name}: binary length ${result.length}`);
+  assertStatus(result[0] === 0, `${mode.name}: first byte mismatch`);
+  assertStatus(result[251] === 0, `${mode.name}: middle byte mismatch`);
+  assertStatus(result[size - 1] === (size - 1) % 251, `${mode.name}: last byte mismatch`);
+  log("filesystem-binary:ok", { mode: mode.name, bytes: result.length });
+}
+
+async function runInterpreterProbe(mode) {
+  const name = `h2-matrix-interpreter-${mode.name}-${Date.now()}`;
+  let interpreter;
+
+  try {
+    log("interpreter:create:start", { mode: mode.name, name, region });
+    interpreter = await withTimeout(`${mode.name}:interpreter-create`, 180_000, () =>
+      CodeInterpreter.create({
+        name,
+        region,
+        memory: 2048,
+        labels,
+      }),
+    );
+    log("interpreter:create:ok", { mode: mode.name, name });
+
+    const execution = await withTimeout(`${mode.name}:interpreter-run`, 90_000, () =>
+      interpreter.runCode("print('h2-matrix-interpreter-ok')", { timeout: 60 }),
+    );
+    const stdout = execution.logs.stdout.join("");
+    assertStatus(
+      stdout.includes("h2-matrix-interpreter-ok"),
+      `${mode.name}: interpreter stdout marker missing`,
+    );
+    log("interpreter-run:ok", { mode: mode.name, stdout });
+  } finally {
+    log("interpreter:cleanup:start", { mode: mode.name, name });
+    if (interpreter) {
+      await interpreter.delete().catch(() => {});
+    }
+    await deleteByName(CodeInterpreter, name);
+    log("interpreter:cleanup:done", { mode: mode.name, name });
+  }
+}
+
+async function runMode(mode) {
+  const name = `h2-matrix-${mode.name}-${Date.now()}`;
+  let sandbox;
+  setH2Mode(mode);
+
+  try {
+    log("sandbox:create:start", { mode: mode.name, name, region, image });
+    sandbox = await withTimeout(`${mode.name}:sandbox-create`, 180_000, () =>
+      SandboxInstance.create({
+        name,
+        image,
+        region,
+        memory: 4096,
+        ports: [{ name: "http", target: 3000, protocol: "HTTP" }],
+        labels,
+      }),
+    );
+    log("sandbox:create:ok", { mode: mode.name, name, status: sandbox.status });
+
+    await runProcessStreamingProbe(sandbox, mode);
+    await runPortFetchProbe(sandbox, mode);
+    await runFilesystemProbe(sandbox, mode);
+    await runInterpreterProbe(mode);
+
+    return { mode: mode.name, ok: true };
+  } catch (error) {
+    log("mode:error", {
+      mode: mode.name,
+      name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { mode: mode.name, ok: false };
+  } finally {
+    log("sandbox:cleanup:start", { mode: mode.name, name });
+    if (sandbox) {
+      await sandbox.delete().catch(() => {});
+    }
+    await deleteByName(SandboxInstance, name);
+    h2Pool.closeAll();
+    log("sandbox:cleanup:done", { mode: mode.name, name });
+  }
+}
+
+try {
+  assertEnv();
+  const results = [];
+  for (const mode of modes) {
+    results.push(await runMode(mode));
+  }
+
+  log("summary", { results });
+  if (results.some((result) => !result.ok)) {
+    process.exitCode = 1;
+  }
+} finally {
+  restoreH2Mode();
+}

--- a/tests/manual/h2-waitforports-diagnostics.mjs
+++ b/tests/manual/h2-waitforports-diagnostics.mjs
@@ -1,0 +1,240 @@
+import { SandboxInstance } from "../../@blaxel/core/dist/esm/index.js";
+import { h2Pool } from "../../@blaxel/core/dist/esm/common/h2pool.js";
+
+const originalDisableH2 = process.env.BL_DISABLE_H2;
+const count = Number.parseInt(process.env.SANDBOX_COUNT || "5", 10);
+const region = process.env.BL_REGION || "us-was-1";
+const labels = {
+  env: "manual-reliability",
+  issue: "eng-2547-waitforports",
+  "created-by": "codex",
+};
+const modes = [
+  { name: "h2-on", disableH2: false },
+  { name: "h2-off", disableH2: true },
+];
+
+const nodeServerCommand = `sleep 2 && node -e "
+const http = require('http');
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('OK');
+});
+server.listen(3000);
+"`;
+
+const pythonServerCommand = `sleep 2 && python3 -c "
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'OK')
+    def log_message(self, *args):
+        pass
+
+HTTPServer(('', 3000), H).serve_forever()
+"`;
+
+function log(phase, details = {}) {
+  console.log(JSON.stringify({ phase, ...details }));
+}
+
+function assertEnv() {
+  const missing = ["BL_API_KEY", "BL_WORKSPACE"].filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(", ")}`);
+  }
+}
+
+function setH2Mode(mode) {
+  h2Pool.closeAll();
+  if (mode.disableH2) {
+    process.env.BL_DISABLE_H2 = "true";
+  } else {
+    delete process.env.BL_DISABLE_H2;
+  }
+}
+
+function restoreH2Mode() {
+  h2Pool.closeAll();
+  if (originalDisableH2 === undefined) {
+    delete process.env.BL_DISABLE_H2;
+  } else {
+    process.env.BL_DISABLE_H2 = originalDisableH2;
+  }
+}
+
+async function withTimeout(label, ms, fn) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([fn(), timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function cleanupSandbox(sandbox, name) {
+  if (sandbox) {
+    await sandbox.delete().catch(() => {});
+  }
+  await SandboxInstance.delete(name).catch(() => {});
+}
+
+function getProbeSpec(mode, index) {
+  const runtime = index % 2 === 0 ? "node" : "python";
+  const image = runtime === "node" ? "blaxel/node:latest" : "blaxel/py-app:latest";
+  const name = `h2-wfp-${mode.name}-${runtime}-${index}-${Date.now()}`;
+  return { index, name, runtime, image };
+}
+
+async function createProbeSandbox(mode, spec) {
+  try {
+    const instance = await withTimeout(`${mode.name}:${spec.name}:create`, 180_000, () =>
+      SandboxInstance.create({
+        name: spec.name,
+        image: spec.image,
+        region,
+        memory: 2048,
+        ports: [{ target: 3000, protocol: "HTTP" }],
+        labels,
+      }),
+    );
+
+    return { ...spec, instance, createError: null };
+  } catch (error) {
+    const createError = error instanceof Error ? error.message : String(error);
+    log("probe:create:error", {
+      mode: mode.name,
+      index: spec.index,
+      name: spec.name,
+      runtime: spec.runtime,
+      error: createError,
+    });
+    return { ...spec, instance: null, createError };
+  }
+}
+
+async function runProbe(mode, sandboxRecord) {
+  const { index, name, instance, runtime } = sandboxRecord;
+  const command = runtime === "node" ? nodeServerCommand : pythonServerCommand;
+  const result = {
+    mode: mode.name,
+    index,
+    name,
+    runtime,
+    execStatus: null,
+    fetchStatus: null,
+    body: null,
+    error: null,
+  };
+
+  try {
+    const execResult = await withTimeout(`${mode.name}:${name}:waitForPorts`, 120_000, () =>
+      instance.process.exec({
+        name: `server-${index}`,
+        command,
+        waitForPorts: [3000],
+      }),
+    );
+    result.execStatus = execResult.status || "started";
+
+    const response = await withTimeout(`${mode.name}:${name}:fetch`, 30_000, () =>
+      instance.fetch(3000),
+    );
+    result.fetchStatus = response.status;
+    result.body = await response.text();
+    if (response.status !== 200 || result.body !== "OK") {
+      throw new Error(`fetch returned ${response.status}: ${result.body}`);
+    }
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error);
+  }
+
+  log("probe:result", result);
+  return result;
+}
+
+async function runMode(mode) {
+  setH2Mode(mode);
+  const sandboxes = [];
+
+  try {
+    log("mode:create:start", { mode: mode.name, count, region });
+    const specs = Array.from({ length: count }, (_, index) => getProbeSpec(mode, index));
+    const created = await Promise.all(
+      specs.map((spec) => createProbeSandbox(mode, spec)),
+    );
+    sandboxes.push(...created);
+    const createFailures = sandboxes
+      .filter((sandboxRecord) => sandboxRecord.createError)
+      .map((sandboxRecord) => ({
+        mode: mode.name,
+        index: sandboxRecord.index,
+        name: sandboxRecord.name,
+        runtime: sandboxRecord.runtime,
+        execStatus: null,
+        fetchStatus: null,
+        body: null,
+        error: sandboxRecord.createError,
+      }));
+    const runnableSandboxes = sandboxes.filter((sandboxRecord) => sandboxRecord.instance);
+    log("mode:create:done", {
+      mode: mode.name,
+      count: sandboxes.length,
+      successes: runnableSandboxes.length,
+      failures: createFailures.length,
+    });
+
+    const results = await Promise.all(
+      runnableSandboxes.map((sandboxRecord) => runProbe(mode, sandboxRecord)),
+    );
+    const allResults = [...createFailures, ...results];
+    const failures = allResults.filter((result) => result.error);
+    log("mode:summary", {
+      mode: mode.name,
+      successes: allResults.length - failures.length,
+      failures: failures.length,
+      results: allResults,
+    });
+
+    return { mode: mode.name, results: allResults, failures };
+  } finally {
+    log("mode:cleanup:start", { mode: mode.name, count: sandboxes.length });
+    await Promise.allSettled(
+      sandboxes.map(({ instance, name }) => cleanupSandbox(instance, name)),
+    );
+    h2Pool.closeAll();
+    log("mode:cleanup:done", { mode: mode.name, count: sandboxes.length });
+  }
+}
+
+try {
+  assertEnv();
+  const summaries = [];
+  for (const mode of modes) {
+    summaries.push(await runMode(mode));
+  }
+
+  log("summary", {
+    summaries: summaries.map((summary) => ({
+      mode: summary.mode,
+      successes: summary.results.length - summary.failures.length,
+      failures: summary.failures.length,
+    })),
+  });
+
+  if (summaries.some((summary) => summary.failures.length > 0)) {
+    process.exitCode = 1;
+  }
+} finally {
+  restoreH2Mode();
+}

--- a/tests/unit/sandbox-filesystem-multipart.test.ts
+++ b/tests/unit/sandbox-filesystem-multipart.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type {
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadPartResponse,
+  SuccessResponse,
+} from "../../@blaxel/core/src/sandbox/client/index.js";
+import { SandboxFileSystem } from "../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+
+type MultipartUploadHarness = {
+  uploadWithMultipart(
+    path: string,
+    blob: Blob,
+    permissions?: string,
+  ): Promise<SuccessResponse>;
+  initiateMultipartUpload(
+    path: string,
+    permissions?: string,
+  ): Promise<MultipartInitiateResponse>;
+  uploadPart(
+    uploadId: string,
+    partNumber: number,
+    fileBlob: Blob,
+  ): Promise<MultipartUploadPartResponse>;
+  completeMultipartUpload(
+    uploadId: string,
+    parts: Array<MultipartPartInfo>,
+  ): Promise<SuccessResponse>;
+  abortMultipartUpload(uploadId: string): Promise<SuccessResponse>;
+};
+
+function createMultipartHarness(): MultipartUploadHarness {
+  return Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+}
+
+function waitForPartUpload(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 5);
+  });
+}
+
+describe("SandboxFileSystem multipart upload failure handling", () => {
+  it("aborts the multipart upload when a part upload fails", async () => {
+    const filesystem = createMultipartHarness();
+    const uploadedParts: number[] = [];
+    const abortedUploadIds: string[] = [];
+    let completeCalled = false;
+
+    filesystem.initiateMultipartUpload = () => {
+      return Promise.resolve({ uploadId: "upload-fail" });
+    };
+    filesystem.uploadPart = async (_uploadId, partNumber) => {
+      await waitForPartUpload();
+      uploadedParts.push(partNumber);
+      if (partNumber === 2) {
+        throw new Error("part 2 failed");
+      }
+      return { partNumber, etag: `etag-${partNumber}` };
+    };
+    filesystem.completeMultipartUpload = () => {
+      completeCalled = true;
+      return Promise.resolve({ message: "completed" });
+    };
+    filesystem.abortMultipartUpload = (uploadId) => {
+      abortedUploadIds.push(uploadId);
+      return Promise.resolve({ message: "aborted" });
+    };
+
+    const blob = new Blob([new Uint8Array(11 * 1024 * 1024)]);
+
+    await expect(
+      filesystem.uploadWithMultipart("/tmp/large-file.bin", blob),
+    ).rejects.toThrow("part 2 failed");
+
+    expect(abortedUploadIds).toEqual(["upload-fail"]);
+    expect(completeCalled).toBe(false);
+    expect(uploadedParts).toContain(2);
+  });
+});


### PR DESCRIPTION
Summary
- Add focused HTTP/2 transport coverage for response-body error cleanup, pooled preflight fallback, and `BL_DISABLE_H2` sandbox-action routing.
- Add multipart failure coverage for abort-on-part-failure, plus true >5 MB binary multipart integration coverage.
- Add manual H2-on/H2-off matrix and `waitForPorts` diagnostics scripts with cleanup checks.

Evidence
- Rebased on main after PR #307 merged at `938f9c6`.
- `cd @blaxel/core && npm run build` passed.
- `cd @blaxel/core && npm test -- --reporter=verbose` passed, 76 passed / 3 skipped.
- `npx vitest run tests/integration/common/h2fetch.test.ts tests/unit/sandbox-filesystem-multipart.test.ts --reporter=verbose --pool=threads --poolOptions.threads.minThreads=1 --poolOptions.threads.maxThreads=1` passed, 31/31.
- Live binary multipart row passed above the real SDK threshold: `tests/integration/sandbox/filesystem.test.ts -t "uploads binary file above multipart threshold with multiple parts"`.
- Live H2 matrix passed H2-on and H2-off for process streaming, port fetch, 6 MB binary multipart, and interpreter.
- Live `waitForPorts` diagnostics passed 5/5 H2-on and 5/5 H2-off with 200/OK.
- Cleanup audit found no leftover `h2-matrix`, `h2-wfp`, or manual-reliability interpreter resources.
- Hosted TS SDK run 26131676451 passed Mendral, Integration Tests, and the full runtime matrix across browser, Bun, Cloudflare Workers, Deno, Node, Vercel, and Webpack.

Notes
- No public SDK API changes.
- This PR remains separate from PR #307; it adds coverage and diagnostics only.
- The `waitForPorts` diagnostic script now records partial create failures and still cleans up by known sandbox name.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds focused HTTP/2 transport test coverage: response-body error cleanup, pooled preflight fallback, and `BL_DISABLE_H2` sandbox-action routing. Also adds a multipart abort-on-part-failure unit test, renames below-threshold filesystem tests, adds a 6 MB binary integration test, and two manual H2-on/H2-off diagnostic scripts.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 90be0fc5e28bac8a8137628b95678da40f727499.</sup>
<!-- /MENDRAL_SUMMARY -->
