### PR TITLE
fix: correct actions/setup-node commit SHA

### DIFF
--- a/.github/workflows/update-sdk-definitions.yaml
+++ b/.github/workflows/update-sdk-definitions.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f2b846f73898f2e17 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 


### PR DESCRIPTION
Wrong: 49933ea5288caeca8642195f2b846f73898f2e17
Right: 49933ea5288caeca8642d1e84afbd3f7d6820020 (v4.4.0)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Corrects a wrong commit SHA for `actions/setup-node` pinned at `v4.4.0`. The old SHA (`49933ea5288caeca8642195f2b846f73898f2e17`) was invalid; the new one (`49933ea5288caeca8642d1e84afbd3f7d6820020`) matches the actual `v4.4.0` tag in the `actions/setup-node` repository.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 879e11a086a861fc0cc86af70d79633b7c2b1f93.</sup>
<!-- /MENDRAL_SUMMARY -->