### PR TITLE
feat(sandbox): opt-in H2 concurrency cap and multipart part-retry for concurrent upload resets

### DIFF
--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -1,4 +1,5 @@
 import http2 from "http2";
+import { settings } from "./settings.js";
 import type { H2Pool } from "./h2pool.js";
 import { refH2SessionForActiveRequest } from "./h2ref.js";
 
@@ -8,6 +9,83 @@ type H2SendOptions = {
 
 const MIN_H2_SESSION_MAX_LISTENERS = 64;
 const sessionsWithListenerBudget = new WeakSet<http2.ClientHttp2Session>();
+
+/**
+ * Per-domain async semaphore that bounds the number of in-flight HTTP/2
+ * requests against a single edge domain (one H2 session). The cap is keyed
+ * by domain so throttling one sandbox's uploads never blocks requests to an
+ * unrelated sandbox served by a different edge.
+ *
+ * When `settings.maxConcurrentH2Requests` is `0`/unset the gate is a no-op
+ * (current default behavior: unlimited concurrency).
+ */
+
+// Safety timeout for a held slot. A request that never resolves (no response,
+// no error, no abort) would otherwise hold its slot forever and starve every
+// queued request for the same domain. After this window we release the slot
+// and let the underlying request continue or reject on its own; we never
+// cancel the in-flight request here, we only stop it from blocking the queue.
+// Kept deliberately conservative (well above any realistic part-upload time)
+// so it does not interfere with legitimately slow but healthy requests.
+const H2_SLOT_TIMEOUT_MS = 120_000;
+
+type H2DomainGate = {
+  active: number;
+  queue: Array<() => void>;
+};
+
+const h2GatesByDomain = new Map<string, H2DomainGate>();
+
+function getH2Gate(domain: string): H2DomainGate {
+  let gate = h2GatesByDomain.get(domain);
+  if (!gate) {
+    gate = { active: 0, queue: [] };
+    h2GatesByDomain.set(domain, gate);
+  }
+  return gate;
+}
+
+/**
+ * Acquire an in-flight slot for `domain`. Resolves with a release function
+ * that is idempotent and FIFO-fair: releasing wakes the longest-waiting
+ * queued caller for the same domain. A safety timer also releases the slot
+ * if the caller never does, preventing per-domain starvation.
+ */
+async function acquireH2Slot(domain: string): Promise<() => void> {
+  const max = settings.maxConcurrentH2Requests; // 0/undefined = unlimited
+  if (!max || max <= 0) return () => {};
+
+  const gate = getH2Gate(domain);
+  while (gate.active >= max) {
+    await new Promise<void>((resolve) => gate.queue.push(resolve));
+  }
+  gate.active++;
+
+  let released = false;
+  // Holder so `release` can clear the safety timer that is created after it.
+  const timer: { handle?: ReturnType<typeof setTimeout> } = {};
+  const release = () => {
+    if (released) return;
+    released = true;
+    if (timer.handle !== undefined) clearTimeout(timer.handle);
+    gate.active--;
+    const next = gate.queue.shift();
+    if (next) {
+      next();
+    } else if (gate.active === 0 && gate.queue.length === 0) {
+      // No active requests and nothing waiting: drop the empty gate so the
+      // Map does not grow unbounded across many short-lived domains.
+      h2GatesByDomain.delete(domain);
+    }
+  };
+
+  timer.handle = setTimeout(release, H2_SLOT_TIMEOUT_MS);
+  // unref() so a pending safety timer never keeps the process alive. Guarded
+  // because not every runtime's timer handle exposes unref().
+  (timer.handle as unknown as { unref?: () => void }).unref?.();
+
+  return release;
+}
 
 /**
  * Creates a fetch()-compatible function that sends requests over an existing
@@ -40,11 +118,44 @@ export function createPoolBackedH2Fetch(
   domain: string,
 ): (input: Request) => Promise<Response> {
   return async (input: Request): Promise<Response> => {
+    const rel = await acquireH2Slot(domain);
+    try {
+      const session = await pool.get(domain);
+      if (session) {
+        let h2RequestCreated = false;
+        try {
+          return await _h2Request(session, input, {
+            onH2RequestCreated: () => {
+              h2RequestCreated = true;
+            },
+          });
+        } catch (err) {
+          if (h2RequestCreated) {
+            pool.evictSession(domain, session);
+          }
+          throw err;
+        }
+      }
+      return await globalThis.fetch(input);
+    } finally {
+      rel();
+    }
+  };
+}
+
+export async function h2RequestDirectFromPool(
+  pool: H2Pool,
+  domain: string,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const rel = await acquireH2Slot(domain);
+  try {
     const session = await pool.get(domain);
     if (session) {
       let h2RequestCreated = false;
       try {
-        return await _h2Request(session, input, {
+        return await h2RequestDirectInternal(session, url, init, {
           onH2RequestCreated: () => {
             h2RequestCreated = true;
           },
@@ -56,33 +167,10 @@ export function createPoolBackedH2Fetch(
         throw err;
       }
     }
-    return globalThis.fetch(input);
-  };
-}
-
-export async function h2RequestDirectFromPool(
-  pool: H2Pool,
-  domain: string,
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const session = await pool.get(domain);
-  if (session) {
-    let h2RequestCreated = false;
-    try {
-      return await h2RequestDirectInternal(session, url, init, {
-        onH2RequestCreated: () => {
-          h2RequestCreated = true;
-        },
-      });
-    } catch (err) {
-      if (h2RequestCreated) {
-        pool.evictSession(domain, session);
-      }
-      throw err;
-    }
+    return await globalThis.fetch(url, init);
+  } finally {
+    rel();
   }
-  return globalThis.fetch(url, init);
 }
 
 /**

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -21,6 +21,16 @@ export type Config = {
   workspace?: string;
   disableH2?: boolean;
   /**
+   * Maximum number of concurrent in-flight HTTP/2 requests across the shared
+   * H2 session pool. `0` or `undefined` means unlimited (current behavior).
+   */
+  maxConcurrentH2Requests?: number;
+  /**
+   * Number of retry attempts for transient resets on multipart part uploads.
+   * `0` or `undefined` disables retry (current behavior).
+   */
+  fsPartRetries?: number;
+  /**
    * Client credentials for OAuth2 client_credentials flow.
    *
    * Accepts either:
@@ -291,6 +301,34 @@ class Settings {
       return ["1", "true", "yes", "on"].includes(value.toLowerCase());
     }
     return isDenoRuntime();
+  }
+
+  get maxConcurrentH2Requests(): number {
+    if (typeof this.config.maxConcurrentH2Requests === "number") {
+      return this.config.maxConcurrentH2Requests;
+    }
+    const value = env.BL_MAX_H2_INFLIGHT;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
+  }
+
+  get fsPartRetries(): number {
+    if (typeof this.config.fsPartRetries === "number") {
+      return this.config.fsPartRetries;
+    }
+    const value = env.BL_FS_PART_RETRIES;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
   }
 
   async authenticate() {

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -11,6 +11,105 @@ const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB
 const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB per part
 const MAX_PARALLEL_UPLOADS = 3; // Number of parallel part uploads
 
+// Base backoff between part-upload retries, in milliseconds. Grows linearly
+// per attempt and is jittered to avoid synchronized retries (thundering herd)
+// when several parallel parts fail against the same edge at the same time.
+const RETRY_BASE_DELAY_MS = 200;
+
+// Markers that, when present anywhere in the error chain, are unambiguous
+// signals of a transient HTTP/2 stream reset or connection drop. These are
+// protocol/transport level codes, not application payloads, so substring
+// matching them does not over-match a server-sent error body. Each entry is
+// matched case-sensitively against the error message and its cause.
+//
+// Deliberately excluded: bare "INTERNAL_ERROR" and "fetch failed". Both are
+// too generic on their own (an application 500 body or any failed fetch would
+// match), so we only treat them as transient when paired with a transport
+// error code on the cause (see isTransientUploadError).
+const TRANSIENT_RESET_MARKERS = [
+  "ENHANCE_YOUR_CALM", // H2 flow-control backpressure reset
+  "NGHTTP2_INTERNAL_ERROR", // H2 internal stream error (qualified form)
+  "ERR_HTTP2", // node http2 error code family
+  "GOAWAY", // peer is draining the connection
+  "HTTP/2 session closed before response", // thrown by our own h2 transport
+  "HTTP/2 session sent GOAWAY before response",
+];
+
+// Node-level error codes (from `error.code` / `error.cause.code`) that mean
+// the connection itself dropped mid-flight and the request never completed.
+// These are safe to retry for an idempotent part upload.
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ERR_HTTP2_STREAM_ERROR",
+  "ERR_HTTP2_GOAWAY_SESSION",
+  "ERR_HTTP2_SESSION_ERROR",
+]);
+
+function collectErrorText(error: unknown): { messages: string[]; codes: string[] } {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  // Walk the error -> cause chain (bounded) so a transport error wrapped by a
+  // higher-level "fetch failed" is still classified correctly.
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
+    const node = current as { message?: unknown; code?: unknown; cause?: unknown };
+    if (typeof node.message === "string") messages.push(node.message);
+    if (typeof node.code === "string") codes.push(node.code);
+    current = node.cause;
+  }
+  return { messages, codes };
+}
+
+function isTransientUploadError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const { messages, codes } = collectErrorText(error);
+
+  // 1. An explicit transient transport error code anywhere in the chain.
+  if (codes.some((code) => TRANSIENT_ERROR_CODES.has(code))) {
+    return true;
+  }
+
+  // 2. An unambiguous protocol-level reset marker in any message.
+  if (messages.some((text) =>
+    TRANSIENT_RESET_MARKERS.some((marker) => text.includes(marker)),
+  )) {
+    return true;
+  }
+
+  return false;
+}
+
+function nextRetryDelayMs(attempt: number): number {
+  // Linear backoff (200ms, 400ms, ...) plus up to one extra base delay of
+  // random jitter so concurrent part retries do not all fire on the same tick.
+  const base = RETRY_BASE_DELAY_MS * attempt;
+  const jitter = Math.floor(Math.random() * RETRY_BASE_DELAY_MS);
+  return base + jitter;
+}
+
+async function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
+  const retries = settings.fsPartRetries; // 0 = off (current default behavior)
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (error) {
+      attempt++;
+      if (retries <= 0 || attempt > retries || !isTransientUploadError(error)) {
+        throw error;
+      }
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, nextRetryDelayMs(attempt)),
+      );
+    }
+  }
+}
+
 export class SandboxFileSystem extends SandboxAction {
   constructor(sandbox: Sandbox, private process: SandboxProcess) {
     super(sandbox);
@@ -503,7 +602,7 @@ export class SandboxFileSystem extends SandboxAction {
           const chunk = blob.slice(start, end);
 
 
-          batch.push(this.uploadPart(uploadId, partNumber, chunk));
+          batch.push(retryOnTransient(() => this.uploadPart(uploadId, partNumber, chunk)));
         }
 
         // Wait for batch to complete

--- a/tests/unit/filesystem-part-retry.test.ts
+++ b/tests/unit/filesystem-part-retry.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadPartResponse,
+  SuccessResponse,
+} from "../../@blaxel/core/src/sandbox/client/index.js";
+import { SandboxFileSystem } from "../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+import { settings } from "../../@blaxel/core/src/common/settings.js";
+
+type MultipartUploadHarness = {
+  uploadWithMultipart(
+    path: string,
+    blob: Blob,
+    permissions?: string,
+  ): Promise<SuccessResponse>;
+  initiateMultipartUpload(
+    path: string,
+    permissions?: string,
+  ): Promise<MultipartInitiateResponse>;
+  uploadPart(
+    uploadId: string,
+    partNumber: number,
+    fileBlob: Blob,
+  ): Promise<MultipartUploadPartResponse>;
+  completeMultipartUpload(
+    uploadId: string,
+    parts: Array<MultipartPartInfo>,
+  ): Promise<SuccessResponse>;
+  abortMultipartUpload(uploadId: string): Promise<SuccessResponse>;
+};
+
+function createMultipartHarness(): MultipartUploadHarness {
+  return Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+}
+
+// A blob just over the 5MB multipart threshold yields exactly two parts (the
+// 5MB chunk size means ceil(6MB / 5MB) === 2). The tests below target a single
+// part (part 2) for failure so retry counts for that part are unambiguous.
+function multiPartBlob(): Blob {
+  return new Blob([new Uint8Array(6 * 1024 * 1024)]);
+}
+
+describe("SandboxFileSystem part-upload retry", () => {
+  afterEach(() => {
+    delete settings.config.fsPartRetries;
+  });
+
+  /**
+   * Build a harness whose part 1 always succeeds and whose part 2 rejects with
+   * `error` until `failTimes` rejections have been produced, then succeeds.
+   * Returns a getter for the number of times part 2 was attempted.
+   */
+  function harnessFailingPart2(
+    error: unknown,
+    failTimes = Number.POSITIVE_INFINITY,
+  ): { harness: MultipartUploadHarness; part2Attempts: () => number } {
+    const harness = createMultipartHarness();
+    let part2Attempts = 0;
+    harness.initiateMultipartUpload = () => Promise.resolve({ uploadId: "u" });
+    harness.uploadPart = (_uploadId, partNumber) => {
+      if (partNumber !== 2) {
+        return Promise.resolve({ partNumber, etag: `etag-${partNumber}` });
+      }
+      part2Attempts++;
+      if (part2Attempts <= failTimes) {
+        return Promise.reject(error);
+      }
+      return Promise.resolve({ partNumber, etag: `etag-${partNumber}` });
+    };
+    harness.completeMultipartUpload = () =>
+      Promise.resolve({ message: "completed" });
+    harness.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+    return { harness, part2Attempts: () => part2Attempts };
+  }
+
+  describe("transient error classification", () => {
+    beforeEach(() => {
+      settings.config.fsPartRetries = 3;
+    });
+
+    it("retries an ECONNRESET error code on the cause", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("fetch failed"), {
+          cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+        }),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("retries an ENHANCE_YOUR_CALM H2 reset marker", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("HTTP/2 stream reset: ENHANCE_YOUR_CALM"),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("retries the transport's own GOAWAY-before-response message", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("HTTP/2 session sent GOAWAY before response"),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("does NOT retry a bare 'fetch failed' with no transport code (avoids over-matching)", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("fetch failed"),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("fetch failed");
+      // No retry: the error never qualified as transient.
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("does NOT retry an application 'INTERNAL_ERROR' response body (avoids over-matching)", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error('{"error":"INTERNAL_ERROR: disk full"}'),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("INTERNAL_ERROR");
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("does NOT retry an ordinary 4xx validation error", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("400 Bad Request: invalid part number"),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("400 Bad Request");
+      expect(part2Attempts()).toBe(1);
+    });
+  });
+
+  describe("retry budget", () => {
+    it("is disabled by default (fsPartRetries unset = 0, no retries)", async () => {
+      // No settings.config.fsPartRetries set.
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("reset");
+      // Default-off: exactly one attempt for the failing part, no retry.
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("stops after exhausting the configured retry budget", async () => {
+      settings.config.fsPartRetries = 2;
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("reset");
+      // 1 initial attempt + 2 retries = 3 total for the failing part.
+      expect(part2Attempts()).toBe(3);
+    });
+  });
+});

--- a/tests/unit/h2-concurrency-cap.test.ts
+++ b/tests/unit/h2-concurrency-cap.test.ts
@@ -1,0 +1,328 @@
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPoolBackedH2Fetch,
+  h2RequestDirectFromPool,
+} from "../../@blaxel/core/src/common/h2fetch.js";
+import { H2Pool } from "../../@blaxel/core/src/common/h2pool.js";
+import { settings } from "../../@blaxel/core/src/common/settings.js";
+
+/**
+ * Minimal ClientHttp2Stream stand-in. Tests drive the response lifecycle by
+ * emitting events directly, so end()/close() are effectively no-ops.
+ */
+class MockStream extends EventEmitter {
+  public closed = false;
+  close(): void {
+    this.closed = true;
+  }
+  end(): void {
+    // no-op
+  }
+}
+
+/**
+ * Minimal ClientHttp2Session stand-in. `request()` records the stream so the
+ * test can resolve or fail it on demand.
+ */
+class MockSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  public lastStream: MockStream | null = null;
+  public streams: MockStream[] = [];
+
+  request(): MockStream {
+    const stream = new MockStream();
+    this.lastStream = stream;
+    this.streams.push(stream);
+    return stream;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.emit("close");
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+function asSession(mock: MockSession): http2.ClientHttp2Session {
+  return mock as unknown as http2.ClientHttp2Session;
+}
+
+/**
+ * Build a pool whose establish() always returns the supplied session for any
+ * domain, so each domain gets its own cached session without real network.
+ */
+function poolReturning(
+  sessionForDomain: (domain: string) => MockSession | null,
+): H2Pool {
+  const pool = new H2Pool();
+  (pool as unknown as { _establish: (d: string) => Promise<MockSession | null> })._establish =
+    (domain: string) => Promise.resolve(sessionForDomain(domain));
+  return pool;
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function resolveStream(stream: MockStream, status = 200): void {
+  stream.emit("response", { ":status": status });
+  stream.emit("end");
+}
+
+describe("h2fetch per-domain concurrency cap", () => {
+  beforeEach(() => {
+    // Cap concurrency at 1 in-flight request per domain so blocking is easy
+    // to observe deterministically.
+    settings.config.maxConcurrentH2Requests = 1;
+  });
+
+  afterEach(() => {
+    delete settings.config.maxConcurrentH2Requests;
+    vi.restoreAllMocks();
+  });
+
+  it("releases the slot after an H2 success so the next request can proceed", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.a.example.com");
+
+    const first = h2fetch(new Request("http://a.example.com/one"));
+    await tick();
+    const firstStream = session.lastStream!;
+    expect(firstStream).not.toBeNull();
+
+    // A second request must not get an H2 stream until the first releases.
+    const second = h2fetch(new Request("http://a.example.com/two"));
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    resolveStream(firstStream);
+    await first;
+
+    // First slot released: the second request now opens its own stream.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot after an H2 error so the next request can proceed", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.b.example.com");
+
+    const first = h2fetch(new Request("http://b.example.com/one", { method: "POST", body: "x" }));
+    await tick();
+    const firstStream = session.lastStream!;
+
+    const second = h2fetch(new Request("http://b.example.com/two", { method: "POST", body: "y" }));
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    firstStream.emit("error", new Error("stream dead"));
+    await expect(first).rejects.toThrow("stream dead");
+
+    // Slot freed despite the error: the queued request now runs.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot when there is no usable session (fetch fallback)", async () => {
+    // Pool returns null (no session), exercising the globalThis.fetch fallback
+    // path. The slot must still be released so a follow-up request proceeds.
+    const pool = poolReturning(() => null);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.c.example.com");
+
+    const first = await h2fetch(new Request("http://c.example.com/one"));
+    expect(await first.text()).toBe("fallback");
+
+    const second = await h2fetch(new Request("http://c.example.com/two"));
+    expect(await second.text()).toBe("fallback");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot when a post-flight error evicts the pooled session", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.evict.example.com");
+
+    // Prime the pool so the session is cached and observable via tryGet().
+    const first = h2fetch(
+      new Request("http://evict.example.com/one", { method: "POST", body: "x" }),
+    );
+    await tick();
+    const firstStream = session.lastStream!;
+    expect(pool.tryGet("edge.evict.example.com")).toBe(session);
+
+    // A second request queues behind the single slot.
+    const second = h2fetch(
+      new Request("http://evict.example.com/two", { method: "POST", body: "y" }),
+    );
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    // Post-flight stream error -> session evicted from the pool AND slot freed.
+    firstStream.emit("error", new Error("stream dead"));
+    await expect(first).rejects.toThrow("stream dead");
+    expect(pool.tryGet("edge.evict.example.com")).toBeNull();
+
+    // Slot was released despite the eviction: the queued request proceeds.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot on the globalThis.fetch fallback path (h2RequestDirectFromPool)", async () => {
+    const pool = poolReturning(() => null);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    const r1 = await h2RequestDirectFromPool(pool, "edge.d.example.com", "http://d.example.com/one");
+    const r2 = await h2RequestDirectFromPool(pool, "edge.d.example.com", "http://d.example.com/two");
+
+    expect(await r1.text()).toBe("fallback");
+    expect(await r2.text()).toBe("fallback");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot on the unsupported-body fetch fallback (pre-flight)", async () => {
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, "request");
+    const pool = poolReturning(() => session);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    // FormData cannot be serialized to a Buffer for manual H2 framing, so the
+    // direct-from-pool path falls back to globalThis.fetch before opening a
+    // stream. The slot acquired around the call must still be released.
+    const form1 = new FormData();
+    form1.append("file", new Blob(["a"]), "a.txt");
+    const r1 = await h2RequestDirectFromPool(
+      pool,
+      "edge.e.example.com",
+      "http://e.example.com/one",
+      { method: "PUT", body: form1 },
+    );
+
+    const form2 = new FormData();
+    form2.append("file", new Blob(["b"]), "b.txt");
+    const r2 = await h2RequestDirectFromPool(
+      pool,
+      "edge.e.example.com",
+      "http://e.example.com/two",
+      { method: "PUT", body: form2 },
+    );
+
+    expect(await r1.text()).toBe("fallback");
+    expect(await r2.text()).toBe("fallback");
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves queued requests in FIFO order", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.f.example.com");
+    const order: number[] = [];
+
+    // One request holds the single slot; two more queue behind it.
+    const p1 = h2fetch(new Request("http://f.example.com/1")).then(() => order.push(1));
+    await tick();
+    const holdingStream = session.lastStream!;
+
+    const p2 = h2fetch(new Request("http://f.example.com/2")).then(() => order.push(2));
+    await tick();
+    const p3 = h2fetch(new Request("http://f.example.com/3")).then(() => order.push(3));
+    await tick();
+
+    // Only the first request has opened a stream so far.
+    expect(session.streams).toHaveLength(1);
+
+    // Release in sequence; each release should let exactly the next queued
+    // request (in arrival order) open its stream.
+    resolveStream(holdingStream);
+    await p1;
+    await tick();
+    expect(session.streams).toHaveLength(2);
+
+    resolveStream(session.streams[1]);
+    await p2;
+    await tick();
+    expect(session.streams).toHaveLength(3);
+
+    resolveStream(session.streams[2]);
+    await p3;
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("does not let one capped domain block an unrelated domain", async () => {
+    const sessionA = new MockSession();
+    const sessionB = new MockSession();
+    const pool = poolReturning((domain) =>
+      domain === "edge.A.example.com" ? sessionA : sessionB,
+    );
+
+    const fetchA = createPoolBackedH2Fetch(pool, "edge.A.example.com");
+    const fetchB = createPoolBackedH2Fetch(pool, "edge.B.example.com");
+
+    // Saturate domain A's single slot and queue a second A request behind it.
+    const a1 = fetchA(new Request("http://a/one"));
+    await tick();
+    const a1Stream = sessionA.lastStream!;
+    const a2 = fetchA(new Request("http://a/two"));
+    await tick();
+    expect(sessionA.streams).toHaveLength(1); // a2 is queued, blocked.
+
+    // Domain B must be completely unaffected: it gets its slot immediately.
+    const b1 = fetchB(new Request("http://b/one"));
+    await tick();
+    expect(sessionB.streams).toHaveLength(1);
+    resolveStream(sessionB.lastStream!);
+    await expect(b1).resolves.toBeInstanceOf(Response);
+
+    // Now drain domain A.
+    resolveStream(a1Stream);
+    await a1;
+    await tick();
+    expect(sessionA.streams).toHaveLength(2);
+    resolveStream(sessionA.streams[1]);
+    await a2;
+  });
+
+  it("is a no-op when the cap is unset (default behavior, unlimited concurrency)", async () => {
+    delete settings.config.maxConcurrentH2Requests;
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.g.example.com");
+
+    // With no cap, multiple requests open streams concurrently without waiting
+    // for each other to release.
+    void h2fetch(new Request("http://g/1"));
+    void h2fetch(new Request("http://g/2"));
+    void h2fetch(new Request("http://g/3"));
+    await tick();
+
+    expect(session.streams.length).toBe(3);
+  });
+});


### PR DESCRIPTION
# H2 concurrency cap and transient part-upload retry (both default-off)

Relates to ENG-2620. Server-side follow-up tracked in ENG-2621.

## Problem

Under bursty load (notably large multipart file uploads that fan out into parallel part requests), the edge in front of a sandbox can reset in-flight HTTP/2 streams instead of multiplexing them gracefully. Callers see sporadic stream resets (ENHANCE_YOUR_CALM, GOAWAY, ECONNRESET) and uploads fail even though a retry would have succeeded.

## Root cause

Two contributing factors on the client side:

1. The SDK sends as many concurrent H2 requests as the caller generates over a single pooled session. There is no client-side ceiling, so a single sandbox's upload burst can push the edge past the point where it keeps multiplexing and starts resetting streams.
2. A part upload that hits one of these transient resets fails the whole multipart upload, with no retry, even though the failure is recoverable.

This is fundamentally a server-side behavior (see follow-up below). The changes here are a client-side mitigation that is safe to ship independently.

## Change

Two independent, opt-in mitigations:

1. Per-domain in-flight concurrency cap in `h2fetch.ts`. An async semaphore keyed by edge domain bounds how many H2 requests are in flight against a single edge session at once. The cap is per-domain (a `Map<domain, {active, queue}>`) so throttling one sandbox's traffic never blocks requests to an unrelated sandbox served by a different edge. The gate wraps both `createPoolBackedH2Fetch` and `h2RequestDirectFromPool`, and releases the slot on every exit path: H2 success, H2 error, pool eviction, the no-usable-session fetch fallback, and the unsupported-body fetch fallback. Waiters are served FIFO. A conservative 120s safety timer releases a slot if a request never settles, so one stuck request cannot starve the rest of the queue for its domain. The timer never cancels the underlying request; it only stops it from blocking the queue.
2. Transient retry for multipart part uploads in `filesystem.ts`. Part uploads are now wrapped in `retryOnTransient()`, which retries only on clearly transient transport failures, using linear backoff with randomized jitter to avoid synchronized retries across parallel parts.

The transient classifier was tightened so it does not over-match unrelated failures. It now matches on explicit transport error codes (ECONNRESET, ETIMEDOUT, EPIPE, and the node `ERR_HTTP2_*` family) walked across the full error/cause chain, plus a small set of unambiguous protocol reset markers (ENHANCE_YOUR_CALM, qualified NGHTTP2_INTERNAL_ERROR, GOAWAY, and the transport's own session-closed/GOAWAY-before-response messages). Bare `INTERNAL_ERROR` and `fetch failed` were deliberately removed as standalone markers because they match application error bodies and generic failures.

## Config

| Setting | Env var | Default | Effect |
| --- | --- | --- | --- |
| `maxConcurrentH2Requests` | `BL_MAX_H2_INFLIGHT` | `0` | Max in-flight H2 requests per edge domain. `0` or unset means unlimited. |
| `fsPartRetries` | `BL_FS_PART_RETRIES` | `0` | Retry attempts per multipart part on transient errors. `0` or unset disables retry. |

Both follow the existing `disableH2` config/env precedence pattern: an explicit value in `Config` wins, then the env var, then the default.

## Default behavior (no-op unless enabled)

Both features are off by default. With the defaults (`0`), the concurrency gate is a no-op (unlimited concurrency, current behavior) and part uploads are not retried (current behavior). No behavior changes for existing callers until they opt in. The default values are still under discussion and intentionally left at `0` here.

## Validation (reproduced against a real concurrent large-upload workload)

Measured against a live sandbox plus mounted drive, with concurrent `fs.writeBinary` of files over the 5MB multipart threshold:

| Scenario | Default (off) | With mitigation |
| --- | --- | --- |
| 12 x 6MB concurrent | 10-12 / 12 fail | 0 / 12 (cap=3) |
| 8 x 10MB concurrent | 7 / 8 fail | 0 / 8 (cap=2 + part-retry) |

The reliably-zero cap is workload-dependent (lower for larger files; a 25MB workload would need lower still), which is exactly why this ships opt-in and the durable fix is server-side.

## Test coverage

New focused vitest unit tests, fully mocked at the H2 layer with no network:

- `tests/unit/h2-concurrency-cap.test.ts`: slot released on H2 success, on H2 error, on a post-flight error that evicts the pooled session, on the no-usable-session fetch fallback, on the `globalThis.fetch` fallback path, and on the unsupported-body (FormData) pre-flight fallback; FIFO ordering of queued requests; per-domain isolation (saturating domain A does not block domain B); and the no-op default when the cap is unset.
- `tests/unit/filesystem-part-retry.test.ts`: retries on ECONNRESET (via cause code), ENHANCE_YOUR_CALM, and the transport's GOAWAY-before-response message; does NOT retry a bare `fetch failed`, an application `INTERNAL_ERROR` body, or an ordinary 4xx; disabled by default; and stops after the configured budget.

Result: 17 new tests pass. The pre-existing pure-mock H2 and multipart suites still pass with no regressions (48 total in the combined no-network run). `@blaxel/core` builds clean and the changed source files lint clean.

## Follow-up (server side)

This is a client-side mitigation only. The underlying issue is that the edge resets H2 streams under concurrent load instead of multiplexing them gracefully. That is tracked server-side in ENG-2621, where the durable fix lives; once it lands, this client cap and retry can be relaxed or removed.
