### PR TITLE
Fix the HTTP/2 concurrency cap to count open streams, not requests awaiting headers

### DIFF
--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -5,6 +5,17 @@ import { refH2SessionForActiveRequest } from "./h2ref.js";
 
 type H2SendOptions = {
   onH2RequestCreated?: () => void;
+  /**
+   * Release the per-domain concurrency slot acquired by the pool-backed
+   * wrappers. The H2 send path owns this once a request is handed to it: the
+   * slot is held for the OPEN-STREAM lifetime (the same lifetime as the h2ref
+   * active-request ref) and freed from `cleanupActiveRequest()` on every
+   * terminal path, or — for a pre-flight fallback that never opens a stream on
+   * the shared session — released immediately before falling back to
+   * `globalThis.fetch`. Idempotent (see `acquireH2Slot`); defaults to a no-op
+   * for the non-pool transports (`createH2Fetch` / `h2RequestDirect`).
+   */
+  releaseSlot?: () => void;
 };
 
 const MIN_H2_SESSION_MAX_LISTENERS = 64;
@@ -20,14 +31,21 @@ const sessionsWithListenerBudget = new WeakSet<http2.ClientHttp2Session>();
  * (current default behavior: unlimited concurrency).
  */
 
-// Safety timeout for a held slot. A request that never resolves (no response,
-// no error, no abort) would otherwise hold its slot forever and starve every
-// queued request for the same domain. After this window we release the slot
-// and let the underlying request continue or reject on its own; we never
-// cancel the in-flight request here, we only stop it from blocking the queue.
-// Kept deliberately conservative (well above any realistic part-upload time)
-// so it does not interfere with legitimately slow but healthy requests.
-const H2_SLOT_TIMEOUT_MS = 120_000;
+// Last-resort leak guard for a held slot. The slot is now released on the real
+// stream terminal (end / error / abort / cancel / pre-response reject), which
+// always fires, so this timer is a pure backstop for the one residual case: a
+// request that never opens a stream AND never settles (no response, no error,
+// no abort) — it must not pin a slot forever and starve the per-domain queue.
+//
+// When it fires it ONLY frees the queue slot. It NEVER aborts or cancels the
+// underlying request or its response stream: `release` does not touch `req` or
+// the body stream, so a long-lived streaming response keeps flowing. Raised
+// well beyond any legitimate stream lifetime so it cannot interfere with a
+// healthy long-open stream (process.streamLogs / execWithStreaming / port
+// proxy). RESIDUAL: a stream that outlives this backstop would have its slot
+// freed early (the queue could then admit one extra stream); acceptable as a
+// pure backstop, since the slot is otherwise tied to the true stream terminal.
+const H2_SLOT_TIMEOUT_MS = 1_800_000; // 30 minutes
 
 type H2DomainGate = {
   active: number;
@@ -46,10 +64,14 @@ function getH2Gate(domain: string): H2DomainGate {
 }
 
 /**
- * Acquire an in-flight slot for `domain`. Resolves with a release function
- * that is idempotent and FIFO-fair: releasing wakes the longest-waiting
- * queued caller for the same domain. A safety timer also releases the slot
- * if the caller never does, preventing per-domain starvation.
+ * Acquire an OPEN-STREAM slot for `domain`. Resolves with a release function
+ * that is idempotent and FIFO-fair: releasing wakes the longest-waiting queued
+ * caller for the same domain. The slot is held for the lifetime of an OPEN H2
+ * stream — the send path releases it on the stream terminal — so the gate
+ * bounds true concurrent streams on the one shared session, not merely requests
+ * awaiting headers (ENG-2678). A backstop timer releases the slot if a request
+ * neither opens a stream nor ever settles, preventing per-domain starvation;
+ * it never aborts the underlying request (see `H2_SLOT_TIMEOUT_MS`).
  */
 async function acquireH2Slot(domain: string): Promise<() => void> {
   const max = settings.maxConcurrentH2Requests; // 0/undefined = unlimited
@@ -118,6 +140,12 @@ export function createPoolBackedH2Fetch(
   domain: string,
 ): (input: Request) => Promise<Response> {
   return async (input: Request): Promise<Response> => {
+    // Acquire the slot here, but hand its release to the send path: it is held
+    // for the OPEN-STREAM lifetime and freed on the stream terminal. Paths that
+    // never open a stream on the shared session (fetch fallbacks go over a
+    // different connection) release it immediately so they do not count against
+    // the open-stream budget. `rel` is idempotent, so the explicit releases
+    // below are safe even though the send path may also release.
     const rel = await acquireH2Slot(domain);
     try {
       const session = await pool.get(domain);
@@ -128,6 +156,7 @@ export function createPoolBackedH2Fetch(
             onH2RequestCreated: () => {
               h2RequestCreated = true;
             },
+            releaseSlot: rel,
           });
         } catch (err) {
           if (h2RequestCreated) {
@@ -136,9 +165,15 @@ export function createPoolBackedH2Fetch(
           throw err;
         }
       }
-      return await globalThis.fetch(input);
-    } finally {
+      // No usable session: this fetch does not open a stream on the shared
+      // session, so free the slot before falling back.
       rel();
+      return await globalThis.fetch(input);
+    } catch (err) {
+      // Pre-send throw (e.g. pool.get() or Request body read): release the slot
+      // so a failed request never pins it. Idempotent if already released.
+      rel();
+      throw err;
     }
   };
 }
@@ -149,6 +184,9 @@ export async function h2RequestDirectFromPool(
   url: string,
   init?: RequestInit,
 ): Promise<Response> {
+  // See createPoolBackedH2Fetch: the slot is held for the OPEN-STREAM lifetime
+  // and released by the send path on the stream terminal; non-stream fallbacks
+  // release it immediately. `rel` is idempotent.
   const rel = await acquireH2Slot(domain);
   try {
     const session = await pool.get(domain);
@@ -159,6 +197,7 @@ export async function h2RequestDirectFromPool(
           onH2RequestCreated: () => {
             h2RequestCreated = true;
           },
+          releaseSlot: rel,
         });
       } catch (err) {
         if (h2RequestCreated) {
@@ -167,9 +206,12 @@ export async function h2RequestDirectFromPool(
         throw err;
       }
     }
-    return await globalThis.fetch(url, init);
-  } finally {
+    // No usable session: fetch over a different connection, no stream opened.
     rel();
+    return await globalThis.fetch(url, init);
+  } catch (err) {
+    rel();
+    throw err;
   }
 }
 
