### PR TITLE
Add integration tests for proxy CONNECT tunnel support and HTTP/2 fun…

### DIFF
--- a/tests/integration/sandbox/proxy/connect-tunnel.test.ts
+++ b/tests/integration/sandbox/proxy/connect-tunnel.test.ts
@@ -114,14 +114,22 @@ except urllib3.exceptions.HTTPError as e:
 
     it('HTTP_PROXY and HTTPS_PROXY env vars are set in sandbox', async () => {
       const result = await sandbox.process.exec({
-        command: 'echo "HTTPS_PROXY=${HTTPS_PROXY}"; echo "HTTP_PROXY=${HTTP_PROXY}"; echo "SSL_CERT_FILE=${SSL_CERT_FILE}"',
+        command: [
+          'test -n "$HTTPS_PROXY" && echo "HTTPS_PROXY_SET=1"',
+          'case "$HTTPS_PROXY" in https://*) echo "HTTPS_PROXY_SCHEME=https" ;; esac',
+          'test -n "$HTTP_PROXY" && echo "HTTP_PROXY_SET=1"',
+          'case "$HTTP_PROXY" in https://*) echo "HTTP_PROXY_SCHEME=https" ;; esac',
+          'test -n "$SSL_CERT_FILE" && test -f "$SSL_CERT_FILE" && echo "SSL_CERT_FILE_SET=1"',
+        ].join(' ; '),
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)
       const out = result.logs || ""
-      expect(out, `proxy env vars missing in sandbox:\n${out}`).toMatch(/HTTPS_PROXY=https:\/\/\S+/)
-      expect(out).toMatch(/HTTP_PROXY=https:\/\/\S+/)
-      expect(out).toMatch(/SSL_CERT_FILE=\/\S+/)
+      expect(out).toContain("HTTPS_PROXY_SET=1")
+      expect(out).toContain("HTTPS_PROXY_SCHEME=https")
+      expect(out).toContain("HTTP_PROXY_SET=1")
+      expect(out).toContain("HTTP_PROXY_SCHEME=https")
+      expect(out).toContain("SSL_CERT_FILE_SET=1")
     }, 30_000)
 
     it('installs a package from PyPI using HTTPS_PROXY only', async () => {
@@ -197,7 +205,7 @@ except urllib3.exceptions.HTTPError as e:
         'export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa-key.json',
         // No --client-protocol=http1 here: gcsfuse will default to HTTP/2 over
         // the proxy's CONNECT tunnel, exercising end-to-end h2 ALPN through MITM.
-        `gcsfuse --foreground=false --debug_fuse --debug_gcs --log-severity=trace ${bucket} /mnt/gcs`,
+        `gcsfuse --foreground=false --log-severity=warning ${bucket} /mnt/gcs`,
         'sleep 2',
         // List bucket root and verify mountpoint is live.
         'ls -la /mnt/gcs | head -20',
@@ -210,7 +218,7 @@ except urllib3.exceptions.HTTPError as e:
         command: mountCmd + ' 2>&1',
         waitForCompletion: true,
       })
-      expect(result.exitCode, `gcsfuse without --client-protocol=http1 failed. logs=${result.logs?.slice(0, 3000)}`).toBe(0)
+      expect(result.exitCode, `gcsfuse without --client-protocol=http1 failed with exitCode=${result.exitCode}`).toBe(0)
       expect(result.logs || '').toContain('is a mountpoint')
     }, 300_000)
   })

