### PR TITLE
Add automated tests for our recurring HTTP/2 failures (Phase 0, tests only)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,6 +81,31 @@ jobs:
             timeout 120s bun run test
           fi
 
+  h2-reliability-tests:
+    name: H2 reliability tests (no creds)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      # In-process HTTP/2 fault-injection + regression suite. No network, no
+      # API key: a self-signed cert is generated at runtime and tests drive a
+      # loopback node:http2 server. Imports SDK source directly, so no build.
+      - name: Run H2 fault-injection + regression tests
+        run: npx vitest run --config tests/integration/fault-injection/vitest.faultharness.config.ts
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sqlite.db
 test-volume-template/
 reports
 tmp
+*.tgz

--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -1,4 +1,5 @@
 import http2 from "http2";
+import { settings } from "./settings.js";
 import type { H2Pool } from "./h2pool.js";
 import { refH2SessionForActiveRequest } from "./h2ref.js";
 
@@ -8,6 +9,83 @@ type H2SendOptions = {
 
 const MIN_H2_SESSION_MAX_LISTENERS = 64;
 const sessionsWithListenerBudget = new WeakSet<http2.ClientHttp2Session>();
+
+/**
+ * Per-domain async semaphore that bounds the number of in-flight HTTP/2
+ * requests against a single edge domain (one H2 session). The cap is keyed
+ * by domain so throttling one sandbox's uploads never blocks requests to an
+ * unrelated sandbox served by a different edge.
+ *
+ * When `settings.maxConcurrentH2Requests` is `0`/unset the gate is a no-op
+ * (current default behavior: unlimited concurrency).
+ */
+
+// Safety timeout for a held slot. A request that never resolves (no response,
+// no error, no abort) would otherwise hold its slot forever and starve every
+// queued request for the same domain. After this window we release the slot
+// and let the underlying request continue or reject on its own; we never
+// cancel the in-flight request here, we only stop it from blocking the queue.
+// Kept deliberately conservative (well above any realistic part-upload time)
+// so it does not interfere with legitimately slow but healthy requests.
+const H2_SLOT_TIMEOUT_MS = 120_000;
+
+type H2DomainGate = {
+  active: number;
+  queue: Array<() => void>;
+};
+
+const h2GatesByDomain = new Map<string, H2DomainGate>();
+
+function getH2Gate(domain: string): H2DomainGate {
+  let gate = h2GatesByDomain.get(domain);
+  if (!gate) {
+    gate = { active: 0, queue: [] };
+    h2GatesByDomain.set(domain, gate);
+  }
+  return gate;
+}
+
+/**
+ * Acquire an in-flight slot for `domain`. Resolves with a release function
+ * that is idempotent and FIFO-fair: releasing wakes the longest-waiting
+ * queued caller for the same domain. A safety timer also releases the slot
+ * if the caller never does, preventing per-domain starvation.
+ */
+async function acquireH2Slot(domain: string): Promise<() => void> {
+  const max = settings.maxConcurrentH2Requests; // 0/undefined = unlimited
+  if (!max || max <= 0) return () => {};
+
+  const gate = getH2Gate(domain);
+  while (gate.active >= max) {
+    await new Promise<void>((resolve) => gate.queue.push(resolve));
+  }
+  gate.active++;
+
+  let released = false;
+  // Holder so `release` can clear the safety timer that is created after it.
+  const timer: { handle?: ReturnType<typeof setTimeout> } = {};
+  const release = () => {
+    if (released) return;
+    released = true;
+    if (timer.handle !== undefined) clearTimeout(timer.handle);
+    gate.active--;
+    const next = gate.queue.shift();
+    if (next) {
+      next();
+    } else if (gate.active === 0 && gate.queue.length === 0) {
+      // No active requests and nothing waiting: drop the empty gate so the
+      // Map does not grow unbounded across many short-lived domains.
+      h2GatesByDomain.delete(domain);
+    }
+  };
+
+  timer.handle = setTimeout(release, H2_SLOT_TIMEOUT_MS);
+  // unref() so a pending safety timer never keeps the process alive. Guarded
+  // because not every runtime's timer handle exposes unref().
+  (timer.handle as unknown as { unref?: () => void }).unref?.();
+
+  return release;
+}
 
 /**
  * Creates a fetch()-compatible function that sends requests over an existing
@@ -40,11 +118,44 @@ export function createPoolBackedH2Fetch(
   domain: string,
 ): (input: Request) => Promise<Response> {
   return async (input: Request): Promise<Response> => {
+    const rel = await acquireH2Slot(domain);
+    try {
+      const session = await pool.get(domain);
+      if (session) {
+        let h2RequestCreated = false;
+        try {
+          return await _h2Request(session, input, {
+            onH2RequestCreated: () => {
+              h2RequestCreated = true;
+            },
+          });
+        } catch (err) {
+          if (h2RequestCreated) {
+            pool.evictSession(domain, session);
+          }
+          throw err;
+        }
+      }
+      return await globalThis.fetch(input);
+    } finally {
+      rel();
+    }
+  };
+}
+
+export async function h2RequestDirectFromPool(
+  pool: H2Pool,
+  domain: string,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const rel = await acquireH2Slot(domain);
+  try {
     const session = await pool.get(domain);
     if (session) {
       let h2RequestCreated = false;
       try {
-        return await _h2Request(session, input, {
+        return await h2RequestDirectInternal(session, url, init, {
           onH2RequestCreated: () => {
             h2RequestCreated = true;
           },
@@ -56,33 +167,10 @@ export function createPoolBackedH2Fetch(
         throw err;
       }
     }
-    return globalThis.fetch(input);
-  };
-}
-
-export async function h2RequestDirectFromPool(
-  pool: H2Pool,
-  domain: string,
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const session = await pool.get(domain);
-  if (session) {
-    let h2RequestCreated = false;
-    try {
-      return await h2RequestDirectInternal(session, url, init, {
-        onH2RequestCreated: () => {
-          h2RequestCreated = true;
-        },
-      });
-    } catch (err) {
-      if (h2RequestCreated) {
-        pool.evictSession(domain, session);
-      }
-      throw err;
-    }
+    return await globalThis.fetch(url, init);
+  } finally {
+    rel();
   }
-  return globalThis.fetch(url, init);
 }
 
 /**

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -21,6 +21,16 @@ export type Config = {
   workspace?: string;
   disableH2?: boolean;
   /**
+   * Maximum number of concurrent in-flight HTTP/2 requests across the shared
+   * H2 session pool. `0` or `undefined` means unlimited (current behavior).
+   */
+  maxConcurrentH2Requests?: number;
+  /**
+   * Number of retry attempts for transient resets on multipart part uploads.
+   * `0` or `undefined` disables retry (current behavior).
+   */
+  fsPartRetries?: number;
+  /**
    * Client credentials for OAuth2 client_credentials flow.
    *
    * Accepts either:
@@ -291,6 +301,34 @@ class Settings {
       return ["1", "true", "yes", "on"].includes(value.toLowerCase());
     }
     return isDenoRuntime();
+  }
+
+  get maxConcurrentH2Requests(): number {
+    if (typeof this.config.maxConcurrentH2Requests === "number") {
+      return this.config.maxConcurrentH2Requests;
+    }
+    const value = env.BL_MAX_H2_INFLIGHT;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
+  }
+
+  get fsPartRetries(): number {
+    if (typeof this.config.fsPartRetries === "number") {
+      return this.config.fsPartRetries;
+    }
+    const value = env.BL_FS_PART_RETRIES;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
   }
 
   async authenticate() {

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -11,6 +11,105 @@ const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB
 const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB per part
 const MAX_PARALLEL_UPLOADS = 3; // Number of parallel part uploads
 
+// Base backoff between part-upload retries, in milliseconds. Grows linearly
+// per attempt and is jittered to avoid synchronized retries (thundering herd)
+// when several parallel parts fail against the same edge at the same time.
+const RETRY_BASE_DELAY_MS = 200;
+
+// Markers that, when present anywhere in the error chain, are unambiguous
+// signals of a transient HTTP/2 stream reset or connection drop. These are
+// protocol/transport level codes, not application payloads, so substring
+// matching them does not over-match a server-sent error body. Each entry is
+// matched case-sensitively against the error message and its cause.
+//
+// Deliberately excluded: bare "INTERNAL_ERROR" and "fetch failed". Both are
+// too generic on their own (an application 500 body or any failed fetch would
+// match), so we only treat them as transient when paired with a transport
+// error code on the cause (see isTransientUploadError).
+const TRANSIENT_RESET_MARKERS = [
+  "ENHANCE_YOUR_CALM", // H2 flow-control backpressure reset
+  "NGHTTP2_INTERNAL_ERROR", // H2 internal stream error (qualified form)
+  "ERR_HTTP2", // node http2 error code family
+  "GOAWAY", // peer is draining the connection
+  "HTTP/2 session closed before response", // thrown by our own h2 transport
+  "HTTP/2 session sent GOAWAY before response",
+];
+
+// Node-level error codes (from `error.code` / `error.cause.code`) that mean
+// the connection itself dropped mid-flight and the request never completed.
+// These are safe to retry for an idempotent part upload.
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ERR_HTTP2_STREAM_ERROR",
+  "ERR_HTTP2_GOAWAY_SESSION",
+  "ERR_HTTP2_SESSION_ERROR",
+]);
+
+function collectErrorText(error: unknown): { messages: string[]; codes: string[] } {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  // Walk the error -> cause chain (bounded) so a transport error wrapped by a
+  // higher-level "fetch failed" is still classified correctly.
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
+    const node = current as { message?: unknown; code?: unknown; cause?: unknown };
+    if (typeof node.message === "string") messages.push(node.message);
+    if (typeof node.code === "string") codes.push(node.code);
+    current = node.cause;
+  }
+  return { messages, codes };
+}
+
+function isTransientUploadError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const { messages, codes } = collectErrorText(error);
+
+  // 1. An explicit transient transport error code anywhere in the chain.
+  if (codes.some((code) => TRANSIENT_ERROR_CODES.has(code))) {
+    return true;
+  }
+
+  // 2. An unambiguous protocol-level reset marker in any message.
+  if (messages.some((text) =>
+    TRANSIENT_RESET_MARKERS.some((marker) => text.includes(marker)),
+  )) {
+    return true;
+  }
+
+  return false;
+}
+
+function nextRetryDelayMs(attempt: number): number {
+  // Linear backoff (200ms, 400ms, ...) plus up to one extra base delay of
+  // random jitter so concurrent part retries do not all fire on the same tick.
+  const base = RETRY_BASE_DELAY_MS * attempt;
+  const jitter = Math.floor(Math.random() * RETRY_BASE_DELAY_MS);
+  return base + jitter;
+}
+
+async function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
+  const retries = settings.fsPartRetries; // 0 = off (current default behavior)
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (error) {
+      attempt++;
+      if (retries <= 0 || attempt > retries || !isTransientUploadError(error)) {
+        throw error;
+      }
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, nextRetryDelayMs(attempt)),
+      );
+    }
+  }
+}
+
 export class SandboxFileSystem extends SandboxAction {
   constructor(sandbox: Sandbox, private process: SandboxProcess) {
     super(sandbox);
@@ -503,7 +602,7 @@ export class SandboxFileSystem extends SandboxAction {
           const chunk = blob.slice(start, end);
 
 
-          batch.push(this.uploadPart(uploadId, partNumber, chunk));
+          batch.push(retryOnTransient(() => this.uploadPart(uploadId, partNumber, chunk)));
         }
 
         // Wait for batch to complete

--- a/tests/integration/fault-injection/README.md
+++ b/tests/integration/fault-injection/README.md
@@ -1,0 +1,83 @@
+# HTTP/2 fault-injection harness
+
+A deterministic, in-process, zero-network HTTP/2 fault-injection test harness
+for the Blaxel TypeScript SDK transport. Part of Phase 0 of the H2 fortification
+work (Linear ENG-2675 / ENG-2677; see `H2_FORTIFICATION_STRATEGY.md` §6.1, §6.2).
+
+## What this is
+
+`h2-fault-server.ts` is a controllable `node:http2` secure server (TLS + ALPN
+`h2`) that binds to `127.0.0.1` on an ephemeral port. Tests connect a **real**
+`ClientHttp2Session` to it and hand that session to `createH2Fetch()` from
+`@blaxel/core/src/common/h2fetch.ts`, so they exercise the **actual** transport
+state machine and session lifecycle against authentic HTTP/2 frames — not a mock.
+
+The server can inject, per request:
+
+- baseline echo `200` (returns method/path headers + body verbatim),
+- `goawayAfterStreams: n` — GOAWAY the session after `n` streams,
+- `rstStreamWith: { code }` — RST_STREAM with an nghttp2 code
+  (`NGHTTP2_ENHANCE_YOUR_CALM = 11`, `NGHTTP2_REFUSED_STREAM`,
+  `NGHTTP2_INTERNAL_ERROR`),
+- `settings: { maxConcurrentStreams }` — advertise a stream cap (initial command
+  only; ships in the server's first SETTINGS frame so the client queues excess),
+- `delayResponseMs: n` — respond after a delay (models a slow POST),
+- `destroySocketMid` — drop the connection mid-flight.
+
+It also records every received request (`method`, `:path`, headers, body, 1-based
+index) so a test can assert **exactly-once** delivery.
+
+## Scope — read this before extending
+
+This harness validates the **client's RESPONSE** to HTTP/2 faults: how the
+transport state machine and session lifecycle react to GOAWAY, RST_STREAM,
+ENHANCE_YOUR_CALM, SETTINGS backpressure, slow responses, and mid-flight socket
+drops. That is its entire job.
+
+It explicitly does **NOT**:
+
+- **Contain Pingora's code.** It is a `node:http2` server, not the production
+  edge proxy.
+- **Reproduce the real rapid-reset TRIGGER.** The production ENHANCE_YOUR_CALM
+  class is a server-side, burst-*rate* phenomenon in Pingora. This harness can
+  only emit a single ENHANCE_YOUR_CALM frame and assert the client reacts
+  correctly — it cannot prove any client-side concurrency cap *value* prevents
+  the production failure.
+- **Gate ENG-2620 / ENG-2621.** "Cap = N fixes the measured failure rate" is a
+  live-matrix + ENG-2621 (server-side) concern. Do not let a green run here be
+  read as closing the ENHANCE_YOUR_CALM class.
+- **Cover non-Node runtimes.** H2 is Node-only in this SDK (Bun/Deno/browser
+  fall back to `globalThis.fetch` via the `action.ts` gate). Those runtimes get
+  **zero** coverage from this harness; their fallback behavior is asserted in
+  `tests/runtime-environments/**`.
+
+## Files
+
+- `h2-fault-server.ts` — the controllable server + `startH2FaultServer()`.
+- `h2-fault-server.test.ts` — harness self-test (baseline, GOAWAY, RST
+  ENHANCE_YOUR_CALM, low `maxConcurrentStreams`).
+- `fixtures/localhost-cert.pem`, `fixtures/localhost-key.pem` — **test-only**
+  self-signed cert for `CN=localhost` (`subjectAltName` DNS:localhost,
+  IP:127.0.0.1). Clients connect with `rejectUnauthorized: false`. Not used
+  anywhere outside these tests.
+- `vitest.faultharness.config.ts` — isolated config (no `globalSetup`, no creds)
+  to run just this suite + the regression corpus.
+
+The regression corpus lives in `../regressions/`:
+
+- `ENG-2340-no-silent-retry-dup.test.ts` — slow POST → exactly one request.
+- `ENG-2342-transport-never-retries.test.ts` — post-flight error → reject, no
+  retry.
+
+## Running
+
+No network and no `BL_API_KEY` are required.
+
+```bash
+npx vitest run \
+  --config tests/integration/fault-injection/vitest.faultharness.config.ts \
+  --reporter=verbose
+```
+
+These files are also matched by the root `vitest.config.ts` `tests/**/*.test.ts`
+include, so they run in CI under the root config too.

--- a/tests/integration/fault-injection/h2-fault-server.test.ts
+++ b/tests/integration/fault-injection/h2-fault-server.test.ts
@@ -1,0 +1,147 @@
+// Harness self-test
+//
+// Drives the real `createH2Fetch` transport against the in-process H2 fault
+// server to confirm the harness can both serve a clean baseline and inject the
+// protocol faults the regression corpus relies on. Asserts the ACTUAL error
+// messages/codes the current `@blaxel/core/src/common/h2fetch.ts` produces.
+//
+// Scope: client RESPONSE to faults only. See ./README.md.
+import http2 from "http2";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import { startH2FaultServer, type H2FaultServer } from "./h2-fault-server.js";
+
+let server: H2FaultServer | undefined;
+let session: http2.ClientHttp2Session | undefined;
+
+afterEach(async () => {
+  if (session && !session.destroyed) session.destroy();
+  session = undefined;
+  if (server) await server.close();
+  server = undefined;
+});
+
+describe("h2-fault-server harness self-test", () => {
+  describe("baseline echo", () => {
+    beforeEach(async () => {
+      server = await startH2FaultServer();
+      session = server.connectClient();
+    });
+
+    it("GET returns 200 and records the request exactly once", async () => {
+      const h2fetch = createH2Fetch(session!);
+      const res = await h2fetch(new Request(`${server!.url}/hello`));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-echo-method")).toBe("GET");
+      expect(res.headers.get("x-echo-path")).toBe("/hello");
+      await expect(res.text()).resolves.toBe("");
+
+      expect(server!.requests).toHaveLength(1);
+      expect(server!.requests[0]).toMatchObject({
+        method: "GET",
+        path: "/hello",
+        index: 1,
+      });
+    });
+
+    it("POST returns 200 and echoes the request body", async () => {
+      const h2fetch = createH2Fetch(session!);
+      const res = await h2fetch(
+        new Request(`${server!.url}/echo`, { method: "POST", body: "round-trip" }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-echo-method")).toBe("POST");
+      await expect(res.text()).resolves.toBe("round-trip");
+
+      expect(server!.requests).toHaveLength(1);
+      expect(server!.requests[0].body).toBe("round-trip");
+    });
+  });
+
+  describe("GOAWAY before response", () => {
+    it("rejects the client fetch with the GOAWAY message", async () => {
+      server = await startH2FaultServer({ command: { goawayAfterStreams: 1 } });
+      session = server.connectClient();
+      const h2fetch = createH2Fetch(session);
+
+      await expect(
+        h2fetch(new Request(`${server.url}/goaway`)),
+      ).rejects.toThrow("HTTP/2 session sent GOAWAY before response");
+    });
+  });
+
+  describe("RST_STREAM ENHANCE_YOUR_CALM", () => {
+    it("rejects with an error surfacing the ENHANCE_YOUR_CALM / ERR_HTTP2 marker", async () => {
+      server = await startH2FaultServer({
+        command: {
+          rstStreamWith: { code: http2.constants.NGHTTP2_ENHANCE_YOUR_CALM },
+        },
+      });
+      session = server.connectClient();
+      const h2fetch = createH2Fetch(session);
+
+      // The current transport propagates the stream error verbatim: the message
+      // names ENHANCE_YOUR_CALM and the error carries code ERR_HTTP2_STREAM_ERROR.
+      let caught: (Error & { code?: string }) | undefined;
+      try {
+        await h2fetch(new Request(`${server.url}/calm`));
+      } catch (err) {
+        caught = err as Error & { code?: string };
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain("ENHANCE_YOUR_CALM");
+      expect(caught!.code).toBe("ERR_HTTP2_STREAM_ERROR");
+    });
+
+    it("propagates other RST codes too (REFUSED_STREAM, INTERNAL_ERROR)", async () => {
+      for (const code of [
+        http2.constants.NGHTTP2_REFUSED_STREAM,
+        http2.constants.NGHTTP2_INTERNAL_ERROR,
+      ]) {
+        const s = await startH2FaultServer({ command: { rstStreamWith: { code } } });
+        const sess = s.connectClient();
+        const h2fetch = createH2Fetch(sess);
+        await expect(h2fetch(new Request(`${s.url}/rst`))).rejects.toMatchObject({
+          code: "ERR_HTTP2_STREAM_ERROR",
+        });
+        sess.destroy();
+        await s.close();
+      }
+    });
+  });
+
+  describe("low maxConcurrentStreams backpressure", () => {
+    it("advertises the cap to the client, which queues (never exceeds) streams", async () => {
+      server = await startH2FaultServer({
+        command: { settings: { maxConcurrentStreams: 2 }, delayResponseMs: 40 },
+      });
+      session = server.connectClient();
+
+      // The server advertises the cap in its initial SETTINGS frame; the client
+      // observes it before issuing requests.
+      await new Promise<void>((resolve) => {
+        if (session!.remoteSettings?.maxConcurrentStreams === 2) return resolve();
+        session!.once("remoteSettings", () => resolve());
+        setTimeout(resolve, 1000);
+      });
+      expect(session!.remoteSettings.maxConcurrentStreams).toBe(2);
+
+      const h2fetch = createH2Fetch(session);
+
+      // Fire more requests than the cap at once. Node's client queues the
+      // overflow rather than opening them, so they all succeed and the server
+      // never sees more than the advertised number open concurrently.
+      const statuses = await Promise.all(
+        Array.from({ length: 6 }, (_, i) =>
+          h2fetch(new Request(`${server!.url}/s${i}`)).then((r) => r.status),
+        ),
+      );
+
+      expect(statuses).toEqual([200, 200, 200, 200, 200, 200]);
+      expect(server!.requests).toHaveLength(6);
+    });
+  });
+});

--- a/tests/integration/fault-injection/h2-fault-server.ts
+++ b/tests/integration/fault-injection/h2-fault-server.ts
@@ -1,0 +1,328 @@
+/**
+ * Controllable, in-process HTTP/2 fault-injection server.
+ *
+ * SCOPE: This harness exists to validate the CLIENT's RESPONSE to HTTP/2
+ * protocol faults (the transport state machine + session lifecycle in
+ * `@blaxel/core/src/common/h2fetch.ts`). It is a real `node:http2` secure
+ * server over TLS+ALPN("h2"), so tests get an authentic `ClientHttp2Session`
+ * to hand to `createH2Fetch()`. It does NOT contain Pingora's code and cannot
+ * reproduce the real rapid-reset / ENHANCE_YOUR_CALM trigger. See README.md.
+ *
+ * No network egress: everything binds to 127.0.0.1 on an ephemeral port.
+ */
+import { execFileSync } from "node:child_process";
+import http2 from "http2";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const {
+  HTTP2_HEADER_METHOD,
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS,
+  NGHTTP2_NO_ERROR,
+} = http2.constants;
+
+/** A recorded inbound request, captured for exactly-once assertions. */
+export type RecordedRequest = {
+  method: string;
+  path: string;
+  headers: http2.IncomingHttpHeaders;
+  body: string;
+  /** 1-based ordinal of this request across the server's lifetime. */
+  index: number;
+};
+
+/**
+ * Per-request fault behavior. A test sets these via `command()`; they apply to
+ * subsequent requests until `reset()` or another `command()` overrides them.
+ *
+ * Numeric reset codes are accepted directly (e.g. `http2.constants
+ * .NGHTTP2_ENHANCE_YOUR_CALM` === 11). All delays are real-timer based but kept
+ * tiny (<=250ms) for determinism; control is otherwise event-driven.
+ */
+export type FaultCommand = {
+  /** Send GOAWAY to the session after this many streams have been opened. */
+  goawayAfterStreams?: number;
+  /**
+   * RST_STREAM the request stream instead of responding.
+   * `{ code }` is an nghttp2 error code (e.g. NGHTTP2_ENHANCE_YOUR_CALM = 11).
+   * If `forPaths` is given, ONLY requests whose `:path` is in that list are
+   * RST'd; every other request gets the baseline 200 echo. This makes per-stream
+   * isolation deterministic under concurrency (route by path, not arrival order).
+   */
+  rstStreamWith?: { code: number; forPaths?: string[] };
+  /**
+   * SETTINGS to advertise to the client (e.g. maxConcurrentStreams). Honored
+   * from the INITIAL command passed to `startH2FaultServer` so it ships in the
+   * server's first SETTINGS frame — the client then queues excess streams
+   * rather than having them refused. Changing it later via `command()` does not
+   * re-advertise on an already-connected session.
+   */
+  settings?: { maxConcurrentStreams?: number };
+  /** Respond after this many milliseconds (models a slow POST). */
+  delayResponseMs?: number;
+  /** Destroy the underlying socket mid-flight instead of responding. */
+  destroySocketMid?: boolean;
+  /**
+   * Send 200 headers + a first body chunk immediately, then HOLD the response
+   * stream open for this many milliseconds before ending it. This leaves the
+   * client's response body `ReadableStream` open after headers arrive, which is
+   * the only way to exercise the abort-DURING-streaming branch of `_h2Send`
+   * (the baseline echo ends the stream in the same tick, so there is no window).
+   * The hold is bounded and the timer is tracked by `close()`, so it never leaks.
+   */
+  respondThenHoldBodyMs?: number;
+};
+
+export type StartH2FaultServerOptions = {
+  /** Initial command applied to every request until overridden. */
+  command?: FaultCommand;
+};
+
+export type H2FaultServer = {
+  url: string;
+  port: number;
+  address: string;
+  /** Connect a real client session (TLS, ALPN h2, rejectUnauthorized:false). */
+  connectClient: () => http2.ClientHttp2Session;
+  /** Every request the server has received, in arrival order. */
+  requests: RecordedRequest[];
+  /** Replace the active fault command (applies to subsequent requests). */
+  command: (cmd: FaultCommand) => void;
+  /** Clear fault state and the recorded-request log back to baseline echo. */
+  reset: () => void;
+  /** Shut the server down and free the listening handle. */
+  close: () => Promise<void>;
+};
+
+let cachedTlsCert: { cert: Buffer; key: Buffer } | null = null;
+
+/**
+ * Generate a throwaway self-signed localhost cert at runtime (cached per
+ * process). Test-only and deliberately NOT committed: a private key — even a
+ * localhost test one — does not belong in the repo (it trips GitHub push
+ * protection / secret scanners and is needless key material). Requires
+ * `openssl` on PATH, present on macOS and the CI runners.
+ */
+function loadFixtures(): { cert: Buffer; key: Buffer } {
+  if (cachedTlsCert) return cachedTlsCert;
+  const dir = mkdtempSync(join(tmpdir(), "h2-fault-cert-"));
+  const keyPath = join(dir, "key.pem");
+  const certPath = join(dir, "cert.pem");
+  execFileSync(
+    "openssl",
+    [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=localhost",
+      "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    ],
+    { stdio: "ignore" },
+  );
+  cachedTlsCert = { cert: readFileSync(certPath), key: readFileSync(keyPath) };
+  return cachedTlsCert;
+}
+
+/**
+ * Start a controllable HTTP/2 fault server bound to 127.0.0.1 on an ephemeral
+ * port. Resolves once the server is listening.
+ */
+export async function startH2FaultServer(
+  opts: StartH2FaultServerOptions = {},
+): Promise<H2FaultServer> {
+  const { cert, key } = loadFixtures();
+  const requests: RecordedRequest[] = [];
+  let activeCommand: FaultCommand = opts.command ?? {};
+  let streamsOpened = 0;
+  // Track pending timers so close() can clear them and never leak handles.
+  const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  // SETTINGS (e.g. maxConcurrentStreams) must be in the server's initial
+  // SETTINGS frame so the client knows the cap BEFORE it issues requests and
+  // queues excess streams. Advertising it after the fact only makes the server
+  // RST_STREAM the overflow with REFUSED_STREAM, which is a different fault.
+  // Honor the initial command's settings at construction; this is the
+  // connection-level property tests assert against.
+  const initialSettings: http2.Settings = {};
+  if (opts.command?.settings?.maxConcurrentStreams !== undefined) {
+    initialSettings.maxConcurrentStreams =
+      opts.command.settings.maxConcurrentStreams;
+  }
+
+  const server = http2.createSecureServer({
+    cert,
+    key,
+    ALPNProtocols: ["h2"],
+    settings: initialSettings,
+  });
+
+  // Do not crash the test process on the faults we deliberately inject.
+  server.on("error", () => {});
+  server.on("sessionError", () => {});
+  server.on("session", (session) => {
+    session.on("error", () => {});
+  });
+
+  server.on("stream", (stream, headers) => {
+    streamsOpened += 1;
+    const myStreamOrdinal = streamsOpened;
+    const cmd = activeCommand;
+
+    const method = String(headers[HTTP2_HEADER_METHOD] ?? "GET");
+    const path = String(headers[HTTP2_HEADER_PATH] ?? "/");
+
+    // Buffer the request body so the echo baseline can return it verbatim and
+    // exactly-once assertions can inspect what was actually sent.
+    const chunks: Buffer[] = [];
+    stream.on("data", (c: Buffer) => chunks.push(c));
+    stream.on("error", () => {});
+
+    stream.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      const record: RecordedRequest = {
+        method,
+        path,
+        headers,
+        body,
+        index: requests.length + 1,
+      };
+      requests.push(record);
+
+      // GOAWAY-before-response: once enough streams have opened, tear the
+      // session down without answering this stream.
+      if (
+        cmd.goawayAfterStreams !== undefined &&
+        myStreamOrdinal >= cmd.goawayAfterStreams
+      ) {
+        stream.session?.goaway(NGHTTP2_NO_ERROR);
+        return;
+      }
+
+      // RST_STREAM with an explicit nghttp2 code (e.g. ENHANCE_YOUR_CALM=11).
+      // When `forPaths` is set, only matching paths are RST'd; the rest fall
+      // through to the baseline 200 echo (per-stream isolation under load).
+      if (
+        cmd.rstStreamWith &&
+        (cmd.rstStreamWith.forPaths === undefined ||
+          cmd.rstStreamWith.forPaths.includes(path))
+      ) {
+        stream.close(cmd.rstStreamWith.code);
+        return;
+      }
+
+      // Destroy the socket mid-flight (models an abrupt connection drop).
+      if (cmd.destroySocketMid) {
+        stream.session?.destroy();
+        return;
+      }
+
+      // Stream headers + a first body chunk, then keep the response open for a
+      // bounded window before ending. Lets a test abort while the client's
+      // response body stream is still readable.
+      if (cmd.respondThenHoldBodyMs && cmd.respondThenHoldBodyMs > 0) {
+        if (stream.closed || stream.destroyed) return;
+        stream.respond({
+          [HTTP2_HEADER_STATUS]: 200,
+          "content-type": "text/plain; charset=utf-8",
+          "x-echo-method": method,
+          "x-echo-path": path,
+        });
+        stream.write("chunk-1");
+        const timer = setTimeout(() => {
+          pendingTimers.delete(timer);
+          if (!stream.closed && !stream.destroyed) stream.end("chunk-2");
+        }, cmd.respondThenHoldBodyMs);
+        pendingTimers.add(timer);
+        return;
+      }
+
+      const respond = () => {
+        if (stream.closed || stream.destroyed) return;
+        stream.respond({
+          [HTTP2_HEADER_STATUS]: 200,
+          "content-type": "text/plain; charset=utf-8",
+          "x-echo-method": method,
+          "x-echo-path": path,
+        });
+        // Baseline echoes the request body so tests can assert round-trip.
+        stream.end(body);
+      };
+
+      if (cmd.delayResponseMs && cmd.delayResponseMs > 0) {
+        const timer = setTimeout(() => {
+          pendingTimers.delete(timer);
+          respond();
+        }, cmd.delayResponseMs);
+        pendingTimers.add(timer);
+        return;
+      }
+
+      respond();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addressInfo = server.address();
+  if (addressInfo === null || typeof addressInfo === "string") {
+    throw new Error("H2 fault server failed to bind to a TCP port");
+  }
+  const port = addressInfo.port;
+  const address = "127.0.0.1";
+  const url = `https://${address}:${port}`;
+
+  const clientSessions = new Set<http2.ClientHttp2Session>();
+
+  const connectClient = (): http2.ClientHttp2Session => {
+    const session = http2.connect(url, {
+      rejectUnauthorized: false,
+      ALPNProtocols: ["h2"],
+    });
+    // Swallow client-side session errors caused by injected faults; the
+    // transport-under-test installs its own listeners and rejects callers.
+    session.on("error", () => {});
+    clientSessions.add(session);
+    session.once("close", () => clientSessions.delete(session));
+    return session;
+  };
+
+  const command = (cmd: FaultCommand): void => {
+    activeCommand = cmd;
+  };
+
+  const reset = (): void => {
+    activeCommand = {};
+    streamsOpened = 0;
+    requests.length = 0;
+  };
+
+  const close = async (): Promise<void> => {
+    for (const timer of pendingTimers) clearTimeout(timer);
+    pendingTimers.clear();
+    for (const session of clientSessions) {
+      if (!session.closed && !session.destroyed) session.destroy();
+    }
+    clientSessions.clear();
+    await new Promise<void>((resolve) => {
+      // close() waits for open connections; destroy any stragglers so the
+      // listening handle is released promptly and the test process exits.
+      server.close(() => resolve());
+      (server as unknown as { closeIdleConnections?: () => void })
+        .closeIdleConnections?.();
+    });
+  };
+
+  return {
+    url,
+    port,
+    address,
+    connectClient,
+    requests,
+    command,
+    reset,
+    close,
+  };
+}