@@ -192,6 +234,9 @@ function h2RequestDirectInternal(
   options?: H2SendOptions,
 ): Promise<Response> {
   if (session.closed || session.destroyed) {
+    // Pre-flight fallback (session unusable): no stream opens on the shared
+    // session, so free any held slot before going over globalThis.fetch.
+    options?.releaseSlot?.();
     return globalThis.fetch(url, init);
   }
 
@@ -229,7 +274,9 @@ function h2RequestDirectInternal(
     } else {
       // FormData, ReadableStream, Blob, etc. can't be serialized to Buffer
       // for manual H2 framing — fall back to regular fetch (pre-flight,
-      // nothing has been sent on the wire yet).
+      // nothing has been sent on the wire yet). No stream opens on the shared
+      // session, so free any held slot before falling back.
+      options?.releaseSlot?.();
       return globalThis.fetch(url, init);
     }
     if (!h2Headers["content-length"]) {
@@ -299,13 +346,19 @@ function _h2Send(
     let streamClosed = false;
     let req: http2.ClientHttp2Stream | null = null;
     let releaseSessionRef = () => {};
+    // The per-domain open-stream slot (idempotent; no-op for the non-pool
+    // transports). Held for the OPEN-STREAM lifetime and released alongside the
+    // session ref from cleanupActiveRequest() on every terminal path.
+    const releaseSlot = options?.releaseSlot ?? (() => {});
     let abort: (() => void) | null = null;
 
     try {
       req = session.request(h2Headers);
     } catch {
       // Pre-flight fallback: session.request() threw synchronously, so no
-      // H2 frames were sent. Safe to retry over globalThis.fetch.
+      // H2 frames were sent. No stream opened on the shared session, so free
+      // the slot before retrying over globalThis.fetch.
+      releaseSlot();
       globalThis.fetch(fallbackUrl, fallbackInit).then(resolve, reject);
       return;
     }
@@ -321,7 +374,13 @@ function _h2Send(
 
     const cleanupActiveRequest = () => {
       if (abort) signal?.removeEventListener("abort", abort);
+      // Slot and session-ref share the OPEN-STREAM lifetime but stay
+      // independent and each idempotent (PM-2160). Every terminal path funnels
+      // through here exactly once: pre-response reject (close/goaway/error),
+      // abort-before-response, abort-during-stream, stream end, stream error,
+      // and ReadableStream cancel — so the slot is freed once on each.
       releaseSessionRef();
+      releaseSlot();
     };
 
     const rejectBeforeResponse = (err: Error) => {

--- a/tests/integration/fault-injection/h2-fault-server.ts
+++ b/tests/integration/fault-injection/h2-fault-server.ts
@@ -73,6 +73,17 @@ export type FaultCommand = {
    * The hold is bounded and the timer is tracked by `close()`, so it never leaks.
    */
   respondThenHoldBodyMs?: number;
+  /**
+   * Send 200 headers + a first body chunk immediately, then HOLD the response
+   * stream open until the test calls `releaseHeldStreams()`. Unlike
+   * `respondThenHoldBodyMs` this has NO wall-clock timer: it models a long-lived
+   * streaming response (process.streamLogs / port proxy) whose body stays open
+   * indefinitely while headers have already arrived. Used by ENG-2678 to keep a
+   * stream OPEN deterministically so open-stream accounting can be asserted
+   * without timing. Any still-held streams are ended by `close()`, so it never
+   * leaks the listening handle.
+   */
+  holdStreamOpenUntilRelease?: boolean;
 };
 
 export type StartH2FaultServerOptions = {
@@ -88,6 +99,21 @@ export type H2FaultServer = {
   connectClient: () => http2.ClientHttp2Session;
   /** Every request the server has received, in arrival order. */
   requests: RecordedRequest[];
+  /** Number of server-side streams currently open (response not yet ended). */
+  concurrentStreams: () => number;
+  /**
+   * Highest number of server-side streams that were ever open at the same time
+   * over the server's lifetime. With a client-side open-stream cap of N this
+   * must never exceed N; the pre-ENG-2678 release-at-headers gate let it climb
+   * past N for long-lived streaming responses.
+   */
+  peakConcurrentStreams: () => number;
+  /**
+   * End every stream currently held open by `holdStreamOpenUntilRelease`,
+   * closing those response bodies. Deterministic, no timers: pairs with the
+   * `holdStreamOpenUntilRelease` command to open then close a stream on demand.
+   */
+  releaseHeldStreams: () => void;
   /** Replace the active fault command (applies to subsequent requests). */
   command: (cmd: FaultCommand) => void;
   /** Clear fault state and the recorded-request log back to baseline echo. */
@@ -135,6 +161,14 @@ export async function startH2FaultServer(
   const requests: RecordedRequest[] = [];
   let activeCommand: FaultCommand = opts.command ?? {};
   let streamsOpened = 0;
+  // Live open-stream accounting. `concurrentStreams` is incremented when a
+  // stream is created and decremented when it closes; `peak` records the high
+  // water mark so a test can assert a client-side cap was actually enforced.
+  let concurrentStreams = 0;
+  let peakConcurrentStreams = 0;
+  // Streams parked open by `holdStreamOpenUntilRelease`, ended on demand by
+  // `releaseHeldStreams()` (or by `close()` so nothing leaks).
+  const heldStreams = new Set<http2.ServerHttp2Stream>();
   // Track pending timers so close() can clear them and never leak handles.
   const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
 
@@ -168,6 +202,18 @@ export async function startH2FaultServer(
     streamsOpened += 1;
     const myStreamOrdinal = streamsOpened;
     const cmd = activeCommand;
+
+    // Open-stream accounting: a stream is "open" from creation until it closes.
+    // This mirrors true HTTP/2 stream concurrency on the one shared session,
+    // which is exactly what ENG-2678's client-side gate must bound.
+    concurrentStreams += 1;
+    if (concurrentStreams > peakConcurrentStreams) {
+      peakConcurrentStreams = concurrentStreams;
+    }
+    stream.once("close", () => {
+      concurrentStreams -= 1;
+      heldStreams.delete(stream);
+    });
 
     const method = String(headers[HTTP2_HEADER_METHOD] ?? "GET");
     const path = String(headers[HTTP2_HEADER_PATH] ?? "/");
@@ -214,6 +260,23 @@ export async function startH2FaultServer(
       // Destroy the socket mid-flight (models an abrupt connection drop).
       if (cmd.destroySocketMid) {
         stream.session?.destroy();
+        return;
+      }
+
+      // Stream headers + a first body chunk, then HOLD open with no timer until
+      // releaseHeldStreams() ends it. Models a long-lived streaming response
+      // whose body stays open after headers; lets a test keep a stream OPEN
+      // deterministically.
+      if (cmd.holdStreamOpenUntilRelease) {
+        if (stream.closed || stream.destroyed) return;
+        stream.respond({
+          [HTTP2_HEADER_STATUS]: 200,
+          "content-type": "text/plain; charset=utf-8",
+          "x-echo-method": method,
+          "x-echo-path": path,
+        });
+        stream.write("chunk-1");
+        heldStreams.add(stream);
         return;
       }
 
@@ -296,12 +359,21 @@ export async function startH2FaultServer(
   const reset = (): void => {
     activeCommand = {};
     streamsOpened = 0;
+    peakConcurrentStreams = 0;
     requests.length = 0;
+  };
+
+  const releaseHeldStreams = (): void => {
+    for (const stream of heldStreams) {
+      if (!stream.closed && !stream.destroyed) stream.end("chunk-2");
+    }
+    heldStreams.clear();
   };
 
   const close = async (): Promise<void> => {
     for (const timer of pendingTimers) clearTimeout(timer);
     pendingTimers.clear();
+    releaseHeldStreams();
     for (const session of clientSessions) {
       if (!session.closed && !session.destroyed) session.destroy();
     }
@@ -321,6 +393,9 @@ export async function startH2FaultServer(
     address,
     connectClient,
     requests,
+    concurrentStreams: () => concurrentStreams,
+    peakConcurrentStreams: () => peakConcurrentStreams,
+    releaseHeldStreams,
     command,
     reset,
     close,

--- a/tests/integration/regressions/ENG-2678-open-stream-cap.test.ts
+++ b/tests/integration/regressions/ENG-2678-open-stream-cap.test.ts
@@ -1,0 +1,231 @@
+// Regression: ENG-2678
+//
+// ENG-2678: the per-domain HTTP/2 concurrency gate counted requests-AWAITING-
+// HEADERS, not OPEN streams. The slot from `acquireH2Slot(domain)` was released
+// in the pool-backed wrappers' `finally{rel()}` as soon as the inner promise
+// resolved — and that promise resolves on the `"response"` event (headers), with
+// a lazy body `ReadableStream` still open. So a long-lived streaming response
+// (process.streamLogs / execWithStreaming / port proxy) freed its slot at headers
+// while its stream stayed open for minutes, and the gate over-admitted streams
+// onto the one shared session: the exact OPEN-stream overload the cap was meant
+// to prevent.
+//
+// The fix (h2fetch.ts) ties the slot to the OPEN-STREAM lifetime — the SAME
+// lifetime as the h2ref active-request ref — releasing it from
+// `cleanupActiveRequest()` on every terminal path (pre-response reject, abort,
+// stream end/error, ReadableStream cancel). Paths that never open a stream on the
+// shared session (fetch fallbacks) release the slot immediately so they do not
+// count against the open-stream budget. The H2_SLOT_TIMEOUT_MS safety timer is
+// kept ONLY as a last-resort leak guard and NEVER aborts/cancels the request.
+//
+// These tests wire a REAL `ClientHttp2Session` from the fault harness into a REAL
+// `H2Pool` via the documented `_establish` hook and drive `createPoolBackedH2Fetch`,
+// asserting against the harness's server-side open-stream accounting.
+//
+// Determinism: stream A is held OPEN with NO timer (`holdStreamOpenUntilRelease`)
+// and ended on demand (`releaseHeldStreams`). To give request B a genuine, fully
+// event-driven opportunity to (wrongly) open a stream we spin the event loop a
+// bounded number of macrotask turns rather than sleeping a fixed wall-clock span
+// — pre-fix B opens within ~1 turn, post-fix B is slot-blocked and never opens.
+// The authoritative assertion is the server-side PEAK concurrent-stream count,
+// which can only exceed the cap if the gate under-counts open streams.
+import type http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPoolBackedH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
+import { settings } from "../../../@blaxel/core/src/common/settings.js";
+import {
+  startH2FaultServer,
+  type H2FaultServer,
+} from "../fault-injection/h2-fault-server.js";
+
+const DOMAIN = "edge.open-stream.example.com";
+// Macrotask-turn budget for "B had every chance to open a stream". Pre-fix B
+// arrives within ~1 turn over loopback; the budget is generous so a slow CI
+// scheduler cannot make a green (post-fix) run flaky, yet it never sleeps.
+const OPEN_CHANCE_TURNS = 50;
+
+type EstablishHook = {
+  _establish: (domain: string) => Promise<http2.ClientHttp2Session>;
+};
+
+let server: H2FaultServer | undefined;
+let pool: H2Pool | undefined;
+
+afterEach(async () => {
+  delete settings.config.maxConcurrentH2Requests;
+  if (pool) pool.closeAll();
+  pool = undefined;
+  if (server) await server.close();
+  server = undefined;
+});
+
+/** Real H2Pool whose establish() hands out a fresh real harness session. */
+function makePool(): H2Pool {
+  const p = new H2Pool();
+  (p as unknown as EstablishHook)._establish = () =>
+    Promise.resolve(server!.connectClient());
+  return p;
+}
+
+/** Yield one macrotask turn so pending I/O callbacks can run. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Spin the event loop up to `turns` macrotask turns, stopping as soon as
+ * `done()` holds. Returns whether `done()` became true. Fully event-driven: no
+ * fixed wall-clock delay gates control flow.
+ */
+async function spinUntil(done: () => boolean, turns: number): Promise<boolean> {
+  for (let i = 0; i < turns; i++) {
+    if (done()) return true;
+    await tick();
+  }
+  return done();
+}
+
+/** Read a ReadableStream to completion, returning the decoded text. */
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) out += decoder.decode(value, { stream: true });
+  }
+  return out + decoder.decode();
+}
+
+const arrived = (path: string): boolean =>
+  server!.requests.some((r) => r.path === path);
+
+describe("ENG-2678: the H2 gate bounds OPEN streams, not requests-awaiting-headers", () => {
+  it("cap=1: while A's stream is held OPEN, B does not open a stream; B proceeds only after A's stream ends", async () => {
+    server = await startH2FaultServer({
+      command: { holdStreamOpenUntilRelease: true },
+    });
+    settings.config.maxConcurrentH2Requests = 1;
+    pool = makePool();
+    const h2fetch = createPoolBackedH2Fetch(pool, DOMAIN);
+
+    // Request A: server responds with headers + a first chunk, then HOLDS the
+    // stream open. Await A's Response (headers) but do NOT drain its body, so
+    // A's stream stays OPEN on the server.
+    const aRes = await h2fetch(new Request(`${server.url}/stream-a`));
+    expect(aRes.status).toBe(200);
+    expect(await spinUntil(() => arrived("/stream-a"), OPEN_CHANCE_TURNS)).toBe(
+      true,
+    );
+    expect(server.concurrentStreams()).toBe(1);
+
+    // Request B: a second pool-backed request to the SAME domain, started while
+    // A's stream is still open. Under an OPEN-stream cap it must QUEUE behind
+    // A's slot and NOT open a stream on the shared session.
+    let bSettled = false;
+    const bResP = h2fetch(new Request(`${server.url}/stream-b`)).then((r) => {
+      bSettled = true;
+      return r;
+    });
+
+    // Give B every chance to (wrongly) open a stream: spin the event loop until
+    // B arrives OR the turn budget is exhausted. Pre-fix A's slot freed at
+    // headers and B opens here within ~1 turn; post-fix B is slot-blocked.
+    await spinUntil(() => arrived("/stream-b"), OPEN_CHANCE_TURNS);
+    expect(arrived("/stream-b")).toBe(false);
+    expect(bSettled).toBe(false);
+    // The crux: peak server-side concurrency never exceeded the cap of 1.
+    expect(server.concurrentStreams()).toBe(1);
+    expect(server.peakConcurrentStreams()).toBe(1);
+
+    // End A's held stream. A's slot is released on the stream terminal, so B's
+    // queued acquire now wakes and B opens its stream. (Only A is held at this
+    // point, so this ends A alone.)
+    server.releaseHeldStreams();
+    await expect(readAll(aRes.body!)).resolves.toBe("chunk-1chunk-2");
+
+    // B opens and responds only now that A's stream has terminated.
+    const bRes = await bResP;
+    expect(bRes.status).toBe(200);
+    expect(bSettled).toBe(true);
+    // B's stream is itself held open; end it so its body completes.
+    server.releaseHeldStreams();
+    await expect(readAll(bRes.body!)).resolves.toBe("chunk-1chunk-2");
+
+    // Both ran, but never at the same time: the gate bounded OPEN streams.
+    expect(server.requests.map((r) => r.path).sort()).toEqual([
+      "/stream-a",
+      "/stream-b",
+    ]);
+    expect(server.peakConcurrentStreams()).toBe(1);
+  });
+
+  it("default-off (cap unset): both requests open streams concurrently (byte-for-byte no-op)", async () => {
+    server = await startH2FaultServer({
+      command: { holdStreamOpenUntilRelease: true },
+    });
+    // No cap set: the gate must be a pure no-op (unlimited concurrency).
+    pool = makePool();
+    const h2fetch = createPoolBackedH2Fetch(pool, DOMAIN);
+
+    const aRes = await h2fetch(new Request(`${server.url}/a`));
+    const bRes = await h2fetch(new Request(`${server.url}/b`));
+    expect(aRes.status).toBe(200);
+    expect(bRes.status).toBe(200);
+
+    // Both streams are held open AT THE SAME TIME: peak concurrency is 2, proving
+    // the gate did not serialize them.
+    expect(
+      await spinUntil(() => server!.concurrentStreams() === 2, OPEN_CHANCE_TURNS),
+    ).toBe(true);
+    expect(server.peakConcurrentStreams()).toBe(2);
+
+    server.releaseHeldStreams();
+    await expect(readAll(aRes.body!)).resolves.toBe("chunk-1chunk-2");
+    await expect(readAll(bRes.body!)).resolves.toBe("chunk-1chunk-2");
+  });
+
+  it("a long-open stream is not aborted/cancelled by the slot lifecycle (safety-timer is a non-disruptive backstop)", async () => {
+    // With cap=1 and A's stream held open, A holds its slot for the whole open-
+    // stream lifetime. The slot machinery (incl. the H2_SLOT_TIMEOUT_MS backstop)
+    // must NEVER abort or cancel the underlying request/stream — it only frees
+    // the queue slot. We assert this structurally, without a wall-clock wait:
+    // A's still-open stream is never errored/closed by the slot path while held,
+    // and ending it server-side delivers the full payload + a clean EOF (an
+    // abort/cancel would instead surface an error on the body reader).
+    server = await startH2FaultServer({
+      command: { holdStreamOpenUntilRelease: true },
+    });
+    settings.config.maxConcurrentH2Requests = 1;
+    pool = makePool();
+    const h2fetch = createPoolBackedH2Fetch(pool, DOMAIN);
+
+    const aRes = await h2fetch(new Request(`${server.url}/long-stream`));
+    expect(aRes.status).toBe(200);
+    const reader = (
+      aRes.body as ReadableStream<Uint8Array>
+    ).getReader();
+    const decoder = new TextDecoder();
+
+    // First chunk arrives and the body stream is open.
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(decoder.decode(first.value)).toBe("chunk-1");
+
+    // Spin the loop: nothing in the slot path errors or closes the still-open
+    // stream while it is held (the no-abort property).
+    await spinUntil(() => false, OPEN_CHANCE_TURNS);
+    expect(server.concurrentStreams()).toBe(1);
+
+    // The stream is intact: ending it server-side delivers the final chunk and a
+    // clean EOF — never an abort/cancel error.
+    server.releaseHeldStreams();
+    const second = await reader.read();
+    expect(second.done).toBe(false);
+    expect(decoder.decode(second.value)).toBe("chunk-2");
+    const end = await reader.read();
+    expect(end.done).toBe(true);
+  });
+});

--- a/tests/unit/h2-concurrency-cap.test.ts
+++ b/tests/unit/h2-concurrency-cap.test.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import type http2 from "http2";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPoolBackedH2Fetch,
@@ -53,10 +52,6 @@ class MockSession extends EventEmitter {
   }
 }
 
-function asSession(mock: MockSession): http2.ClientHttp2Session {
-  return mock as unknown as http2.ClientHttp2Session;
-}
-
 /**
  * Build a pool whose establish() always returns the supplied session for any
  * domain, so each domain gets its own cached session without real network.
@@ -74,9 +69,24 @@ function tick(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-function resolveStream(stream: MockStream, status = 200): void {
+/**
+ * Emit ONLY the response headers, leaving the body stream OPEN. Post-ENG-2678
+ * the concurrency slot is tied to the OPEN-STREAM lifetime, so headers alone
+ * must NOT free the slot — only a stream terminal does.
+ */
+function respondHeaders(stream: MockStream, status = 200): void {
   stream.emit("response", { ":status": status });
+}
+
+/** Emit the stream terminal (`end`), which closes the body and frees the slot. */
+function endStream(stream: MockStream): void {
   stream.emit("end");
+}
+
+/** Headers + immediate end: a full, instantly-closed stream (slot freed). */
+function resolveStream(stream: MockStream, status = 200): void {
+  respondHeaders(stream, status);
+  endStream(stream);
 }
 
 describe("h2fetch per-domain concurrency cap", () => {
@@ -91,7 +101,10 @@ describe("h2fetch per-domain concurrency cap", () => {
     vi.restoreAllMocks();
   });
 
-  it("releases the slot after an H2 success so the next request can proceed", async () => {
+  it("holds the slot until the OPEN stream terminates (not at headers) so the next request waits for the body to end", async () => {
+    // ENG-2678: the slot is tied to the OPEN-STREAM lifetime. Headers arriving
+    // (the first request's promise resolving with a streaming Response) must NOT
+    // free the slot — only the stream terminal (`end`) does.
     const session = new MockSession();
     const pool = poolReturning(() => session);
     const h2fetch = createPoolBackedH2Fetch(pool, "edge.a.example.com");
@@ -106,10 +119,16 @@ describe("h2fetch per-domain concurrency cap", () => {
     await tick();
     expect(session.streams).toHaveLength(1);
 
-    resolveStream(firstStream);
+    // Headers arrive and `first` resolves with a (still-open) streaming Response,
+    // but the slot stays HELD: the second request still must not open a stream.
+    respondHeaders(firstStream);
     await first;
+    await tick();
+    expect(session.streams).toHaveLength(1);
 
-    // First slot released: the second request now opens its own stream.
+    // The first stream terminates (body ends): NOW the slot frees and the second
+    // request opens its own stream.
+    endStream(firstStream);
     await tick();
     expect(session.streams).toHaveLength(2);
     resolveStream(session.lastStream!);
@@ -129,6 +148,8 @@ describe("h2fetch per-domain concurrency cap", () => {
     await tick();
     expect(session.streams).toHaveLength(1);
 
+    // A stream error is a stream terminal (here, pre-response), so it frees the
+    // slot via the same cleanup path as a normal stream end.
     firstStream.emit("error", new Error("stream dead"));
     await expect(first).rejects.toThrow("stream dead");
 
@@ -258,10 +279,16 @@ describe("h2fetch per-domain concurrency cap", () => {
     // Only the first request has opened a stream so far.
     expect(session.streams).toHaveLength(1);
 
-    // Release in sequence; each release should let exactly the next queued
-    // request (in arrival order) open its stream.
-    resolveStream(holdingStream);
+    // ENG-2678 timing: the holder's headers arriving do not advance the queue —
+    // its slot is held until the OPEN stream terminates.
+    respondHeaders(holdingStream);
     await p1;
+    await tick();
+    expect(session.streams).toHaveLength(1);
+
+    // Release in sequence by terminating each stream; each terminal should let
+    // exactly the next queued request (in arrival order) open its stream.
+    endStream(holdingStream);
     await tick();
     expect(session.streams).toHaveLength(2);
 
@@ -301,9 +328,13 @@ describe("h2fetch per-domain concurrency cap", () => {
     resolveStream(sessionB.lastStream!);
     await expect(b1).resolves.toBeInstanceOf(Response);
 
-    // Now drain domain A.
-    resolveStream(a1Stream);
+    // Now drain domain A. Headers alone do not free A's slot (open-stream
+    // timing); a2 only opens once a1's stream terminates.
+    respondHeaders(a1Stream);
     await a1;
+    await tick();
+    expect(sessionA.streams).toHaveLength(1);
+    endStream(a1Stream);
     await tick();
     expect(sessionA.streams).toHaveLength(2);
     resolveStream(sessionA.streams[1]);


### PR DESCRIPTION
**What this is:** a fix to how the SDK limits concurrent HTTP/2 requests. It is off by default, so nothing changes for anyone until the limit is turned on.

**The problem:** with the limit on, it freed a slot as soon as a response's headers arrived. But a streaming response (logs, command output, port proxy) stays open long after its headers, so those long-lived streams stopped counting against the limit and the shared connection could be pushed past it, which is the exact overload the limit exists to prevent.

**What it changes:**
- The limit now holds a slot for as long as the stream is actually open, so it counts real concurrent streams.
- Requests that fall back to a normal fetch release their slot right away (a different connection, so they should not count against it).
- The safety timer is now a long backstop that only frees a stuck slot and never cancels a live request.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes the HTTP/2 per-domain concurrency gate to hold slots for the full open-stream lifetime rather than releasing on response headers. The slot is now freed from `cleanupActiveRequest()` on every terminal path (stream end/error/abort/cancel), while fallback paths that never open a stream on the shared session release immediately. The safety timer is raised to 30 minutes and demoted to a non-disruptive backstop. Adds a regression test using the fault server's new `holdStreamOpenUntilRelease` / `releaseHeldStreams` API.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 627aa662925b2deb35181a6c266f5355d4232764.</sup>
<!-- /MENDRAL_SUMMARY -->