--- a/tests/integration/sandbox/proxy/connect-tunnel.test.ts
+++ b/tests/integration/sandbox/proxy/connect-tunnel.test.ts
@@ -1,0 +1,217 @@
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { execProxyCommandWithRetry, parseJsonOutput, proxyCleanup } from './helpers.js'
+
+type PythonProxyOutput = {
+  status: number
+  body: string
+  error?: string
+}
+
+/**
+ * CONNECT tunnel coverage:
+ *  - Python `urllib3` request to `https://storage.googleapis.com/...`
+ *    over CONNECT with ProxyTarget `Authorization: Bearer <token>` injection.
+ *  - `pip install` over CONNECT (pip uses its own HTTPS stack against pypi.org).
+ *  - `gcsfuse` against a real GCS bucket WITHOUT `--client-protocol=http1`, which
+ *    forces the Go GCS client to use HTTP/2 over the CONNECT tunnel. Only runs when
+ *    `BL_TEST_GCS_BUCKET` + `GCSFUSE_SA_KEY_JSON` are provided.
+ */
+describe('proxy CONNECT tunnel support', () => {
+  const unsetHttpProxyEnv = 'env -u HTTP_PROXY -u http_proxy'
+
+  describe('Python urllib3 through CONNECT', () => {
+    const createdSandboxes: string[] = []
+    afterAll(proxyCleanup(createdSandboxes))
+
+    let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+    const urllib3HelperScript = `
+import os, sys, json, urllib.parse, urllib3
+method = sys.argv[1] if len(sys.argv) > 1 else "GET"
+url = sys.argv[2] if len(sys.argv) > 2 else "https://storage.googleapis.com/storage/v1/b/blaxel-sdk-nonexistent-bucket-for-test/o"
+headers = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+body = sys.argv[4].encode() if len(sys.argv) > 4 else None
+try:
+    proxy_url = os.environ["HTTPS_PROXY"]
+    proxy_auth = urllib.parse.unquote(urllib.parse.urlsplit(proxy_url).netloc.rsplit("@", 1)[0])
+    http = urllib3.ProxyManager(
+        proxy_url,
+        proxy_headers=urllib3.make_headers(proxy_basic_auth=proxy_auth),
+        cert_reqs="CERT_REQUIRED",
+        ca_certs=os.environ.get("SSL_CERT_FILE"),
+    )
+    resp = http.request(method, url, body=body, headers=headers, timeout=urllib3.Timeout(connect=10, read=30), retries=False)
+    print(json.dumps({"status": resp.status, "body": resp.data.decode("utf-8", errors="replace")}))
+except urllib3.exceptions.HTTPError as e:
+    print(json.dumps({"status": 0, "body": str(e), "error": e.__class__.__name__}))
+`.trim()
+
+    beforeAll(async () => {
+      const name = uniqueName("proxy-urllib")
+      sandbox = await SandboxInstance.create({
+        name, image: "blaxel/py-app:latest", region: defaultRegion, labels: defaultLabels,
+        network: {
+          proxy: {
+            routing: [
+              {
+                destinations: ["storage.googleapis.com"],
+                headers: { "Authorization": "Bearer {{SECRET:gcp-token}}" },
+                secrets: { "gcp-token": "fake-bearer-token-for-connect-test-42" },
+              },
+              {
+                destinations: ["pypi.org", "files.pythonhosted.org"],
+              },
+            ],
+          },
+        },
+      })
+      createdSandboxes.push(name)
+      const install = await sandbox.process.exec({
+        command: `${unsetHttpProxyEnv} pip install --break-system-packages --quiet --no-cache-dir urllib3 2>&1`,
+        waitForCompletion: true,
+      })
+      expect(install.exitCode, install.logs).toBe(0)
+      await sandbox.fs.write("/tmp/urllib3-test.py", urllib3HelperScript)
+    }, 120_000)
+
+    it('urllib3 reaches GCS through CONNECT with proxy-injected Authorization', async () => {
+      const result = await execProxyCommandWithRetry(
+        sandbox,
+        `${unsetHttpProxyEnv} python3 /tmp/urllib3-test.py GET https://storage.googleapis.com/storage/v1/b/blaxel-sdk-nonexistent-bucket-for-test/o 2>&1`,
+        { retries: 0, delayMs: 3000 },
+      )
+      expect(result.exitCode, result.logs).toBe(0)
+      const out = parseJsonOutput(result.logs) as PythonProxyOutput
+      // The fake bearer token should be injected by the proxy and rejected by GCS.
+      expect([401, 403], `expected auth-related 4xx from GCS, got ${out.status}: ${out.body?.slice(0, 300)}`).toContain(out.status)
+      expect(out.body.toLowerCase()).toMatch(/auth|credential|permission|forbidden|invalid/)
+    }, 90_000)
+  })
+
+  describe('pip install through CONNECT', () => {
+    const createdSandboxes: string[] = []
+    afterAll(proxyCleanup(createdSandboxes))
+
+    let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+    beforeAll(async () => {
+      const name = uniqueName("proxy-pip-ct")
+      sandbox = await SandboxInstance.create({
+        name, image: "blaxel/py-app:latest", region: defaultRegion, labels: defaultLabels,
+        network: {
+          proxy: {
+            // Global rule (no header/body injection) -- enables the proxy and lets pip
+            // CONNECT to pypi.org + files.pythonhosted.org. `routing: []` alone does NOT
+            // enable the proxy (HTTPS_PROXY env var is not set in that case).
+            routing: [{ destinations: ["*"] }],
+          },
+        },
+      })
+      createdSandboxes.push(name)
+    }, 120_000)
+
+    it('HTTP_PROXY and HTTPS_PROXY env vars are set in sandbox', async () => {
+      const result = await sandbox.process.exec({
+        command: 'echo "HTTPS_PROXY=${HTTPS_PROXY}"; echo "HTTP_PROXY=${HTTP_PROXY}"; echo "SSL_CERT_FILE=${SSL_CERT_FILE}"',
+        waitForCompletion: true,
+      })
+      expect(result.exitCode).toBe(0)
+      const out = result.logs || ""
+      expect(out, `proxy env vars missing in sandbox:\n${out}`).toMatch(/HTTPS_PROXY=https:\/\/\S+/)
+      expect(out).toMatch(/HTTP_PROXY=https:\/\/\S+/)
+      expect(out).toMatch(/SSL_CERT_FILE=\/\S+/)
+    }, 30_000)
+
+    it('installs a package from PyPI using HTTPS_PROXY only', async () => {
+      // No --proxy flag: pip/urllib3 should pick up HTTPS_PROXY for HTTPS URLs.
+      const result = await execProxyCommandWithRetry(
+        sandbox,
+        `${unsetHttpProxyEnv} pip install --break-system-packages --quiet --no-cache-dir idna 2>&1 && pip show idna 2>&1 | grep -E "^Version:"`,
+        { retries: 5, delayMs: 3000 },
+      )
+      expect(result.exitCode, result.logs).toBe(0)
+      expect(result.logs?.trim()).toMatch(/Version:\s+\d+\.\d+/)
+    }, 240_000)
+  })
+
+  describe('gcsfuse with native HTTP/2 (no --client-protocol=http1)', () => {
+    const bucket = process.env.BL_TEST_GCS_BUCKET
+    const saKeyJson = process.env.GCSFUSE_SA_KEY_JSON
+
+    if (!bucket || !saKeyJson) {
+      it.skip('requires BL_TEST_GCS_BUCKET + GCSFUSE_SA_KEY_JSON env vars', () => {})
+      return
+    }
+
+    const createdSandboxes: string[] = []
+    afterAll(proxyCleanup(createdSandboxes))
+
+    let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+    beforeAll(async () => {
+      const name = uniqueName("proxy-gcsfuse")
+      sandbox = await SandboxInstance.create({
+        name, image: "blaxel/py-app:latest", region: defaultRegion, labels: defaultLabels,
+        network: {
+          proxy: {
+            routing: [{
+              destinations: ["storage.googleapis.com", "*.googleapis.com", "oauth2.googleapis.com"],
+            }],
+          },
+        },
+      })
+      createdSandboxes.push(name)
+
+      // Stage the service account key inside the sandbox.
+      await sandbox.fs.write("/tmp/sa-key.json", saKeyJson)
+
+      // Best-effort gcsfuse install. The official .deb works on Debian/Ubuntu bases.
+      // We fall back to apt-based install if the image supports it; the test fails
+      // loudly if the binary is unavailable so the user knows to bring their own image.
+      const install = await sandbox.process.exec({
+        command: [
+          'set -e',
+          'export DEBIAN_FRONTEND=noninteractive',
+          '(command -v gcsfuse && gcsfuse --version) || (',
+          '  apt-get update -qq && apt-get install -y --no-install-recommends curl ca-certificates fuse3 lsb-release gnupg 2>&1 || true ;',
+          '  export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s 2>/dev/null || echo bookworm) ;',
+          '  echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" > /etc/apt/sources.list.d/gcsfuse.list ;',
+          '  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - 2>/dev/null || true ;',
+          '  apt-get update -qq && apt-get install -y --no-install-recommends gcsfuse',
+          ')',
+          'gcsfuse --version',
+        ].join(' ; ') + ' 2>&1',
+        waitForCompletion: true,
+      })
+      if (install.exitCode !== 0) {
+        throw new Error(`gcsfuse install failed (try a Debian-based image with FUSE access). exitCode=${install.exitCode}; logs=${install.logs?.slice(0, 1500)}`)
+      }
+    }, 600_000)
+
+    it('mounts a GCS bucket through the proxy CONNECT tunnel using HTTP/2', async () => {
+      const mountCmd = [
+        'set -e',
+        'mkdir -p /mnt/gcs',
+        'export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa-key.json',
+        // No --client-protocol=http1 here: gcsfuse will default to HTTP/2 over
+        // the proxy's CONNECT tunnel, exercising end-to-end h2 ALPN through MITM.
+        `gcsfuse --foreground=false --debug_fuse --debug_gcs --log-severity=trace ${bucket} /mnt/gcs`,
+        'sleep 2',
+        // List bucket root and verify mountpoint is live.
+        'ls -la /mnt/gcs | head -20',
+        'mountpoint /mnt/gcs',
+        // Clean up.
+        '(fusermount3 -u /mnt/gcs || fusermount -u /mnt/gcs || umount /mnt/gcs) 2>&1 || true',
+      ].join(' && ')
+
+      const result = await sandbox.process.exec({
+        command: mountCmd + ' 2>&1',
+        waitForCompletion: true,
+      })
+      expect(result.exitCode, `gcsfuse without --client-protocol=http1 failed. logs=${result.logs?.slice(0, 3000)}`).toBe(0)
+      expect(result.logs || '').toContain('is a mountpoint')
+    }, 300_000)
+  })
+})