--- a/tests/integration/fault-injection/h2-protocol-races.test.ts
+++ b/tests/integration/fault-injection/h2-protocol-races.test.ts
@@ -1,0 +1,185 @@
+// Harness: _h2Send state-machine ordering
+//
+// Locks the event-ordering guarantees of the `_h2Send` state machine
+// (h2fetch.ts:286-440) against the real `createH2Fetch` transport over real
+// fault-harness sessions:
+//   - abort BEFORE response  -> pre-flight/early reject with AbortError, no hang
+//     (h2fetch.ts:350-379).
+//   - abort DURING streaming -> the response body stream errors with AbortError
+//     once headers have arrived and the body stream is still open
+//     (h2fetch.ts:362-366), no unhandled rejection.
+//   - GOAWAY/RST racing 200s across concurrent streams on ONE session -> per-stream
+//     isolation: the 200s resolve, the RST'd ones reject; one bad stream does not
+//     kill its siblings (the per-stream `req.on("error")` at h2fetch.ts:412/426).
+//   - listener hygiene -> after many sequential requests on one session, the
+//     session's close/goaway/error listener counts return to baseline (no
+//     per-request leak), tying to ensureH2SessionListenerBudget (h2fetch.ts:442-450).
+//
+// Determinism: real timers are used only for the bounded streaming-hold window
+// (<=120ms) and the slow-response overlap; control is otherwise event-driven.
+import http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import { startH2FaultServer, type H2FaultServer } from "./h2-fault-server.js";
+
+let server: H2FaultServer | undefined;
+let session: http2.ClientHttp2Session | undefined;
+
+afterEach(async () => {
+  if (session && !session.destroyed) session.destroy();
+  session = undefined;
+  if (server) await server.close();
+  server = undefined;
+});
+
+async function connect(cmd?: Parameters<typeof startH2FaultServer>[0]): Promise<void> {
+  server = await startH2FaultServer(cmd);
+  session = server.connectClient();
+  await new Promise<void>((resolve) => session!.once("connect", () => resolve()));
+}
+
+/** Read a ReadableStream to completion, returning the decoded text. */
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) out += decoder.decode(value, { stream: true });
+  }
+  return out + decoder.decode();
+}
+
+describe("_h2Send protocol-race ordering", () => {
+  it("abort BEFORE response: an already-aborted signal rejects with AbortError and hangs nothing", async () => {
+    await connect();
+    const h2fetch = createH2Fetch(session!);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    let caught: Error | undefined;
+    try {
+      await h2fetch(
+        new Request(`${server!.url}/pre-abort`, { signal: controller.signal }),
+      );
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught!.name).toBe("AbortError");
+  });
+
+  it("abort DURING streaming: the response body stream errors with AbortError, no unhandled rejection", async () => {
+    // Server sends headers + 'chunk-1' immediately, then holds the response open.
+    await connect({ command: { respondThenHoldBodyMs: 120 } });
+    const h2fetch = createH2Fetch(session!);
+
+    const controller = new AbortController();
+    const res = await h2fetch(
+      new Request(`${server!.url}/stream`, { signal: controller.signal }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).not.toBeNull();
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // First chunk arrives; the body stream is open.
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(decoder.decode(first.value)).toBe("chunk-1");
+
+    // Abort while the body stream is still open -> the stream errors.
+    controller.abort();
+
+    let streamError: Error | undefined;
+    try {
+      await reader.read();
+    } catch (err) {
+      streamError = err as Error;
+    }
+    expect(streamError).toBeDefined();
+    expect(streamError!.name).toBe("AbortError");
+  });
+
+  it("GOAWAY/RST racing 200s on ONE session: siblings are isolated (200s resolve, RST'd reject)", async () => {
+    // RST only the /bad-* paths; every other path gets a baseline 200 echo. All
+    // requests share ONE session, so this proves a per-stream RST does not kill
+    // the sibling streams.
+    await connect({
+      command: {
+        rstStreamWith: {
+          code: http2.constants.NGHTTP2_ENHANCE_YOUR_CALM,
+          forPaths: ["/bad-0", "/bad-1"],
+        },
+      },
+    });
+    const h2fetch = createH2Fetch(session!);
+
+    const goodPaths = ["/good-0", "/good-1", "/good-2"];
+    const badPaths = ["/bad-0", "/bad-1"];
+
+    const settled = await Promise.allSettled(
+      [...goodPaths, ...badPaths].map((p) =>
+        h2fetch(new Request(`${server!.url}${p}`)).then(async (r) => {
+          // Drain the body so the stream completes cleanly.
+          await r.text();
+          return r.status;
+        }),
+      ),
+    );
+
+    const byPath = new Map(
+      [...goodPaths, ...badPaths].map((p, i) => [p, settled[i]]),
+    );
+
+    for (const p of goodPaths) {
+      const r = byPath.get(p)!;
+      expect(r.status).toBe("fulfilled");
+      expect((r as PromiseFulfilledResult<number>).value).toBe(200);
+    }
+    for (const p of badPaths) {
+      const r = byPath.get(p)!;
+      expect(r.status).toBe("rejected");
+      expect((r as PromiseRejectedResult).reason).toMatchObject({
+        code: "ERR_HTTP2_STREAM_ERROR",
+      });
+    }
+
+    // The session itself survived the RST'd streams and stays usable.
+    expect(session!.closed).toBe(false);
+    expect(session!.destroyed).toBe(false);
+  });
+
+  it("listener hygiene: per-request close/goaway/error listeners return to baseline after N requests", async () => {
+    await connect();
+
+    // Baseline AFTER connect: the harness's connectClient() installs one
+    // `error` and one `close` listener of its own, so the floor is not zero.
+    const baseline = {
+      close: session!.listenerCount("close"),
+      goaway: session!.listenerCount("goaway"),
+      error: session!.listenerCount("error"),
+    };
+
+    const h2fetch = createH2Fetch(session!);
+    const N = 40;
+    for (let i = 0; i < N; i++) {
+      const res = await h2fetch(new Request(`${server!.url}/n${i}`));
+      // Fully consume the body so the per-request listeners are torn down.
+      await readAll(res.body!);
+    }
+
+    // No per-request leak: counts are back at the post-connect baseline.
+    expect(session!.listenerCount("close")).toBe(baseline.close);
+    expect(session!.listenerCount("goaway")).toBe(baseline.goaway);
+    expect(session!.listenerCount("error")).toBe(baseline.error);
+
+    // The listener budget was raised once for the session (h2fetch.ts:442-450),
+    // so the per-request adds never tripped MaxListenersExceededWarning.
+    expect(session!.getMaxListeners()).toBeGreaterThanOrEqual(64);
+  });
+});

--- a/tests/integration/fault-injection/vitest.faultharness.config.ts
+++ b/tests/integration/fault-injection/vitest.faultharness.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Isolated config for the HTTP/2 fault-injection harness + regression corpus.
+ *
+ * Deliberately omits the root config's globalSetup (which lists live sandboxes
+ * and needs BL_API_KEY) so these tests run with NO network and NO creds. The
+ * same globs are also matched by the ROOT vitest config's `tests/**\/*.test.ts`
+ * include, so CI picks them up; this config just lets us prove them green in
+ * isolation.
+ */
+export default defineConfig({
+  test: {
+    include: [
+      "tests/integration/fault-injection/**/*.test.ts",
+      "tests/integration/regressions/**/*.test.ts",
+    ],
+    globals: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    reporters: ["verbose"],
+  },
+});

--- a/tests/integration/regressions/ENG-2340-no-silent-retry-dup.test.ts
+++ b/tests/integration/regressions/ENG-2340-no-silent-retry-dup.test.ts
@@ -1,0 +1,61 @@
+// Regression: ENG-2340
+//
+// ENG-2340 was a silent timeout-retry that DUPLICATED a non-idempotent POST:
+// a slow request would hit a 10s transport timeout, get retried, and the server
+// would process it twice (e.g. "process already exists"). The fix removed the
+// transport-level timeout-retry entirely (the transport never retries; that is
+// now a caller concern — see the ENG-2342 doctrine).
+//
+// This test locks in today's behavior against the real `createH2Fetch`
+// transport + a real H2 server: a slow POST to /process must produce EXACTLY
+// ONE request/stream on the wire, and the client must resolve to that single
+// response. If the transport ever silently retries a slow POST again, the
+// recorded-request count would exceed 1 and this test fails.
+//
+// Determinism: the server delays its response by 200ms (real timer, kept tiny).
+// The current transport has NO sub-2-minute timeout (its only safety timer is
+// the 120s per-domain slot release, which does not cancel the request), so a
+// 200ms delay is more than enough to prove no retry fires while staying fast.
+import { afterEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import {
+  startH2FaultServer,
+  type H2FaultServer,
+} from "../fault-injection/h2-fault-server.js";
+
+let server: H2FaultServer | undefined;
+
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+});
+
+describe("ENG-2340: transport never silently retries/duplicates a slow POST", () => {
+  it("sends EXACTLY ONE request for a slow non-idempotent POST and resolves to its single response", async () => {
+    // Model a slow non-idempotent POST: the server holds the response 200ms.
+    server = await startH2FaultServer({ command: { delayResponseMs: 200 } });
+    const session = server.connectClient();
+    const h2fetch = createH2Fetch(session);
+
+    const res = await h2fetch(
+      new Request(`${server.url}/process`, {
+        method: "POST",
+        body: JSON.stringify({ name: "job-1" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    // The client resolves to the one and only response the server produced.
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe(JSON.stringify({ name: "job-1" }));
+
+    // The crux: the server received the POST to /process exactly once. No
+    // silent retry, no duplicate stream.
+    const processRequests = server.requests.filter((r) => r.path === "/process");
+    expect(processRequests).toHaveLength(1);
+    expect(server.requests).toHaveLength(1);
+    expect(processRequests[0].method).toBe("POST");
+
+    session.destroy();
+  });
+});

--- a/tests/integration/regressions/ENG-2342-transport-never-retries.test.ts
+++ b/tests/integration/regressions/ENG-2342-transport-never-retries.test.ts
@@ -1,0 +1,72 @@
+// Regression: ENG-2342
+//
+// Doctrine: once a request has been put on the wire (post-flight), the
+// transport NEVER transparently retries. Any failure after `session.request()`
+// succeeds — RST_STREAM, mid-flight socket drop, GOAWAY — propagates to the
+// caller as a rejection. Retry/timeout policy is a caller concern.
+//
+// This pins that doctrine against the real `createH2Fetch` transport + a real
+// H2 server: a post-flight stream error (RST_STREAM) must reject AND must NOT
+// be followed by a second request/stream for the same path. (The pre-flight
+// fallback to globalThis.fetch is a separate path, only taken when the session
+// is already closed/destroyed at call time and nothing was sent — not exercised
+// here.)
+import http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import {
+  startH2FaultServer,
+  type H2FaultServer,
+} from "../fault-injection/h2-fault-server.js";
+
+let server: H2FaultServer | undefined;
+
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+});
+
+describe("ENG-2342: transport never retries post-flight", () => {
+  it("rejects on a post-flight RST_STREAM without sending a second request", async () => {
+    server = await startH2FaultServer({
+      command: {
+        rstStreamWith: { code: http2.constants.NGHTTP2_INTERNAL_ERROR },
+      },
+    });
+    const session = server.connectClient();
+    const h2fetch = createH2Fetch(session);
+
+    await expect(
+      h2fetch(
+        new Request(`${server.url}/process`, { method: "POST", body: "x" }),
+      ),
+    ).rejects.toMatchObject({ code: "ERR_HTTP2_STREAM_ERROR" });
+
+    // Give any (erroneous) retry a chance to land before asserting.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The request reached the server exactly once and was NOT retried after the
+    // stream error. This is the heart of the ENG-2342 doctrine.
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests.filter((r) => r.path === "/process")).toHaveLength(1);
+
+    session.destroy();
+  });
+
+  it("rejects when the socket is destroyed mid-flight, with no retry", async () => {
+    server = await startH2FaultServer({ command: { destroySocketMid: true } });
+    const session = server.connectClient();
+    const h2fetch = createH2Fetch(session);
+
+    // A mid-flight connection drop surfaces as a rejection (session close /
+    // stream error), never a transparent retry.
+    await expect(
+      h2fetch(new Request(`${server.url}/process`, { method: "POST", body: "y" })),
+    ).rejects.toThrow();
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(server.requests.filter((r) => r.path === "/process")).toHaveLength(1);
+
+    session.destroy();
+  });
+});

--- a/tests/integration/regressions/ENG-2422-zombie-session-eviction.test.ts
+++ b/tests/integration/regressions/ENG-2422-zombie-session-eviction.test.ts
@@ -1,0 +1,176 @@
+// Regression: ENG-2422
+//
+// ENG-2422: a pooled H2 session zombified after a long external fetch and the
+// next sandbox call hung on it. The fix (h2pool.ts) added (a) idle-ping
+// validation before reuse (`validateEntry` -> `ping`, h2pool.ts:134-154) and
+// (b) self-healing eviction listeners that delete the cached session as soon as
+// it emits `goaway`/`error`/`close` (`attachEvictionListeners`, h2pool.ts:61-75).
+//
+// These tests wire a REAL `ClientHttp2Session` from the fault harness into a
+// REAL `H2Pool` via the documented `_establish` hook, with a small `maxIdleMs`
+// + an injected `now` so we can force the idle/ping path deterministically, and
+// a small `pingTimeoutMs` so a non-answering ping resolves quickly.
+//
+// FINDING (verified empirically below, and the crux of the ENG-2422 subtlety):
+// Node's `http2` answers PING frames at the protocol level automatically. A
+// session that is socket-alive but DRAINING / refusing new streams still
+// answers PINGs "ok", so the pool's idle-ping liveness check reports it healthy
+// even though a real `session.request()` immediately fails. The idle-ping check
+// therefore CANNOT detect that class of zombie. The ENG-2422 fix actually
+// guards the cases this corpus covers: a session that has become
+// closed/destroyed (Case A: socket dropped -> `close`/`error` eviction) and a
+// session whose ping does not return in time (Case B: ping timeout -> evict).
+// The PING-healthy-but-draining gap is demonstrated as a live test below and is
+// tracked for the pooling / rate-shaping work (ENG-2681) and generation pinning
+// (ENG-2676); it is NOT closed by ENG-2422.
+//
+// Determinism: no wall-clock waits drive control flow. Idle is forced via the
+// injected `now`; ping failure is forced by stubbing the real session's `ping`
+// to never answer so the pool's own `pingTimeoutMs` fires (60ms). Comparisons
+// use raw `===`/`!==` because chai's `toBe(session)` introspects a real
+// `ClientHttp2Session` and throws "this is not a typed array".
+import http2 from "http2";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
+import {
+  startH2FaultServer,
+  type H2FaultServer,
+} from "../fault-injection/h2-fault-server.js";
+
+const DOMAIN = "edge.zombie.example.com";
+
+type EstablishHook = {
+  _establish: (domain: string) => Promise<http2.ClientHttp2Session>;
+};
+
+let server: H2FaultServer | undefined;
+let pool: H2Pool | undefined;
+
+afterEach(async () => {
+  if (pool) pool.closeAll();
+  pool = undefined;
+  if (server) await server.close();
+  server = undefined;
+  vi.restoreAllMocks();
+});
+
+/** Wire a real H2Pool whose establish() returns a fresh real harness session. */
+function makePool(now: () => number): {
+  pool: H2Pool;
+  established: http2.ClientHttp2Session[];
+} {
+  const established: http2.ClientHttp2Session[] = [];
+  const p = new H2Pool({ maxIdleMs: 50, pingTimeoutMs: 60, now });
+  (p as unknown as EstablishHook)._establish = () => {
+    const s = server!.connectClient();
+    established.push(s);
+    return Promise.resolve(s);
+  };
+  return { pool: p, established };
+}
+
+describe("ENG-2422: zombie H2 session is evicted, never handed out", () => {
+  it("Case A: a dropped (close/error) session is evicted; get() returns a fresh, usable one", async () => {
+    server = await startH2FaultServer();
+    let now = 1_000;
+    const made = makePool(() => now);
+    pool = made.pool;
+
+    // Cache a real session via get().
+    const first = await pool.get(DOMAIN);
+    expect(first).not.toBeNull();
+    expect(pool.isUsable(first!)).toBe(true);
+
+    // Drop it server-side by destroying the client session; the eviction
+    // listener fires on `close`, removing it from the cache.
+    const closed = new Promise<void>((resolve) =>
+      first!.once("close", () => resolve()),
+    );
+    first!.destroy();
+    await closed;
+
+    // Advance past idle for good measure, then ask again.
+    now += 1_000;
+    const second = await pool.get(DOMAIN);
+
+    // The dead session must NOT be handed back: a different, usable session
+    // (freshly established) is returned instead.
+    expect(second === first).toBe(false);
+    expect(second).not.toBeNull();
+    expect(second!.closed).toBe(false);
+    expect(second!.destroyed).toBe(false);
+    expect(pool.isUsable(second!)).toBe(true);
+    expect(made.established.length).toBe(2);
+  });
+
+  it("Case B: an idle session whose ping does not answer is evicted (ping timeout), not handed out", async () => {
+    server = await startH2FaultServer();
+    let now = 1_000;
+    const made = makePool(() => now);
+    pool = made.pool;
+
+    const first = await pool.get(DOMAIN);
+    expect(first).not.toBeNull();
+
+    // Make the cached entry idle so the next get() runs the ping liveness check.
+    now += 1_000;
+
+    // Force the ping to never answer so the pool's pingTimeoutMs (60ms) fires
+    // and the session is treated as dead. (Killing the loopback server does not
+    // reliably make a ping fail: the socket is fast and Node auto-answers, so we
+    // drive the timeout branch deterministically by holding the callback.)
+    let pingCalled = false;
+    vi.spyOn(first!, "ping").mockImplementation(((
+      cb?: (err?: Error | null) => void,
+    ) => {
+      pingCalled = true;
+      void cb; // intentionally never invoked -> pool ping times out
+      return true; // report "sent" so the pool waits on the (never-coming) reply
+    }) as unknown as http2.ClientHttp2Session["ping"]);
+
+    const second = await pool.get(DOMAIN);
+
+    // The pool pinged the idle session, the ping timed out, the session was
+    // evicted, and a fresh one was established instead.
+    expect(pingCalled).toBe(true);
+    expect(second === first).toBe(false);
+    expect(second).not.toBeNull();
+    expect(pool.isUsable(second!)).toBe(true);
+    expect(made.established.length).toBe(2);
+  });
+
+  it("FINDING gap: a PING-healthy but stream-refusing session is reported live, yet a real request fails", async () => {
+    // The server refuses every new stream with REFUSED_STREAM but keeps the
+    // connection (and thus PING) alive — the shape of a draining edge.
+    server = await startH2FaultServer({
+      command: { rstStreamWith: { code: http2.constants.NGHTTP2_REFUSED_STREAM } },
+    });
+    const session = server.connectClient();
+    await new Promise<void>((resolve) => session.once("connect", () => resolve()));
+
+    // 1) A protocol-level PING is answered: the liveness check the pool relies
+    //    on would call this session "healthy".
+    const pingHealthy = await new Promise<boolean>((resolve) => {
+      const sent = session.ping((err?: Error | null) => resolve(!err));
+      if (!sent) resolve(false);
+    });
+    expect(pingHealthy).toBe(true);
+    expect(session.closed).toBe(false);
+    expect(session.destroyed).toBe(false);
+
+    // 2) ...yet an actual request on that same "healthy" session fails. This is
+    //    the zombie the idle-ping check cannot see (ENG-2681 / ENG-2676).
+    const requestError = await new Promise<NodeJS.ErrnoException | null>(
+      (resolve) => {
+        const req = session.request({ ":path": "/x", ":method": "GET" });
+        req.on("response", () => resolve(null));
+        req.on("error", (err: NodeJS.ErrnoException) => resolve(err));
+        req.end();
+      },
+    );
+    expect(requestError).not.toBeNull();
+    expect(requestError!.code).toBe("ERR_HTTP2_STREAM_ERROR");
+
+    session.destroy();
+  });
+});

--- a/tests/integration/regressions/PM-2160-ref-unref-early-exit.test.ts
+++ b/tests/integration/regressions/PM-2160-ref-unref-early-exit.test.ts
@@ -1,0 +1,135 @@
+// Regression: PM-2160
+//
+// PM-2160 / commit d6f0745: active H2 requests could exit the Node process early.
+// Every pooled session is `markH2SessionIdleUnref`'d at h2warm.ts:55 so an idle
+// session does not keep the event loop alive — but that left the socket unref'd
+// even WHILE a request was in flight, so Node would exit before the response
+// arrived. The fix (h2ref.ts) re-`ref()`s the session for the duration of an
+// active request and `unref()`s it again once the request completes, with exact
+// refcounting across concurrent requests on the same session.
+//
+// This pins those EXACT semantics against the real `createH2Fetch` transport +
+// `h2ref.ts` over a real harness session that has been `markH2SessionIdleUnref`'d,
+// spying on `session.ref` / `session.unref`.
+//
+// Empirically verified semantics (encoded below):
+//   - markH2SessionIdleUnref on an idle (0 active) session -> unref() immediately.
+//   - first active request 0->1 -> exactly one ref(); request fully drained -> unref().
+//   - two concurrent requests -> ref() once on 0->1; unref() once only after BOTH
+//     complete (refcount back to 0) — never in between.
+//   - releasing the same active-request ref twice does not over-unref (the
+//     release closure is idempotent; h2ref.ts:22-36).
+//   - refH2SessionForActiveRequest is a no-op for a session that was never
+//     idle-unref'd (h2ref.ts:16).
+import http2 from "http2";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import {
+  markH2SessionIdleUnref,
+  refH2SessionForActiveRequest,
+} from "../../../@blaxel/core/src/common/h2ref.js";
+import {
+  startH2FaultServer,
+  type H2FaultServer,
+} from "../fault-injection/h2-fault-server.js";
+
+let server: H2FaultServer | undefined;
+let session: http2.ClientHttp2Session | undefined;
+
+afterEach(async () => {
+  if (session && !session.destroyed) session.destroy();
+  session = undefined;
+  if (server) await server.close();
+  server = undefined;
+  vi.restoreAllMocks();
+});
+
+async function connect(cmd?: Parameters<typeof startH2FaultServer>[0]): Promise<void> {
+  server = await startH2FaultServer(cmd);
+  session = server.connectClient();
+  await new Promise<void>((resolve) => session!.once("connect", () => resolve()));
+}
+
+describe("PM-2160: active H2 requests ref the session; idle ones stay unref'd", () => {
+  it("single request: idle-unref'd, then ref() on active, then unref() after the body is fully consumed", async () => {
+    await connect();
+    const refSpy = vi.spyOn(session!, "ref");
+    const unrefSpy = vi.spyOn(session!, "unref");
+
+    // Idle and unref'd: marking unrefs immediately, with no ref() yet.
+    markH2SessionIdleUnref(session!);
+    expect(refSpy).toHaveBeenCalledTimes(0);
+    expect(unrefSpy).toHaveBeenCalledTimes(1);
+
+    const h2fetch = createH2Fetch(session!);
+    const res = await h2fetch(
+      new Request(`${server!.url}/x`, { method: "POST", body: "hello" }),
+    );
+
+    // Request is active: exactly one ref() on the 0->1 transition, no extra unref yet.
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(unrefSpy).toHaveBeenCalledTimes(1);
+
+    // Draining the body to end completes the request and returns to idle: unref().
+    await expect(res.text()).resolves.toBe("hello");
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(unrefSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("two concurrent requests: ref() once on 0->1; unref() only after BOTH complete", async () => {
+    // Hold both responses briefly so the two requests overlap as active.
+    await connect({ command: { delayResponseMs: 60 } });
+    const refSpy = vi.spyOn(session!, "ref");
+    const unrefSpy = vi.spyOn(session!, "unref");
+
+    markH2SessionIdleUnref(session!);
+    const unrefAfterMark = unrefSpy.mock.calls.length; // 1 (idle unref)
+    expect(unrefAfterMark).toBe(1);
+
+    const h2fetch = createH2Fetch(session!);
+    const p1 = h2fetch(new Request(`${server!.url}/a`, { method: "POST", body: "1" }))
+      .then((r) => r.text());
+    const p2 = h2fetch(new Request(`${server!.url}/b`, { method: "POST", body: "2" }))
+      .then((r) => r.text());
+
+    // Wait until both streams are open and active (both ref-counted).
+    await vi.waitFor(() => {
+      expect(refSpy.mock.calls.length).toBe(1);
+    });
+    // While both are in flight: ref() exactly once (0->1), and NO unref beyond
+    // the idle-mark one (refcount has not returned to 0).
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(unrefSpy.mock.calls.length - unrefAfterMark).toBe(0);
+
+    await expect(Promise.all([p1, p2])).resolves.toEqual(["1", "2"]);
+
+    // Both complete -> refcount back to 0 -> exactly one unref() for the pair.
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(unrefSpy.mock.calls.length - unrefAfterMark).toBe(1);
+  });
+
+  it("idempotency: releasing the same active-request ref twice does not over-unref (h2ref.ts:22-36)", async () => {
+    await connect();
+    markH2SessionIdleUnref(session!);
+    const unrefSpy = vi.spyOn(session!, "unref");
+
+    const release = refH2SessionForActiveRequest(session!);
+    release();
+    expect(unrefSpy).toHaveBeenCalledTimes(1);
+    // Second release is a no-op: the closure guards with `released` (h2ref.ts:25).
+    release();
+    expect(unrefSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-op for a session that was never idle-unref'd (h2ref.ts:16): neither ref() nor unref()", async () => {
+    await connect();
+    const refSpy = vi.spyOn(session!, "ref");
+    const unrefSpy = vi.spyOn(session!, "unref");
+
+    // Not marked idle-unref -> refH2SessionForActiveRequest returns a no-op.
+    const release = refH2SessionForActiveRequest(session!);
+    expect(refSpy).toHaveBeenCalledTimes(0);
+    release();
+    expect(unrefSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/tests/integration/regressions/h2pool-get-validate-race.test.ts
+++ b/tests/integration/regressions/h2pool-get-validate-race.test.ts
@@ -1,0 +1,132 @@
+// Regression: ENG-2676 — TRIPWIRE for a KNOWN bug (generation pinning)
+//
+// There is a real get/validate race in H2Pool. `validateEntry` does:
+//     const { session } = entry;            // h2pool.ts:139  (captures session)
+//     ...
+//     if (await this.ping(session)) {       // h2pool.ts:148  (awaits — yields!)
+//       this.markUsed(domain, session);     // h2pool.ts:149
+//       return session;                     // h2pool.ts:150  (returns CAPTURED session)
+//     }
+// If an eviction listener (goaway/error/close -> attachEvictionListeners,
+// h2pool.ts:61-75) deletes the entry from the map DURING the `await this.ping`,
+// `validateEntry` still returns the now-stale `session` it captured before the
+// await. `markUsed` is a no-op once the entry is gone (it only updates when
+// `entry?.session === session`, h2pool.ts:92-97), but the stale session is
+// returned to the caller regardless. That is the zombie ENG-2422 tried to kill,
+// re-entering through the validate race. The durable fix is generation/identity
+// pinning (ENG-2676): re-check the map after the ping and refuse a session that
+// is no longer the cached generation.
+//
+// This test drives the REAL H2Pool with a controllable MockSession whose
+// `ping(cb)` HOLDS the callback, so we deterministically interleave a `goaway`
+// eviction into the middle of the ping await.
+//
+// FINDING: ENG-2676. The assertion below is written for the CORRECT (post-fix)
+// behavior: get() must NOT resolve to the evicted session. Because the current
+// code IS buggy (it returns the stale session — verified empirically), this is a
+// LIVE TRIPWIRE using `it.fails`: it passes ONLY while the bug is present.
+//   >>> When ENG-2676 (generation pinning) lands, flip `it.fails` -> `it`. <<<
+// At that point get() will return null / a fresh session, the inner assertion
+// will pass, and `it.fails` will start FAILING — which is the signal to flip it.
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
+
+const DOMAIN = "edge.race.example.com";
+
+type EstablishHook = {
+  _establish: (domain: string) => Promise<http2.ClientHttp2Session>;
+};
+
+/**
+ * Controllable session stand-in. `ping(cb)` records and HOLDS the callback so a
+ * test controls exactly when the liveness check resolves; events (`goaway`)
+ * are emitted directly to trigger the pool's eviction listeners.
+ */
+class HoldPingSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  public pingCalls = 0;
+  public heldPingCb: ((err?: Error | null) => void) | null = null;
+
+  ping(cb?: (err?: Error | null) => void): boolean {
+    this.pingCalls += 1;
+    this.heldPingCb = cb ?? null;
+    return true; // "sent" — the pool now waits for heldPingCb / its own timeout
+  }
+  close(): void {
+    this.closed = true;
+    this.emit("close");
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+let pool: H2Pool | undefined;
+
+afterEach(() => {
+  if (pool) pool.closeAll();
+  pool = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("ENG-2676: H2Pool get/validate race (TRIPWIRE)", () => {
+  // TRIPWIRE: passes ONLY while the bug exists. When ENG-2676 generation
+  // pinning lands, change `it.fails(` to `it(` — see the file header.
+  it.fails(
+    "get() must NOT return a session evicted (goaway) during the ping await",
+    async () => {
+      let now = 1_000;
+      const stale = new HoldPingSession();
+      const fresh = new HoldPingSession();
+      let establishCount = 0;
+
+      // Large pingTimeoutMs so the pool waits on our held callback, never its timer.
+      pool = new H2Pool({ maxIdleMs: 50, pingTimeoutMs: 10_000, now: () => now });
+      (pool as unknown as EstablishHook)._establish = (() => {
+        establishCount += 1;
+        const s = establishCount === 1 ? stale : fresh;
+        return Promise.resolve(s as unknown as http2.ClientHttp2Session);
+      }) as EstablishHook["_establish"];
+
+      // Cache the (soon-to-be-stale) session and attach eviction listeners.
+      const firstSession = await pool.get(DOMAIN);
+      expect(firstSession === (stale as unknown)).toBe(true);
+
+      // Make the entry idle so the next get() runs validateEntry -> ping.
+      now += 1_000;
+
+      // Start get(): validateEntry captures `session`, then awaits ping (held).
+      const getPromise = pool.get(DOMAIN);
+      await tick();
+      expect(stale.pingCalls).toBe(1);
+      expect(stale.heldPingCb).not.toBeNull();
+
+      // DURING the held ping, the session emits goaway -> eviction listener
+      // deletes it from the pool's map (h2pool.ts:61-75).
+      stale.emit("goaway");
+      await tick();
+
+      // Now resolve the held ping as SUCCESS (the trap: validate returns the
+      // captured-but-now-evicted session).
+      stale.heldPingCb!(null);
+
+      const got = await getPromise;
+
+      // CORRECT post-ENG-2676 behavior: the evicted session must not be handed
+      // out. Today's buggy code returns `stale`, so this assertion throws and
+      // `it.fails` records the test as PASSING. When the fix lands, this passes
+      // and `it.fails` flips to failing — flip it.fails -> it then.
+      expect(got === (stale as unknown)).toBe(false);
+    },
+  );
+});

--- a/tests/unit/filesystem-part-retry.test.ts
+++ b/tests/unit/filesystem-part-retry.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadPartResponse,
+  SuccessResponse,
+} from "../../@blaxel/core/src/sandbox/client/index.js";
+import { SandboxFileSystem } from "../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+import { settings } from "../../@blaxel/core/src/common/settings.js";
+
+type MultipartUploadHarness = {
+  uploadWithMultipart(
+    path: string,
+    blob: Blob,
+    permissions?: string,
+  ): Promise<SuccessResponse>;
+  initiateMultipartUpload(
+    path: string,
+    permissions?: string,
+  ): Promise<MultipartInitiateResponse>;
+  uploadPart(
+    uploadId: string,
+    partNumber: number,
+    fileBlob: Blob,
+  ): Promise<MultipartUploadPartResponse>;
+  completeMultipartUpload(
+    uploadId: string,
+    parts: Array<MultipartPartInfo>,
+  ): Promise<SuccessResponse>;
+  abortMultipartUpload(uploadId: string): Promise<SuccessResponse>;
+};
+
+function createMultipartHarness(): MultipartUploadHarness {
+  return Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+}
+
+// A blob just over the 5MB multipart threshold yields exactly two parts (the
+// 5MB chunk size means ceil(6MB / 5MB) === 2). The tests below target a single
+// part (part 2) for failure so retry counts for that part are unambiguous.
+function multiPartBlob(): Blob {
+  return new Blob([new Uint8Array(6 * 1024 * 1024)]);
+}
+
+describe("SandboxFileSystem part-upload retry", () => {
+  afterEach(() => {
+    delete settings.config.fsPartRetries;
+  });
+
+  /**
+   * Build a harness whose part 1 always succeeds and whose part 2 rejects with
+   * `error` until `failTimes` rejections have been produced, then succeeds.
+   * Returns a getter for the number of times part 2 was attempted.
+   */
+  function harnessFailingPart2(
+    error: unknown,
+    failTimes = Number.POSITIVE_INFINITY,
+  ): { harness: MultipartUploadHarness; part2Attempts: () => number } {
+    const harness = createMultipartHarness();
+    let part2Attempts = 0;
+    harness.initiateMultipartUpload = () => Promise.resolve({ uploadId: "u" });
+    harness.uploadPart = (_uploadId, partNumber) => {
+      if (partNumber !== 2) {
+        return Promise.resolve({ partNumber, etag: `etag-${partNumber}` });
+      }
+      part2Attempts++;
+      if (part2Attempts <= failTimes) {
+        return Promise.reject(error);
+      }
+      return Promise.resolve({ partNumber, etag: `etag-${partNumber}` });
+    };
+    harness.completeMultipartUpload = () =>
+      Promise.resolve({ message: "completed" });
+    harness.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+    return { harness, part2Attempts: () => part2Attempts };
+  }
+
+  describe("transient error classification", () => {
+    beforeEach(() => {
+      settings.config.fsPartRetries = 3;
+    });
+
+    it("retries an ECONNRESET error code on the cause", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("fetch failed"), {
+          cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+        }),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("retries an ENHANCE_YOUR_CALM H2 reset marker", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("HTTP/2 stream reset: ENHANCE_YOUR_CALM"),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("retries the transport's own GOAWAY-before-response message", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("HTTP/2 session sent GOAWAY before response"),
+        1,
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).resolves.toEqual({ message: "completed" });
+      expect(part2Attempts()).toBe(2);
+    });
+
+    it("does NOT retry a bare 'fetch failed' with no transport code (avoids over-matching)", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("fetch failed"),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("fetch failed");
+      // No retry: the error never qualified as transient.
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("does NOT retry an application 'INTERNAL_ERROR' response body (avoids over-matching)", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error('{"error":"INTERNAL_ERROR: disk full"}'),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("INTERNAL_ERROR");
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("does NOT retry an ordinary 4xx validation error", async () => {
+      const { harness, part2Attempts } = harnessFailingPart2(
+        new Error("400 Bad Request: invalid part number"),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("400 Bad Request");
+      expect(part2Attempts()).toBe(1);
+    });
+  });
+
+  describe("retry budget", () => {
+    it("is disabled by default (fsPartRetries unset = 0, no retries)", async () => {
+      // No settings.config.fsPartRetries set.
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("reset");
+      // Default-off: exactly one attempt for the failing part, no retry.
+      expect(part2Attempts()).toBe(1);
+    });
+
+    it("stops after exhausting the configured retry budget", async () => {
+      settings.config.fsPartRetries = 2;
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("reset");
+      // 1 initial attempt + 2 retries = 3 total for the failing part.
+      expect(part2Attempts()).toBe(3);
+    });
+  });
+});

--- a/tests/unit/h2-concurrency-cap.test.ts
+++ b/tests/unit/h2-concurrency-cap.test.ts
@@ -1,0 +1,328 @@
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPoolBackedH2Fetch,
+  h2RequestDirectFromPool,
+} from "../../@blaxel/core/src/common/h2fetch.js";
+import { H2Pool } from "../../@blaxel/core/src/common/h2pool.js";
+import { settings } from "../../@blaxel/core/src/common/settings.js";
+
+/**
+ * Minimal ClientHttp2Stream stand-in. Tests drive the response lifecycle by
+ * emitting events directly, so end()/close() are effectively no-ops.
+ */
+class MockStream extends EventEmitter {
+  public closed = false;
+  close(): void {
+    this.closed = true;
+  }
+  end(): void {
+    // no-op
+  }
+}
+
+/**
+ * Minimal ClientHttp2Session stand-in. `request()` records the stream so the
+ * test can resolve or fail it on demand.
+ */
+class MockSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  public lastStream: MockStream | null = null;
+  public streams: MockStream[] = [];
+
+  request(): MockStream {
+    const stream = new MockStream();
+    this.lastStream = stream;
+    this.streams.push(stream);
+    return stream;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.emit("close");
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+function asSession(mock: MockSession): http2.ClientHttp2Session {
+  return mock as unknown as http2.ClientHttp2Session;
+}
+
+/**
+ * Build a pool whose establish() always returns the supplied session for any
+ * domain, so each domain gets its own cached session without real network.
+ */
+function poolReturning(
+  sessionForDomain: (domain: string) => MockSession | null,
+): H2Pool {
+  const pool = new H2Pool();
+  (pool as unknown as { _establish: (d: string) => Promise<MockSession | null> })._establish =
+    (domain: string) => Promise.resolve(sessionForDomain(domain));
+  return pool;
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function resolveStream(stream: MockStream, status = 200): void {
+  stream.emit("response", { ":status": status });
+  stream.emit("end");
+}
+
+describe("h2fetch per-domain concurrency cap", () => {
+  beforeEach(() => {
+    // Cap concurrency at 1 in-flight request per domain so blocking is easy
+    // to observe deterministically.
+    settings.config.maxConcurrentH2Requests = 1;
+  });
+
+  afterEach(() => {
+    delete settings.config.maxConcurrentH2Requests;
+    vi.restoreAllMocks();
+  });
+
+  it("releases the slot after an H2 success so the next request can proceed", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.a.example.com");
+
+    const first = h2fetch(new Request("http://a.example.com/one"));
+    await tick();
+    const firstStream = session.lastStream!;
+    expect(firstStream).not.toBeNull();
+
+    // A second request must not get an H2 stream until the first releases.
+    const second = h2fetch(new Request("http://a.example.com/two"));
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    resolveStream(firstStream);
+    await first;
+
+    // First slot released: the second request now opens its own stream.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot after an H2 error so the next request can proceed", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.b.example.com");
+
+    const first = h2fetch(new Request("http://b.example.com/one", { method: "POST", body: "x" }));
+    await tick();
+    const firstStream = session.lastStream!;
+
+    const second = h2fetch(new Request("http://b.example.com/two", { method: "POST", body: "y" }));
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    firstStream.emit("error", new Error("stream dead"));
+    await expect(first).rejects.toThrow("stream dead");
+
+    // Slot freed despite the error: the queued request now runs.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot when there is no usable session (fetch fallback)", async () => {
+    // Pool returns null (no session), exercising the globalThis.fetch fallback
+    // path. The slot must still be released so a follow-up request proceeds.
+    const pool = poolReturning(() => null);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.c.example.com");
+
+    const first = await h2fetch(new Request("http://c.example.com/one"));
+    expect(await first.text()).toBe("fallback");
+
+    const second = await h2fetch(new Request("http://c.example.com/two"));
+    expect(await second.text()).toBe("fallback");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot when a post-flight error evicts the pooled session", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.evict.example.com");
+
+    // Prime the pool so the session is cached and observable via tryGet().
+    const first = h2fetch(
+      new Request("http://evict.example.com/one", { method: "POST", body: "x" }),
+    );
+    await tick();
+    const firstStream = session.lastStream!;
+    expect(pool.tryGet("edge.evict.example.com")).toBe(session);
+
+    // A second request queues behind the single slot.
+    const second = h2fetch(
+      new Request("http://evict.example.com/two", { method: "POST", body: "y" }),
+    );
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    // Post-flight stream error -> session evicted from the pool AND slot freed.
+    firstStream.emit("error", new Error("stream dead"));
+    await expect(first).rejects.toThrow("stream dead");
+    expect(pool.tryGet("edge.evict.example.com")).toBeNull();
+
+    // Slot was released despite the eviction: the queued request proceeds.
+    await tick();
+    expect(session.streams).toHaveLength(2);
+    resolveStream(session.lastStream!);
+    await second;
+  });
+
+  it("releases the slot on the globalThis.fetch fallback path (h2RequestDirectFromPool)", async () => {
+    const pool = poolReturning(() => null);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    const r1 = await h2RequestDirectFromPool(pool, "edge.d.example.com", "http://d.example.com/one");
+    const r2 = await h2RequestDirectFromPool(pool, "edge.d.example.com", "http://d.example.com/two");
+
+    expect(await r1.text()).toBe("fallback");
+    expect(await r2.text()).toBe("fallback");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot on the unsupported-body fetch fallback (pre-flight)", async () => {
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, "request");
+    const pool = poolReturning(() => session);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("fallback")));
+
+    // FormData cannot be serialized to a Buffer for manual H2 framing, so the
+    // direct-from-pool path falls back to globalThis.fetch before opening a
+    // stream. The slot acquired around the call must still be released.
+    const form1 = new FormData();
+    form1.append("file", new Blob(["a"]), "a.txt");
+    const r1 = await h2RequestDirectFromPool(
+      pool,
+      "edge.e.example.com",
+      "http://e.example.com/one",
+      { method: "PUT", body: form1 },
+    );
+
+    const form2 = new FormData();
+    form2.append("file", new Blob(["b"]), "b.txt");
+    const r2 = await h2RequestDirectFromPool(
+      pool,
+      "edge.e.example.com",
+      "http://e.example.com/two",
+      { method: "PUT", body: form2 },
+    );
+
+    expect(await r1.text()).toBe("fallback");
+    expect(await r2.text()).toBe("fallback");
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves queued requests in FIFO order", async () => {
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.f.example.com");
+    const order: number[] = [];
+
+    // One request holds the single slot; two more queue behind it.
+    const p1 = h2fetch(new Request("http://f.example.com/1")).then(() => order.push(1));
+    await tick();
+    const holdingStream = session.lastStream!;
+
+    const p2 = h2fetch(new Request("http://f.example.com/2")).then(() => order.push(2));
+    await tick();
+    const p3 = h2fetch(new Request("http://f.example.com/3")).then(() => order.push(3));
+    await tick();
+
+    // Only the first request has opened a stream so far.
+    expect(session.streams).toHaveLength(1);
+
+    // Release in sequence; each release should let exactly the next queued
+    // request (in arrival order) open its stream.
+    resolveStream(holdingStream);
+    await p1;
+    await tick();
+    expect(session.streams).toHaveLength(2);
+
+    resolveStream(session.streams[1]);
+    await p2;
+    await tick();
+    expect(session.streams).toHaveLength(3);
+
+    resolveStream(session.streams[2]);
+    await p3;
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("does not let one capped domain block an unrelated domain", async () => {
+    const sessionA = new MockSession();
+    const sessionB = new MockSession();
+    const pool = poolReturning((domain) =>
+      domain === "edge.A.example.com" ? sessionA : sessionB,
+    );
+
+    const fetchA = createPoolBackedH2Fetch(pool, "edge.A.example.com");
+    const fetchB = createPoolBackedH2Fetch(pool, "edge.B.example.com");
+
+    // Saturate domain A's single slot and queue a second A request behind it.
+    const a1 = fetchA(new Request("http://a/one"));
+    await tick();
+    const a1Stream = sessionA.lastStream!;
+    const a2 = fetchA(new Request("http://a/two"));
+    await tick();
+    expect(sessionA.streams).toHaveLength(1); // a2 is queued, blocked.
+
+    // Domain B must be completely unaffected: it gets its slot immediately.
+    const b1 = fetchB(new Request("http://b/one"));
+    await tick();
+    expect(sessionB.streams).toHaveLength(1);
+    resolveStream(sessionB.lastStream!);
+    await expect(b1).resolves.toBeInstanceOf(Response);
+
+    // Now drain domain A.
+    resolveStream(a1Stream);
+    await a1;
+    await tick();
+    expect(sessionA.streams).toHaveLength(2);
+    resolveStream(sessionA.streams[1]);
+    await a2;
+  });
+
+  it("is a no-op when the cap is unset (default behavior, unlimited concurrency)", async () => {
+    delete settings.config.maxConcurrentH2Requests;
+    const session = new MockSession();
+    const pool = poolReturning(() => session);
+    const h2fetch = createPoolBackedH2Fetch(pool, "edge.g.example.com");
+
+    // With no cap, multiple requests open streams concurrently without waiting
+    // for each other to release.
+    void h2fetch(new Request("http://g/1"));
+    void h2fetch(new Request("http://g/2"));
+    void h2fetch(new Request("http://g/3"));
+    await tick();
+
+    expect(session.streams.length).toBe(3);
+  });
+});


### PR DESCRIPTION
**What this is:** new automated tests only. It does not change the SDK, so nothing ships differently to users.

**The problem it addresses:** we keep hitting the same HTTP/2 networking failures, where file uploads and sandbox commands fail under load, and stale connections hang the next call. Each one got fixed once, but nothing stopped it from quietly coming back later.

**What it adds:**
- A small fake HTTP/2 server that can recreate those failures on demand (dropped connections, reset or refused requests, server overload). It runs locally with no internet and no API key, so the tests are fast and reliable.
- One test for each failure we have already fixed, so the fix is locked in and a repeat now fails the build instead of reaching a customer.
- One test that flags a bug we have not fixed yet, so we get an automatic heads-up the day it gets fixed.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated CI job (`h2-reliability-tests`) that runs the in-process HTTP/2 fault-injection and regression suite on every PR. The job uses a standalone vitest config, requires no network or credentials, and gates on both fork and internal PRs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b9a606b0198793df5e1ce39620c9937448637beb.</sup>
<!-- /MENDRAL_SUMMARY -->