--- a/tests/integration/sandbox/proxy/http2.test.ts
+++ b/tests/integration/sandbox/proxy/http2.test.ts
@@ -1,0 +1,206 @@
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
+
+type HttpBinResponse = {
+  headers: Record<string, string>
+  json?: Record<string, unknown>
+}
+
+type Http2Output = {
+  alpnProtocol: string
+  status: number
+  body: string
+}
+
+/**
+ * Node helper that performs an HTTP/2 request, optionally tunneling through
+ * the sandbox-injected HTTPS proxy via CONNECT + TLS ALPN negotiation.
+ *
+ * Usage: node /tmp/proxy-test-h2.js <method> <url> [headersJson] [body]
+ * Stdout: single JSON object {alpnProtocol, status, body}
+ */
+const http2HelperScript = `
+const http2 = require("http2");
+const tls = require("tls");
+const net = require("net");
+
+const method = process.argv[2] || "GET";
+const targetUrl = process.argv[3] || "https://httpbin.org/headers";
+const extraHeaders = process.argv[4] ? JSON.parse(process.argv[4]) : {};
+const bodyData = process.argv[5] || null;
+const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
+                 process.env.HTTP_PROXY || process.env.http_proxy;
+const target = new URL(targetUrl);
+
+function fireH2(tlsSocket) {
+  const negotiated = tlsSocket.alpnProtocol || "";
+  if (negotiated !== "h2") {
+    process.stdout.write(JSON.stringify({ alpnProtocol: negotiated || "(none)", status: 0, body: "" }));
+    try { tlsSocket.destroy(); } catch (_) {}
+    process.exit(0);
+  }
+  const client = http2.connect("https://" + target.hostname, {
+    createConnection: () => tlsSocket,
+  });
+  client.on("error", (e) => { process.stderr.write("H2 ERR: " + e.message + "\\n"); process.exit(1); });
+
+  const reqHeaders = {
+    ":method": method,
+    ":path": target.pathname + target.search,
+    ":scheme": "https",
+    ":authority": target.hostname,
+  };
+  for (const k of Object.keys(extraHeaders)) reqHeaders[k.toLowerCase()] = extraHeaders[k];
+  if (bodyData) {
+    reqHeaders["content-type"] = "application/json";
+    reqHeaders["content-length"] = Buffer.byteLength(bodyData);
+  }
+
+  const req = client.request(reqHeaders);
+  let status = 0;
+  req.on("response", (h) => { status = parseInt(h[":status"]); });
+  let body = "";
+  req.setEncoding("utf8");
+  req.on("data", (chunk) => { body += chunk; });
+  req.on("end", () => {
+    process.stdout.write(JSON.stringify({ alpnProtocol: negotiated, status, body }));
+    try { client.close(); } catch (_) {}
+    process.exit(0);
+  });
+  req.on("error", (e) => { process.stderr.write("H2 REQ ERR: " + e.message + "\\n"); process.exit(1); });
+
+  if (bodyData) req.write(bodyData);
+  req.end();
+}
+
+function viaProxy() {
+  const p = new URL(proxyUrl);
+  const port = parseInt(p.port) || (p.protocol === "https:" ? 443 : 3128);
+  const auth = (p.username || p.password)
+    ? "Proxy-Authorization: Basic " +
+      Buffer.from(decodeURIComponent(p.username||"") + ":" + decodeURIComponent(p.password||"")).toString("base64") + "\\r\\n"
+    : "";
+  const connectMsg = "CONNECT " + target.hostname + ":443 HTTP/1.1\\r\\n" +
+    "Host: " + target.hostname + ":443\\r\\n" + auth + "\\r\\n";
+
+  function onProxySocket(proxySock) {
+    let buf = "";
+    proxySock.on("data", function h(chunk) {
+      buf += chunk.toString();
+      if (buf.indexOf("\\r\\n\\r\\n") < 0) return;
+      proxySock.removeListener("data", h);
+      const code = parseInt(buf.split(" ")[1]);
+      if (code !== 200) {
+        process.stderr.write("CONNECT " + code + "\\n");
+        process.exit(1);
+      }
+      const tlsSocket = tls.connect({
+        socket: proxySock,
+        servername: target.hostname,
+        ALPNProtocols: ["h2", "http/1.1"],
+      }, () => fireH2(tlsSocket));
+      tlsSocket.on("error", (e) => { process.stderr.write("INNER TLS: " + e.message + "\\n"); process.exit(1); });
+    });
+    proxySock.write(connectMsg);
+  }
+
+  const timeout = setTimeout(() => { process.stderr.write("PROXY TIMEOUT\\n"); process.exit(1); }, 20000);
+  if (p.protocol === "https:") {
+    const s = tls.connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onProxySocket(s); });
+    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TLS: " + e.message + "\\n"); process.exit(1); });
+  } else {
+    const s = net.connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onProxySocket(s); });
+    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TCP: " + e.message + "\\n"); process.exit(1); });
+  }
+}
+
+if (!proxyUrl) {
+  const tlsSocket = tls.connect({
+    host: target.hostname,
+    port: 443,
+    servername: target.hostname,
+    ALPNProtocols: ["h2", "http/1.1"],
+  }, () => fireH2(tlsSocket));
+  tlsSocket.on("error", (e) => { process.stderr.write("DIRECT TLS: " + e.message + "\\n"); process.exit(1); });
+} else {
+  viaProxy();
+}
+`.trim()
+
+describe('proxy end-to-end functionality over HTTP/2', () => {
+  const createdSandboxes: string[] = []
+  afterAll(proxyCleanup(createdSandboxes))
+
+  let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+  beforeAll(async () => {
+    sandbox = await createReadyProxySandbox(
+      async () => {
+        const name = uniqueName("proxy-h2")
+        const sandbox = await SandboxInstance.create({
+          name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
+          network: {
+            proxy: {
+              routing: [{
+                destinations: ["httpbin.org"],
+                headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}" },
+                body: { "injected_field": "body-injected", "secret_body": "{{SECRET:test-api-key}}" },
+                secrets: { "test-api-key": "resolved-secret-42" },
+              }],
+            },
+          },
+        })
+        return { name, sandbox }
+      },
+      createdSandboxes,
+      'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+      (result) => {
+        if (result.exitCode !== 0) return false
+        const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
+        return headers["x-proxy-test"] === "header-injected" && headers["x-api-key"] === "resolved-secret-42"
+      },
+    )
+    await sandbox.fs.write("/tmp/proxy-test-h2.js", http2HelperScript)
+  }, 180_000)
+
+  it('negotiates h2 ALPN and routes HTTP/2 GET through the proxy with header injection', async () => {
+    const result = await execProxyCommandWithRetry(sandbox, 'node /tmp/proxy-test-h2.js GET https://httpbin.org/headers')
+    expect(result.exitCode, result.logs).toBe(0)
+    const out = parseJsonObjectOutput<Http2Output>(result.logs)
+    expect(out.alpnProtocol, `expected ALPN h2, got "${out.alpnProtocol}"`).toBe("h2")
+    expect(out.status).toBe(200)
+    const httpbin = JSON.parse(out.body) as HttpBinResponse
+    const headers = lowercaseKeys(httpbin.headers)
+    expect(headers["x-blaxel-request-id"]).toBeDefined()
+    expect(headers["x-proxy-test"]).toBe("header-injected")
+    expect(headers["x-api-key"]).toBe("resolved-secret-42")
+  }, 60_000)
+
+  it('routes HTTP/2 POST through the proxy with body injection', async () => {
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js POST https://httpbin.org/post '{}' '{"user_data":"from-h2"}'`)
+    expect(result.exitCode, result.logs).toBe(0)
+    const out = parseJsonObjectOutput<Http2Output>(result.logs)
+    expect(out.alpnProtocol).toBe("h2")
+    expect(out.status).toBe(200)
+    const httpbin = JSON.parse(out.body) as HttpBinResponse
+    expect(httpbin.json?.user_data).toBe("from-h2")
+    expect(httpbin.json?.injected_field).toBe("body-injected")
+    expect(httpbin.json?.secret_body).toBe("resolved-secret-42")
+    const headers = lowercaseKeys(httpbin.headers)
+    expect(headers["x-proxy-test"]).toBe("header-injected")
+    expect(headers["x-api-key"]).toBe("resolved-secret-42")
+  }, 60_000)
+
+  it('preserves user-sent headers over HTTP/2 through the proxy', async () => {
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js GET https://httpbin.org/headers '{"X-User-Custom":"from-h2-client"}'`)
+    expect(result.exitCode, result.logs).toBe(0)
+    const out = parseJsonObjectOutput<Http2Output>(result.logs)
+    expect(out.alpnProtocol).toBe("h2")
+    const httpbin = JSON.parse(out.body) as HttpBinResponse
+    const headers = lowercaseKeys(httpbin.headers)
+    expect(headers["x-user-custom"]).toBe("from-h2-client")
+    expect(headers["x-proxy-test"]).toBe("header-injected")
+  }, 60_000)
+})


### PR DESCRIPTION
…ctionality

- Introduced tests for Python `urllib3` and `pip install` through a CONNECT tunnel, verifying proxy-injected Authorization headers and environment variable settings.
- Added HTTP/2 request tests to ensure proper routing and header/body injection through the proxy.
- Enhanced coverage for sandbox operations involving proxy configurations, ensuring reliability and correctness in various scenarios.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds integration tests for proxy CONNECT tunnel support (Python urllib3, pip install, gcsfuse/HTTP2) and HTTP/2 end-to-end proxy functionality with header/body injection and ALPN negotiation.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 12cbe337e1662196bcf32440f082144881ae5017.</sup>
<!-- /MENDRAL_SUMMARY -->