### PR TITLE
fix(sandbox): file/drive/process ops self-heal transient connection resets (ENG-2680 + idempotent reads)

### DIFF
--- a/@blaxel/core/fix-browser-imports.js
+++ b/@blaxel/core/fix-browser-imports.js
@@ -79,8 +79,8 @@ function replaceH2FilesWithStubs(buildDir) {
     },
     {
       name: 'h2fetch',
-      js: `// Browser stub - H2 fetch is Node.js only, falls back to global fetch\nexport function createH2Fetch(session) { return (input) => globalThis.fetch(input); }\nexport function createPoolBackedH2Fetch(pool, domain) { return (input) => globalThis.fetch(input); }\nexport function h2RequestDirect(session, url, init) { return globalThis.fetch(url, init); }\nexport function h2RequestDirectFromPool(pool, domain, url, init) { return globalThis.fetch(url, init); }\n`,
-      dts: `export declare function createH2Fetch(session: any): (input: Request) => Promise<Response>;\nexport declare function createPoolBackedH2Fetch(pool: any, domain: string): (input: Request) => Promise<Response>;\nexport declare function h2RequestDirect(session: any, url: string, init?: RequestInit): Promise<Response>;\nexport declare function h2RequestDirectFromPool(pool: any, domain: string, url: string, init?: RequestInit): Promise<Response>;\n`,
+      js: `// Browser stub - H2 fetch is Node.js only, falls back to global fetch\nexport function createH2Fetch(session) { return (input) => globalThis.fetch(input); }\nexport function createPoolBackedH2Fetch(pool, domain) { return (input) => globalThis.fetch(input); }\nexport function h2RequestDirect(session, url, init) { return globalThis.fetch(url, init); }\nexport function h2RequestDirectFromPool(pool, domain, url, init) { return globalThis.fetch(url, init); }\nexport async function withUploadSlot(domain, fn) { return fn(); }\n`,
+      dts: `export declare function createH2Fetch(session: any): (input: Request) => Promise<Response>;\nexport declare function createPoolBackedH2Fetch(pool: any, domain: string): (input: Request) => Promise<Response>;\nexport declare function h2RequestDirect(session: any, url: string, init?: RequestInit): Promise<Response>;\nexport declare function h2RequestDirectFromPool(pool: any, domain: string, url: string, init?: RequestInit): Promise<Response>;\nexport declare function withUploadSlot<T>(domain: string, fn: () => Promise<T>): Promise<T>;\n`,
     },
   ];
 

--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -52,32 +52,37 @@ type H2DomainGate = {
   queue: Array<() => void>;
 };
 
+// Global per-domain gate (the opt-in maxConcurrentH2Requests cap).
 const h2GatesByDomain = new Map<string, H2DomainGate>();
+// Upload-scoped per-domain gate (the default-on multipart upload cap, ENG-2680).
+// Kept separate from the global gate so it only ever throttles upload parts.
+const h2UploadGatesByDomain = new Map<string, H2DomainGate>();
 
-function getH2Gate(domain: string): H2DomainGate {
-  let gate = h2GatesByDomain.get(domain);
+function getGate(gates: Map<string, H2DomainGate>, domain: string): H2DomainGate {
+  let gate = gates.get(domain);
   if (!gate) {
     gate = { active: 0, queue: [] };
-    h2GatesByDomain.set(domain, gate);
+    gates.set(domain, gate);
   }
   return gate;
 }
 
 /**
- * Acquire an OPEN-STREAM slot for `domain`. Resolves with a release function
- * that is idempotent and FIFO-fair: releasing wakes the longest-waiting queued
- * caller for the same domain. The slot is held for the lifetime of an OPEN H2
- * stream — the send path releases it on the stream terminal — so the gate
- * bounds true concurrent streams on the one shared session, not merely requests
- * awaiting headers (ENG-2678). A backstop timer releases the slot if a request
- * neither opens a stream nor ever settles, preventing per-domain starvation;
- * it never aborts the underlying request (see `H2_SLOT_TIMEOUT_MS`).
+ * Core per-domain async semaphore, shared by the global and upload gates.
+ * Resolves with a release function that is idempotent and FIFO-fair: releasing
+ * wakes the longest-waiting queued caller for the same domain. When `max` is
+ * `0`/unset the gate is a no-op (unlimited). A backstop timer releases the slot
+ * if a holder never releases, preventing per-domain starvation; it never aborts
+ * the underlying request (see `H2_SLOT_TIMEOUT_MS`).
  */
-async function acquireH2Slot(domain: string): Promise<() => void> {
-  const max = settings.maxConcurrentH2Requests; // 0/undefined = unlimited
+async function acquireGateSlot(
+  gates: Map<string, H2DomainGate>,
+  domain: string,
+  max: number,
+): Promise<() => void> {
   if (!max || max <= 0) return () => {};
 
-  const gate = getH2Gate(domain);
+  const gate = getGate(gates, domain);
   while (gate.active >= max) {
     await new Promise<void>((resolve) => gate.queue.push(resolve));
   }
@@ -95,9 +100,9 @@ async function acquireH2Slot(domain: string): Promise<() => void> {
     if (next) {
       next();
     } else if (gate.active === 0 && gate.queue.length === 0) {
-      // No active requests and nothing waiting: drop the empty gate so the
-      // Map does not grow unbounded across many short-lived domains.
-      h2GatesByDomain.delete(domain);
+      // No active holders and nothing waiting: drop the empty gate so the Map
+      // does not grow unbounded across many short-lived domains.
+      gates.delete(domain);
     }
   };
 
@@ -107,6 +112,43 @@ async function acquireH2Slot(domain: string): Promise<() => void> {
   (timer.handle as unknown as { unref?: () => void }).unref?.();
 
   return release;
+}
+
+/**
+ * Acquire the global OPEN-STREAM slot for `domain` (the opt-in
+ * `maxConcurrentH2Requests` cap; `0`/unset = unlimited, the default). Held for
+ * the lifetime of an OPEN H2 stream — the send path releases it on the stream
+ * terminal — so the gate bounds true concurrent streams on the one shared
+ * session, not merely requests awaiting headers (ENG-2678).
+ */
+function acquireH2Slot(domain: string): Promise<() => void> {
+  return acquireGateSlot(h2GatesByDomain, domain, settings.maxConcurrentH2Requests);
+}
+
+/**
+ * Acquire an upload-scoped slot for `domain`, bounding concurrent multipart
+ * upload-part requests on the shared H2 connection (ENG-2680). Separate from the
+ * global gate so it only throttles uploads. Defaults to 2 — the measured value
+ * that stops concurrent large uploads tripping ENHANCE_YOUR_CALM — making it the
+ * one reliability mitigation on by default, scoped to the upload path.
+ */
+function acquireUploadSlot(domain: string): Promise<() => void> {
+  return acquireGateSlot(h2UploadGatesByDomain, domain, settings.maxConcurrentUploadH2Requests);
+}
+
+/**
+ * Run `fn` while holding an upload slot for `domain`, releasing it when `fn`
+ * settles (the part PUT completes or fails). Bounds concurrent in-flight upload
+ * parts per domain across all files sharing the connection. Used by the
+ * multipart upload path; a no-op wrapper when the upload cap is unset.
+ */
+export async function withUploadSlot<T>(domain: string, fn: () => Promise<T>): Promise<T> {
+  const release = await acquireUploadSlot(domain);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
 }
 
 /**

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -43,8 +43,17 @@ export type Config = {
    */
   maxConcurrentH2Requests?: number;
   /**
-   * Number of retry attempts for transient resets on multipart part uploads.
-   * `0` or `undefined` disables retry (current behavior).
+   * Maximum number of concurrent in-flight multipart upload-part requests per
+   * edge domain on the shared H2 connection. Defaults to 2 (the measured value
+   * that stops concurrent large uploads tripping ENHANCE_YOUR_CALM). Scoped to
+   * the upload-part path only; non-upload traffic is unaffected. `0` disables it.
+   */
+  maxConcurrentUploadH2Requests?: number;
+  /**
+   * Retry attempts for transient connection resets (ECONNRESET, GOAWAY,
+   * ENHANCE_YOUR_CALM, etc.) on file uploads. Covers both small single-PUT
+   * uploads and multipart parts; both are idempotent writes and safe to retry.
+   * Defaults to 3. Set `0` to disable.
    */
   fsPartRetries?: number;
   /**
@@ -335,6 +344,20 @@ class Settings {
     return 0;
   }
 
+  get maxConcurrentUploadH2Requests(): number {
+    if (typeof this.config.maxConcurrentUploadH2Requests === "number") {
+      return this.config.maxConcurrentUploadH2Requests;
+    }
+    const value = env.BL_MAX_UPLOAD_H2_INFLIGHT;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 2;
+  }
+
   get fsPartRetries(): number {
     if (typeof this.config.fsPartRetries === "number") {
       return this.config.fsPartRetries;
@@ -346,7 +369,7 @@ class Settings {
         return parsed;
       }
     }
-    return 0;
+    return 3;
   }
 
   /**

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -57,6 +57,15 @@ export type Config = {
    */
   fsPartRetries?: number;
   /**
+   * Retry attempts for transient connection resets on IDEMPOTENT sandbox reads
+   * (fs.read/readBinary/ls/search/find/grep, drives.list, process.get/list/logs).
+   * Higher than the upload default so a later attempt can span a multi-second
+   * sandbox cold-start/standby wake (the window a first-call read reset falls in).
+   * Defaults to 5. Set `0` to disable. Never applied to non-idempotent ops
+   * (process.exec, drives.mount, etc.).
+   */
+  sandboxReadRetries?: number;
+  /**
    * Client credentials for OAuth2 client_credentials flow.
    *
    * Accepts either:
@@ -370,6 +379,20 @@ class Settings {
       }
     }
     return 3;
+  }
+
+  get sandboxReadRetries(): number {
+    if (typeof this.config.sandboxReadRetries === "number") {
+      return this.config.sandboxReadRetries;
+    }
+    const value = env.BL_SANDBOX_READ_RETRIES;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 5;
   }
 
   /**

--- a/@blaxel/core/src/common/transient-retry.ts
+++ b/@blaxel/core/src/common/transient-retry.ts
@@ -1,0 +1,161 @@
+import { settings } from "./settings.js";
+
+// Markers that, when present anywhere in the error chain, are unambiguous
+// signals of a transient HTTP/2 stream reset or connection drop. These are
+// protocol/transport level codes, not application payloads, so substring
+// matching them does not over-match a server-sent error body. Each entry is
+// matched case-sensitively against the error message and its cause.
+//
+// Deliberately excluded: bare "INTERNAL_ERROR" and "fetch failed". Both are
+// too generic on their own (an application 500 body or any failed fetch would
+// match), so we only treat them as transient when paired with a transport
+// error code on the cause (see isTransientResetError).
+const TRANSIENT_RESET_MARKERS = [
+  "ENHANCE_YOUR_CALM", // H2 flow-control backpressure reset
+  "NGHTTP2_INTERNAL_ERROR", // H2 internal stream error (qualified form)
+  "ERR_HTTP2", // node http2 error code family
+  "GOAWAY", // peer is draining the connection
+  "HTTP/2 session closed before response", // thrown by our own h2 transport
+  "HTTP/2 session sent GOAWAY before response",
+];
+
+// Node-level error codes (from `error.code` / `error.cause.code`) that mean
+// the connection itself dropped mid-flight and the request never completed.
+// These are safe to retry for an idempotent request.
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ERR_HTTP2_STREAM_ERROR",
+  "ERR_HTTP2_GOAWAY_SESSION",
+  "ERR_HTTP2_SESSION_ERROR",
+]);
+
+function collectErrorText(error: unknown): { messages: string[]; codes: string[] } {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  // Walk the error -> cause chain (bounded) so a transport error wrapped by a
+  // higher-level "fetch failed" is still classified correctly.
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
+    const node = current as { message?: unknown; code?: unknown; cause?: unknown };
+    if (typeof node.message === "string") messages.push(node.message);
+    if (typeof node.code === "string") codes.push(node.code);
+    current = node.cause;
+  }
+  return { messages, codes };
+}
+
+// True when the error chain carries a real HTTP response (a status came back
+// from the server). Such an error is an APPLICATION response — never a transport
+// reset — even if the server's error body text happens to contain a reset marker
+// like "GOAWAY" or "ERR_HTTP2". Guarding on this stops a marker-bearing 4xx/5xx
+// body from being misread as transient and retried (the over-match Codex flagged
+// for the now default-on idempotent-read retry).
+function hasHttpResponseStatus(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
+    const node = current as { status?: unknown; response?: { status?: unknown }; cause?: unknown };
+    if (typeof node.status === "number") return true;
+    if (node.response && typeof node.response === "object" &&
+        typeof (node.response as { status?: unknown }).status === "number") {
+      return true;
+    }
+    current = node.cause;
+  }
+  return false;
+}
+
+/**
+ * True only for transport-level resets/drops that are safe to retry on an
+ * IDEMPOTENT request (transient HTTP/2 stream reset, GOAWAY, or a dropped
+ * connection). Application errors (4xx/5xx — even when their body text contains
+ * a marker word) and a bare "fetch failed" with no transport code are
+ * deliberately NOT transient, so auto-retry never masks a real server error or
+ * duplicates a non-idempotent call.
+ *
+ * This is the single classifier shared by the upload-part retry (ENG-2680) and
+ * the idempotent sandbox-op retry (read/list/etc.), so both judge "transient"
+ * identically.
+ */
+export function isTransientResetError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  // An error that carries an HTTP response is an application error, not a
+  // transport reset — never retry it on the strength of a marker in its body.
+  if (hasHttpResponseStatus(error)) {
+    return false;
+  }
+  const { messages, codes } = collectErrorText(error);
+
+  // 1. An explicit transient transport error code anywhere in the chain.
+  if (codes.some((code) => TRANSIENT_ERROR_CODES.has(code))) {
+    return true;
+  }
+
+  // 2. An unambiguous protocol-level reset marker in any message.
+  if (messages.some((text) =>
+    TRANSIENT_RESET_MARKERS.some((marker) => text.includes(marker)),
+  )) {
+    return true;
+  }
+
+  return false;
+}
+
+const DEFAULT_BASE_DELAY_MS = 200;
+const DEFAULT_MAX_DELAY_MS = 2000;
+
+// Exponential backoff with full-jitter on top of one base delay, capped so a
+// single wait never blocks unreasonably long. Exponential (rather than linear)
+// gives a later attempt room to span a multi-second sandbox cold-start/standby
+// wake, which is the window a first-call reset falls into, while early attempts
+// stay fast for the common quick-reset case.
+function backoffDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const exponential = baseDelayMs * Math.pow(2, attempt - 1);
+  const capped = Math.min(exponential, maxDelayMs);
+  const jitter = Math.floor(Math.random() * baseDelayMs);
+  return capped + jitter;
+}
+
+export type RetryOptions = {
+  retries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+};
+
+/**
+ * Run `fn`, retrying only on transient transport resets (see
+ * isTransientResetError) with exponential backoff. Caller owns idempotency:
+ * ONLY wrap idempotent operations (GET-shaped reads/lists, or an idempotent
+ * PUT of the same bytes) — never a non-idempotent POST such as process.exec,
+ * which would duplicate the side effect (ENG-2340).
+ *
+ * Defaults to `settings.sandboxReadRetries` (the higher idempotent-read budget,
+ * sized for a multi-second standby wake). The upload path passes
+ * `{ retries: settings.fsPartRetries }` to keep its own (lower) budget.
+ */
+export async function retryOnTransientReset<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const retries = options.retries ?? settings.sandboxReadRetries;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (error) {
+      attempt++;
+      if (retries <= 0 || attempt > retries || !isTransientResetError(error)) {
+        throw error;
+      }
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, backoffDelayMs(attempt, baseDelayMs, maxDelayMs)),
+      );
+    }
+  }
+}

--- a/@blaxel/core/src/sandbox/drive/drive.ts
+++ b/@blaxel/core/src/sandbox/drive/drive.ts
@@ -1,5 +1,6 @@
 import { Sandbox } from "../../client/types.gen.js";
 import { SandboxAction } from "../action.js";
+import { retryOnTransientReset } from "../../common/transient-retry.js";
 import {
   postDrivesMount,
   deleteDrivesMountByMountPath,
@@ -53,11 +54,15 @@ export class SandboxDrive extends SandboxAction {
    * List all mounted drives in the sandbox
    */
   async list(): Promise<DriveMountInfo[]> {
-    const { response, data, error } = await getDrivesMount(this.withClient({
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    const result = data as GetDrivesMountResponse;
-    return result.mounts ?? [];
+    // Idempotent GET: self-heal a transient connection reset after sandbox resume.
+    // mount/unmount stay un-retried (non-idempotent POST/DELETE).
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getDrivesMount(this.withClient({
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      const result = data as GetDrivesMountResponse;
+      return result.mounts ?? [];
+    });
   }
 }

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -144,8 +144,11 @@ export class SandboxFileSystem extends SandboxAction {
       return await response.json() as SuccessResponse;
     };
 
-    const doPut = () => retryOnTransient(putOnce);
-    return h2Domain ? withUploadSlot(h2Domain, doPut) : doPut();
+    // Acquire the upload slot per-attempt INSIDE the retry so the per-domain cap
+    // bounds in-flight streams, not retry sequences: the slot is released during
+    // backoff, so a failing PUT never pins a slot while it sleeps (Mendral review).
+    const putWithSlot = h2Domain ? () => withUploadSlot(h2Domain, putOnce) : putOnce;
+    return retryOnTransient(putWithSlot);
   }
 
   async writeTree(files: SandboxFilesystemFile[], destinationPath: string | null = null) {
@@ -551,8 +554,11 @@ export class SandboxFileSystem extends SandboxAction {
           const end = Math.min(start + CHUNK_SIZE, size);
           const chunk = blob.slice(start, end);
 
-          const uploadOne = () => retryOnTransient(() => this.uploadPart(uploadId, partNumber, chunk));
-          batch.push(h2Domain ? withUploadSlot(h2Domain, uploadOne) : uploadOne());
+          // Slot acquired per-attempt inside the retry (see writeBinary): bounds
+          // concurrent part streams, not retry sequences; freed during backoff.
+          const doPart = () => this.uploadPart(uploadId, partNumber, chunk);
+          const partWithSlot = h2Domain ? () => withUploadSlot(h2Domain, doPart) : doPart;
+          batch.push(retryOnTransient(partWithSlot));
         }
 
         // Wait for batch to complete

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from "../../client/types.gen.js";
 import { fs } from "../../common/node.js";
 import { settings } from "../../common/settings.js";
+import { withUploadSlot } from "../../common/h2fetch.js";
 import { SandboxAction } from "../action.js";
 import { ContentSearchResponse, deleteFilesystemByPath, deleteFilesystemMultipartByUploadIdAbort, Directory, FindResponse, FuzzySearchResponse, getFilesystemByPath, getFilesystemContentSearchByPath, getFilesystemFindByPath, getFilesystemSearchByPath, getWatchFilesystemByPath, MultipartInitiateResponse, MultipartPartInfo, MultipartUploadPartResponse, postFilesystemMultipartByUploadIdComplete, postFilesystemMultipartInitiateByPath, putFilesystemByPath, PutFilesystemByPathError, putFilesystemMultipartByUploadIdPart, SuccessResponse } from "../client/index.js";
 import { SandboxProcess } from "../process/index.js";
@@ -63,7 +64,11 @@ function collectErrorText(error: unknown): { messages: string[]; codes: string[]
   return { messages, codes };
 }
 
-function isTransientUploadError(error: unknown): boolean {
+// Exported for the real-transport fault-injection tests (not re-exported through
+// the package barrel, so this is not part of the public API): they assert that
+// errors produced by an ACTUAL node:http2 RST_STREAM/GOAWAY/socket-drop are
+// classified transient, bridging the synthetic-error unit tests to reality.
+export function isTransientUploadError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -92,8 +97,12 @@ function nextRetryDelayMs(attempt: number): number {
   return base + jitter;
 }
 
-async function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
-  const retries = settings.fsPartRetries; // 0 = off (current default behavior)
+// Exported for the real-transport fault-injection tests (not part of the public
+// API; see isTransientUploadError above). This is the exact wrapper the upload
+// paths use, so driving it over a real faulting H2 server proves the retry loop
+// actually fires for production fault shapes, not just synthetic ones.
+export async function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
+  const retries = settings.fsPartRetries; // default 3 (ENG-2680); 0 disables
   let attempt = 0;
   for (;;) {
     try {
@@ -192,32 +201,41 @@ export class SandboxFileSystem extends SandboxAction {
       return await this.uploadWithMultipart(path, fileBlob, "0644");
     }
 
-    // Use regular upload for small files
-    const formData = new FormData();
-    formData.append("file", fileBlob, "test-binary.bin");
-    formData.append("permissions", "0644");
-    formData.append("path", path);
-
-    // Build URL
+    // Use regular upload for small files. Run the PUT under the same upload
+    // reliability wrapper as multipart parts: bound concurrency (ENG-2680) and
+    // retry transient connection resets (ECONNRESET/GOAWAY/ENHANCE_YOUR_CALM). A
+    // PUT of the same bytes to the same path is idempotent, so retry is safe.
+    // The FormData is rebuilt per attempt so a retried request has a fresh body.
     let url = `${this.url}/filesystem/${path}`;
     if (this.forcedUrl) {
       url = `${this.forcedUrl.toString()}/filesystem/${path}`;
     }
 
-    const response = await this.h2Fetch(url, {
-      method: 'PUT',
-      headers: {
-        ...settings.headers,
-      },
-      body: formData,
-    });
+    const h2Domain = this.sandbox?.h2Domain;
+    const putOnce = async (): Promise<SuccessResponse> => {
+      const formData = new FormData();
+      formData.append("file", fileBlob, "test-binary.bin");
+      formData.append("permissions", "0644");
+      formData.append("path", path);
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to write binary: ${response.status} ${errorText}`);
-    }
+      const response = await this.h2Fetch(url, {
+        method: 'PUT',
+        headers: {
+          ...settings.headers,
+        },
+        body: formData,
+      });
 
-    return await response.json() as SuccessResponse;
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to write binary: ${response.status} ${errorText}`);
+      }
+
+      return await response.json() as SuccessResponse;
+    };
+
+    const doPut = () => retryOnTransient(putOnce);
+    return h2Domain ? withUploadSlot(h2Domain, doPut) : doPut();
   }
 
   async writeTree(files: SandboxFilesystemFile[], destinationPath: string | null = null) {
@@ -591,6 +609,13 @@ export class SandboxFileSystem extends SandboxAction {
       const numParts = Math.ceil(size / CHUNK_SIZE);
       const parts: Array<MultipartPartInfo> = [];
 
+      // Bound concurrent upload-part streams on the shared H2 connection so many
+      // parts (within and across files) cannot burst past the server's
+      // rapid-reset limit (ENG-2680). Scoped to uploads; default cap is 2. With
+      // no h2Domain the parts go over globalThis.fetch on separate connections,
+      // so the shared-connection cap does not apply.
+      const h2Domain = this.sandbox?.h2Domain;
+
       // Upload parts in batches for parallel processing
       for (let i = 0; i < numParts; i += MAX_PARALLEL_UPLOADS) {
         const batch: Array<Promise<MultipartUploadPartResponse>> = [];
@@ -601,8 +626,8 @@ export class SandboxFileSystem extends SandboxAction {
           const end = Math.min(start + CHUNK_SIZE, size);
           const chunk = blob.slice(start, end);
 
-
-          batch.push(retryOnTransient(() => this.uploadPart(uploadId, partNumber, chunk)));
+          const uploadOne = () => retryOnTransient(() => this.uploadPart(uploadId, partNumber, chunk));
+          batch.push(h2Domain ? withUploadSlot(h2Domain, uploadOne) : uploadOne());
         }
 
         // Wait for batch to complete

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -123,10 +123,15 @@ export class SandboxFileSystem extends SandboxAction {
       formData.append("permissions", "0644");
       formData.append("path", path);
 
+      // A forceUrl (session-token) sandbox carries its own headers and must not
+      // require global credentials; settings.headers now throws without them
+      // (ENG-2698). Mirror streamLogs/execWithStreaming, which already pick
+      // sandbox.headers for forceUrl sessions.
+      const headers = this.sandbox.forceUrl ? this.sandbox.headers : settings.headers;
       const response = await this.h2Fetch(url, {
         method: 'PUT',
         headers: {
-          ...settings.headers,
+          ...headers,
         },
         body: formData,
       });

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "../../client/types.gen.js";
 import { fs } from "../../common/node.js";
 import { settings } from "../../common/settings.js";
 import { withUploadSlot } from "../../common/h2fetch.js";
+import { isTransientResetError, retryOnTransientReset } from "../../common/transient-retry.js";
 import { SandboxAction } from "../action.js";
 import { ContentSearchResponse, deleteFilesystemByPath, deleteFilesystemMultipartByUploadIdAbort, Directory, FindResponse, FuzzySearchResponse, getFilesystemByPath, getFilesystemContentSearchByPath, getFilesystemFindByPath, getFilesystemSearchByPath, getWatchFilesystemByPath, MultipartInitiateResponse, MultipartPartInfo, MultipartUploadPartResponse, postFilesystemMultipartByUploadIdComplete, postFilesystemMultipartInitiateByPath, putFilesystemByPath, PutFilesystemByPathError, putFilesystemMultipartByUploadIdPart, SuccessResponse } from "../client/index.js";
 import { SandboxProcess } from "../process/index.js";
@@ -12,111 +13,15 @@ const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB
 const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB per part
 const MAX_PARALLEL_UPLOADS = 3; // Number of parallel part uploads
 
-// Base backoff between part-upload retries, in milliseconds. Grows linearly
-// per attempt and is jittered to avoid synchronized retries (thundering herd)
-// when several parallel parts fail against the same edge at the same time.
-const RETRY_BASE_DELAY_MS = 200;
-
-// Markers that, when present anywhere in the error chain, are unambiguous
-// signals of a transient HTTP/2 stream reset or connection drop. These are
-// protocol/transport level codes, not application payloads, so substring
-// matching them does not over-match a server-sent error body. Each entry is
-// matched case-sensitively against the error message and its cause.
-//
-// Deliberately excluded: bare "INTERNAL_ERROR" and "fetch failed". Both are
-// too generic on their own (an application 500 body or any failed fetch would
-// match), so we only treat them as transient when paired with a transport
-// error code on the cause (see isTransientUploadError).
-const TRANSIENT_RESET_MARKERS = [
-  "ENHANCE_YOUR_CALM", // H2 flow-control backpressure reset
-  "NGHTTP2_INTERNAL_ERROR", // H2 internal stream error (qualified form)
-  "ERR_HTTP2", // node http2 error code family
-  "GOAWAY", // peer is draining the connection
-  "HTTP/2 session closed before response", // thrown by our own h2 transport
-  "HTTP/2 session sent GOAWAY before response",
-];
-
-// Node-level error codes (from `error.code` / `error.cause.code`) that mean
-// the connection itself dropped mid-flight and the request never completed.
-// These are safe to retry for an idempotent part upload.
-const TRANSIENT_ERROR_CODES = new Set([
-  "ECONNRESET",
-  "ECONNREFUSED",
-  "ETIMEDOUT",
-  "EPIPE",
-  "ERR_HTTP2_STREAM_ERROR",
-  "ERR_HTTP2_GOAWAY_SESSION",
-  "ERR_HTTP2_SESSION_ERROR",
-]);
-
-function collectErrorText(error: unknown): { messages: string[]; codes: string[] } {
-  const messages: string[] = [];
-  const codes: string[] = [];
-  // Walk the error -> cause chain (bounded) so a transport error wrapped by a
-  // higher-level "fetch failed" is still classified correctly.
-  let current: unknown = error;
-  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
-    const node = current as { message?: unknown; code?: unknown; cause?: unknown };
-    if (typeof node.message === "string") messages.push(node.message);
-    if (typeof node.code === "string") codes.push(node.code);
-    current = node.cause;
-  }
-  return { messages, codes };
-}
-
-// Exported for the real-transport fault-injection tests (not re-exported through
-// the package barrel, so this is not part of the public API): they assert that
-// errors produced by an ACTUAL node:http2 RST_STREAM/GOAWAY/socket-drop are
-// classified transient, bridging the synthetic-error unit tests to reality.
-export function isTransientUploadError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const { messages, codes } = collectErrorText(error);
-
-  // 1. An explicit transient transport error code anywhere in the chain.
-  if (codes.some((code) => TRANSIENT_ERROR_CODES.has(code))) {
-    return true;
-  }
-
-  // 2. An unambiguous protocol-level reset marker in any message.
-  if (messages.some((text) =>
-    TRANSIENT_RESET_MARKERS.some((marker) => text.includes(marker)),
-  )) {
-    return true;
-  }
-
-  return false;
-}
-
-function nextRetryDelayMs(attempt: number): number {
-  // Linear backoff (200ms, 400ms, ...) plus up to one extra base delay of
-  // random jitter so concurrent part retries do not all fire on the same tick.
-  const base = RETRY_BASE_DELAY_MS * attempt;
-  const jitter = Math.floor(Math.random() * RETRY_BASE_DELAY_MS);
-  return base + jitter;
-}
-
-// Exported for the real-transport fault-injection tests (not part of the public
-// API; see isTransientUploadError above). This is the exact wrapper the upload
-// paths use, so driving it over a real faulting H2 server proves the retry loop
-// actually fires for production fault shapes, not just synthetic ones.
-export async function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
-  const retries = settings.fsPartRetries; // default 3 (ENG-2680); 0 disables
-  let attempt = 0;
-  for (;;) {
-    try {
-      return await fn();
-    } catch (error) {
-      attempt++;
-      if (retries <= 0 || attempt > retries || !isTransientUploadError(error)) {
-        throw error;
-      }
-      await new Promise<void>((resolve) =>
-        setTimeout(resolve, nextRetryDelayMs(attempt)),
-      );
-    }
-  }
+// The transient-reset classifier and retry loop live in
+// common/transient-retry.ts, shared with the idempotent sandbox-op retry
+// (read/list/etc.) so every path judges "transient" identically. These aliases
+// preserve the import surface the ENG-2680 fault tests already depend on.
+export const isTransientUploadError = isTransientResetError;
+export function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
+  // Upload path keeps its own (lower) fsPartRetries budget; the shared helper
+  // otherwise defaults to the higher idempotent-read budget (sandboxReadRetries).
+  return retryOnTransientReset(fn, { retries: settings.fsPartRetries });
 }
 
 export class SandboxFileSystem extends SandboxAction {
@@ -262,31 +167,38 @@ export class SandboxFileSystem extends SandboxAction {
 
   async read(path: string): Promise<string> {
     path = this.formatPath(path);
-    const { response, data, error } = await getFilesystemByPath(this.withClient({
-      path: { path },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    if (data && 'content' in data) {
-      return data.content;
-    }
-    throw new Error("Unsupported file type");
+    // Idempotent GET: self-heal a transient connection reset (e.g. first call
+    // after sandbox resume). Non-transient errors (404, etc.) are not retried.
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getFilesystemByPath(this.withClient({
+        path: { path },
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      if (data && 'content' in data) {
+        return data.content;
+      }
+      throw new Error("Unsupported file type");
+    });
   }
 
   async readBinary(path: string): Promise<Blob> {
     path = this.formatPath(path);
-    const { response, data, error } = await getFilesystemByPath(this.withClient({
-      path: { path },
-      baseUrl: this.url,
-      headers: {
-        'Accept': 'application/octet-stream',
-      },
-    }));
-    this.handleResponseError(response, data, error);
-    if (typeof data === 'string') {
-      return new Blob([data]);
-    }
-    return data as Blob;
+    // Idempotent GET: self-heal a transient connection reset.
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getFilesystemByPath(this.withClient({
+        path: { path },
+        baseUrl: this.url,
+        headers: {
+          'Accept': 'application/octet-stream',
+        },
+      }));
+      this.handleResponseError(response, data, error);
+      if (typeof data === 'string') {
+        return new Blob([data]);
+      }
+      return data as Blob;
+    });
   }
 
   async download(src: string, destinationPath: string, { mode = 0o644 }: { mode?: number } = {}): Promise<void> {
@@ -312,15 +224,19 @@ export class SandboxFileSystem extends SandboxAction {
 
   async ls(path: string): Promise<Directory> {
     path = this.formatPath(path);
-    const { response, data, error } = await getFilesystemByPath(this.withClient({
-      path: { path },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    if (!data || !('files' in data || 'subdirectories' in data)) {
-      throw new Error(JSON.stringify({ error: "Directory not found" }));
-    }
-    return data as Directory;
+    // Idempotent GET: self-heal a transient connection reset (the file-tree
+    // refresh that customers hit as intermittent 500s after sandbox resume).
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getFilesystemByPath(this.withClient({
+        path: { path },
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      if (!data || !('files' in data || 'subdirectories' in data)) {
+        throw new Error(JSON.stringify({ error: "Directory not found" }));
+      }
+      return data as Directory;
+    });
   }
 
   async search(
@@ -350,14 +266,15 @@ export class SandboxFileSystem extends SandboxAction {
       queryParams.excludeHidden = options.excludeHidden;
     }
 
-    const result = await getFilesystemSearchByPath(this.withClient({
-      path: { path: formattedPath },
-      query: queryParams,
-      baseUrl: this.url,
-    }));
-
-    this.handleResponseError(result.response, result.data, result.error);
-    return result.data as FuzzySearchResponse;
+    return retryOnTransientReset(async () => {
+      const result = await getFilesystemSearchByPath(this.withClient({
+        path: { path: formattedPath },
+        query: queryParams,
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(result.response, result.data, result.error);
+      return result.data as FuzzySearchResponse;
+    });
   }
 
   async find(
@@ -390,13 +307,15 @@ export class SandboxFileSystem extends SandboxAction {
       queryParams.excludeHidden = options.excludeHidden;
     }
 
-    const result = await getFilesystemFindByPath(this.withClient({
-      path: { path: formattedPath },
-      query: queryParams,
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(result.response, result.data, result.error);
-    return result.data as FindResponse;
+    return retryOnTransientReset(async () => {
+      const result = await getFilesystemFindByPath(this.withClient({
+        path: { path: formattedPath },
+        query: queryParams,
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(result.response, result.data, result.error);
+      return result.data as FindResponse;
+    });
   }
 
   async grep(
@@ -433,14 +352,15 @@ export class SandboxFileSystem extends SandboxAction {
       queryParams.excludeDirs = options.excludeDirs.join(',');
     }
 
-    const result = await getFilesystemContentSearchByPath(this.withClient({
-      path: { path: formattedPath },
-      query: queryParams,
-      baseUrl: this.url,
-    }));
-
-    this.handleResponseError(result.response, result.data, result.error);
-    return result.data as ContentSearchResponse;
+    return retryOnTransientReset(async () => {
+      const result = await getFilesystemContentSearchByPath(this.withClient({
+        path: { path: formattedPath },
+        query: queryParams,
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(result.response, result.data, result.error);
+      return result.data as ContentSearchResponse;
+    });
   }
 
   async cp(source: string, destination: string, { maxWait = 180000 }: { maxWait?: number } = {}): Promise<CopyResponse> {

--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from "../../client/types.gen.js";
 import { settings } from "../../common/settings.js";
 import { SandboxAction } from "../action.js";
+import { retryOnTransientReset } from "../../common/transient-retry.js";
 import { DeleteProcessByIdentifierKillResponse, DeleteProcessByIdentifierResponse, GetProcessByIdentifierResponse, GetProcessResponse, PostProcessResponse, ProcessRequest, deleteProcessByIdentifier, deleteProcessByIdentifierKill, getProcess, getProcessByIdentifier, getProcessByIdentifierLogs, postProcess } from "../client/index.js";
 import { ProcessRequestWithLog, ProcessResponseWithLog } from "../types.js";
 
@@ -331,20 +332,28 @@ export class SandboxProcess extends SandboxAction {
   }
 
   async get(identifier: string): Promise<GetProcessByIdentifierResponse> {
-    const { response, data, error } = await getProcessByIdentifier(this.withClient({
-      path: { identifier },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as GetProcessByIdentifierResponse;
+    // Idempotent GET: self-heal a transient connection reset (also makes the
+    // wait() poll loop resilient). exec() stays un-retried — it is a
+    // non-idempotent POST and retrying it duplicates the process (ENG-2340).
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getProcessByIdentifier(this.withClient({
+        path: { identifier },
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      return data as GetProcessByIdentifierResponse;
+    });
   }
 
   async list(): Promise<GetProcessResponse> {
-    const { response, data, error } = await getProcess(this.withClient({
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as GetProcessResponse;
+    // Idempotent GET: self-heal a transient connection reset.
+    return retryOnTransientReset(async () => {
+      const { response, data, error } = await getProcess(this.withClient({
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      return data as GetProcessResponse;
+    });
   }
 
   async stop(identifier: string): Promise<DeleteProcessByIdentifierResponse> {
@@ -366,11 +375,15 @@ export class SandboxProcess extends SandboxAction {
   }
 
   async logs(identifier: string, type: "stdout" | "stderr" | "all" = "all"): Promise<string> {
-    const { response, data, error } = await getProcessByIdentifierLogs(this.withClient({
-      path: { identifier },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
+    // Idempotent GET: self-heal a transient connection reset.
+    const data = await retryOnTransientReset(async () => {
+      const { response, data, error } = await getProcessByIdentifierLogs(this.withClient({
+        path: { identifier },
+        baseUrl: this.url,
+      }));
+      this.handleResponseError(response, data, error);
+      return data;
+    });
     if (type === "all") {
       return data?.logs || "";
     } else if (type === "stdout") {

--- a/tests/integration/fault-injection/h2-upload-retry-real-transport.test.ts
+++ b/tests/integration/fault-injection/h2-upload-retry-real-transport.test.ts
@@ -1,0 +1,144 @@
+// Real-transport coverage for ENG-2680 upload retry.
+//
+// The unit tests (tests/unit/filesystem-part-retry.test.ts) classify SYNTHETIC
+// error objects. That leaves one untested seam: does an error produced by an
+// ACTUAL node:http2 RST_STREAM / GOAWAY / socket-drop carry the codes/markers the
+// classifier matches? If it does not, the retry machinery is all green in unit
+// tests yet never fires in production. These tests close that seam by driving the
+// real `createH2Fetch` transport against the in-process H2 fault server, then:
+//   1. asserting the real rejection is classified transient (retry WILL fire),
+//   2. driving the real `retryOnTransient` loop over real faults (retry count +
+//      self-heal when the fault clears),
+//   3. confirming the classifier stays conservative (no over-retry).
+// No creds, no network beyond loopback. See ./README.md for the harness scope.
+import http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import {
+  isTransientUploadError,
+  retryOnTransient,
+} from "../../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+import { settings } from "../../../@blaxel/core/src/common/settings.js";
+import { startH2FaultServer, type H2FaultServer } from "./h2-fault-server.js";
+
+const {
+  NGHTTP2_ENHANCE_YOUR_CALM,
+  NGHTTP2_REFUSED_STREAM,
+  NGHTTP2_INTERNAL_ERROR,
+} = http2.constants;
+
+let server: H2FaultServer | undefined;
+let session: http2.ClientHttp2Session | undefined;
+
+afterEach(async () => {
+  if (session && !session.destroyed) session.destroy();
+  session = undefined;
+  if (server) await server.close();
+  server = undefined;
+  delete settings.config.fsPartRetries;
+});
+
+// Drive one real fetch against `server` and return the rejection it produced
+// (or undefined if it unexpectedly resolved).
+async function captureFetchError(path: string): Promise<unknown> {
+  const h2fetch = createH2Fetch(session!);
+  try {
+    await h2fetch(new Request(`${server!.url}${path}`));
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}
+
+describe("ENG-2680 real-transport: faults that should self-heal are classified transient", () => {
+  it.each([
+    ["RST_STREAM ENHANCE_YOUR_CALM", { rstStreamWith: { code: NGHTTP2_ENHANCE_YOUR_CALM } }],
+    ["RST_STREAM REFUSED_STREAM", { rstStreamWith: { code: NGHTTP2_REFUSED_STREAM } }],
+    ["RST_STREAM INTERNAL_ERROR", { rstStreamWith: { code: NGHTTP2_INTERNAL_ERROR } }],
+    ["GOAWAY before response", { goawayAfterStreams: 1 }],
+    ["socket destroyed mid-flight", { destroySocketMid: true }],
+  ])("classifies a real %s error as transient (retry will fire)", async (_label, command) => {
+    server = await startH2FaultServer({ command });
+    session = server.connectClient();
+
+    const err = await captureFetchError("/upload-part");
+
+    expect(err).toBeDefined(); // the real transport rejected, as expected
+    expect(isTransientUploadError(err)).toBe(true);
+  });
+
+  it("does NOT flag a clean real 200 response as an error (no spurious retry)", async () => {
+    server = await startH2FaultServer();
+    session = server.connectClient();
+    const h2fetch = createH2Fetch(session);
+
+    const res = await h2fetch(new Request(`${server.url}/ok`));
+    expect(res.status).toBe(200); // resolved, nothing for retry to act on
+    expect(server.requests).toHaveLength(1);
+  });
+});
+
+describe("ENG-2680 real-transport: the actual retryOnTransient loop over real faults", () => {
+  it("retries a persistent real transient fault the configured number of times, then surfaces it", async () => {
+    settings.config.fsPartRetries = 2;
+    server = await startH2FaultServer({
+      command: { rstStreamWith: { code: NGHTTP2_ENHANCE_YOUR_CALM } },
+    });
+    session = server.connectClient();
+    const h2fetch = createH2Fetch(session);
+
+    await expect(
+      retryOnTransient(() => h2fetch(new Request(`${server!.url}/part`))),
+    ).rejects.toBeDefined();
+
+    // 1 initial attempt + 2 retries = 3 real round-trips the server actually saw.
+    expect(server.requests).toHaveLength(3);
+  });
+
+  it("self-heals once the real transient fault clears between attempts", async () => {
+    settings.config.fsPartRetries = 3;
+    server = await startH2FaultServer({
+      command: { rstStreamWith: { code: NGHTTP2_ENHANCE_YOUR_CALM } },
+    });
+    session = server.connectClient();
+    const srv = server;
+    const h2fetch = createH2Fetch(session);
+
+    // Clear the fault as soon as the first attempt has reached the server. The
+    // retry backoff (>=200ms) leaves ample room, so attempt 2 sees the baseline
+    // echo — no wall-clock guessing, the flip is gated on the recorded request.
+    const clearAfterFirstHit = (async () => {
+      while (srv.requests.length < 1) {
+        await new Promise<void>((r) => setImmediate(r));
+      }
+      srv.command({}); // back to baseline 200 echo
+    })();
+
+    const res = await retryOnTransient(() => h2fetch(new Request(`${srv.url}/heal`)));
+    await clearAfterFirstHit;
+
+    expect(res.status).toBe(200); // the retry landed once the fault cleared
+    expect(srv.requests.length).toBeGreaterThanOrEqual(2); // failed at least once first
+  });
+});
+
+describe("ENG-2680: the classifier stays conservative (no over-retry)", () => {
+  it("does NOT treat application errors or a bare 'fetch failed' as transient", () => {
+    // An app-level 500 body, a generic fetch failure, and an ordinary 4xx must
+    // never be retried — only transport-level resets qualify. This is the safety
+    // boundary that keeps auto-retry from masking real server errors.
+    expect(isTransientUploadError(new Error('{"error":"INTERNAL_ERROR: disk full"}'))).toBe(false);
+    expect(isTransientUploadError(new Error("fetch failed"))).toBe(false);
+    expect(isTransientUploadError(new Error("400 Bad Request: invalid part"))).toBe(false);
+    expect(isTransientUploadError(undefined)).toBe(false);
+    expect(isTransientUploadError(null)).toBe(false);
+  });
+
+  it("treats a transport reset wrapped under a generic message as transient", () => {
+    // The real failure shape: "fetch failed" wrapping a cause carrying the code.
+    const wrapped = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    });
+    expect(isTransientUploadError(wrapped)).toBe(true);
+  });
+});

--- a/tests/integration/regressions/ENG-2680-single-put-retry.test.ts
+++ b/tests/integration/regressions/ENG-2680-single-put-retry.test.ts
@@ -1,0 +1,116 @@
+// Regression: ENG-2680 — the small-file single-PUT upload path (writeBinary for
+// a blob at/under the multipart threshold, which most small uploads take and
+// which the multipart part-retry never covered) now runs under the same
+// retry-on-transient-reset wrapper as multipart parts, AND rebuilds its
+// FormData body per attempt so a retried PUT carries a fresh body rather than an
+// already-consumed one. This is the path Vivek's failing writeBinary most likely
+// hit. Drives the real SandboxFileSystem.writeBinary through a stubbed h2Fetch.
+// No creds, no network.
+import { afterEach, describe, expect, it } from "vitest";
+import { SandboxFileSystem } from "../../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+import { settings } from "../../../@blaxel/core/src/common/settings.js";
+
+type WriteBinaryHarness = {
+  writeBinary(path: string, content: Uint8Array): Promise<{ message?: string }>;
+};
+
+// A transport reset shaped like the real failure: a top-level "fetch failed"
+// wrapping a cause that carries the ECONNRESET code (the form the classifier
+// must walk the cause chain to recognize).
+function econnreset(): Error {
+  return Object.assign(new Error("fetch failed"), {
+    cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+  });
+}
+
+function okResponse() {
+  return { ok: true, json: () => Promise.resolve({ message: "written" }) };
+}
+
+function httpError(status: number, body: string) {
+  return { ok: false, status, text: () => Promise.resolve(body) };
+}
+
+/**
+ * Build a writeBinary harness whose stubbed h2Fetch follows `behaviors` by
+ * attempt (the last entry repeats): a behavior that throws simulates a transport
+ * reset, one that returns an object simulates an HTTP response. Records the body
+ * object handed to each attempt so a test can prove the FormData is rebuilt.
+ */
+function harness(behaviors: Array<() => unknown>) {
+  const h = Object.create(SandboxFileSystem.prototype) as Record<string, unknown>;
+  // url getter reads sandbox.forceUrl; absent h2Domain keeps the PUT off the
+  // withUploadSlot gate so this test isolates retry behavior, not concurrency.
+  h.sandbox = { forceUrl: "http://edge.test", metadata: { name: "t" } };
+  h.formatPath = (p: string) => p;
+  const bodies: unknown[] = [];
+  let attempts = 0;
+  h.h2Fetch = (_url: unknown, init?: { body?: unknown }) => {
+    const i = attempts++;
+    bodies.push(init?.body);
+    const behavior = behaviors[Math.min(i, behaviors.length - 1)];
+    // Wrap so a synchronous throw surfaces as a rejected promise, matching how a
+    // real reset reaches the retry wrapper.
+    return Promise.resolve().then(behavior);
+  };
+  return {
+    fsys: h as unknown as WriteBinaryHarness,
+    attempts: () => attempts,
+    bodies,
+  };
+}
+
+describe("ENG-2680: single-PUT (small-file) upload retry", () => {
+  afterEach(() => {
+    delete settings.config.fsPartRetries;
+  });
+
+  it("retries a transient reset on the small-file PUT path and self-heals (on by default)", async () => {
+    expect(settings.fsPartRetries).toBe(3); // default-on, no config set
+    const { fsys, attempts, bodies } = harness([
+      () => {
+        throw econnreset();
+      },
+      () => {
+        throw econnreset();
+      },
+      () => okResponse(),
+    ]);
+
+    await expect(
+      fsys.writeBinary("/tmp/small.bin", new Uint8Array(16)),
+    ).resolves.toEqual({ message: "written" });
+
+    // 1 initial attempt + 2 retries, then success.
+    expect(attempts()).toBe(3);
+    // Each attempt got a freshly built FormData body, never a reused reference.
+    // A consumed/reused body is exactly what would make a "retry" silently send
+    // nothing; distinct instances prove the per-attempt rebuild.
+    expect(bodies).toHaveLength(3);
+    for (const body of bodies) expect(body).toBeInstanceOf(FormData);
+    expect(new Set(bodies).size).toBe(3);
+  });
+
+  it("does NOT retry a non-transient HTTP failure on the PUT path", async () => {
+    const { fsys, attempts } = harness([() => httpError(400, "invalid path")]);
+
+    await expect(
+      fsys.writeBinary("/tmp/small.bin", new Uint8Array(16)),
+    ).rejects.toThrow("Failed to write binary: 400");
+    expect(attempts()).toBe(1); // a 4xx is not transient: no retry
+  });
+
+  it("can be turned off on the PUT path (fsPartRetries = 0)", async () => {
+    settings.config.fsPartRetries = 0;
+    const { fsys, attempts } = harness([
+      () => {
+        throw econnreset();
+      },
+    ]);
+
+    await expect(
+      fsys.writeBinary("/tmp/small.bin", new Uint8Array(16)),
+    ).rejects.toThrow();
+    expect(attempts()).toBe(1); // retry disabled: exactly one attempt
+  });
+});

--- a/tests/integration/regressions/ENG-2680-upload-cap.test.ts
+++ b/tests/integration/regressions/ENG-2680-upload-cap.test.ts
@@ -1,0 +1,118 @@
+// Regression: ENG-2680 — multipart upload-part concurrency is bounded by a
+// per-domain semaphore (default 2) so concurrent large uploads cannot burst
+// past the server's rapid-reset limit (NGHTTP2_ENHANCE_YOUR_CALM). This locks
+// the default cap value and the semaphore's behavior (admit at the cap, FIFO
+// hand-off, per-domain isolation, disable at 0). No creds, no network.
+import { afterEach, describe, expect, it } from "vitest";
+import { withUploadSlot } from "../../../@blaxel/core/src/common/h2fetch.js";
+import { settings } from "../../../@blaxel/core/src/common/settings.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+afterEach(() => {
+  delete (settings.config as Record<string, unknown>).maxConcurrentUploadH2Requests;
+});
+
+describe("ENG-2680: multipart upload-part concurrency cap", () => {
+  it("ships upload reliability on by default (concurrency cap 2, retries 3)", () => {
+    expect(settings.maxConcurrentUploadH2Requests).toBe(2);
+    expect(settings.fsPartRetries).toBe(3);
+  });
+
+  it("defaults to 2 concurrent upload parts per domain", async () => {
+    expect(settings.maxConcurrentUploadH2Requests).toBe(2);
+
+    let active = 0;
+    let peak = 0;
+    let started = 0;
+    const gates = Array.from({ length: 5 }, () => deferred());
+    const run = (i: number) =>
+      withUploadSlot("edge.test", () => {
+        started++;
+        active++;
+        peak = Math.max(peak, active);
+        return gates[i].promise.then(() => {
+          active--;
+        });
+      });
+    const tasks = gates.map((_, i) => run(i));
+
+    await tick();
+    expect(started).toBe(2); // only 2 admitted at the cap
+    expect(active).toBe(2);
+
+    gates[0].resolve();
+    await tick();
+    expect(started).toBe(3); // freeing one admits the next (FIFO)
+
+    gates[1].resolve();
+    gates[2].resolve();
+    gates[3].resolve();
+    gates[4].resolve();
+    await Promise.all(tasks);
+    expect(peak).toBe(2); // never exceeded the cap
+  });
+
+  it("respects an overridden cap", async () => {
+    (settings.config as Record<string, unknown>).maxConcurrentUploadH2Requests = 1;
+    let active = 0;
+    let peak = 0;
+    const gates = Array.from({ length: 3 }, () => deferred());
+    const tasks = gates.map((g) =>
+      withUploadSlot("edge.one", () => {
+        active++;
+        peak = Math.max(peak, active);
+        return g.promise.then(() => {
+          active--;
+        });
+      }),
+    );
+    await tick();
+    expect(peak).toBe(1);
+    gates.forEach((g) => g.resolve());
+    await Promise.all(tasks);
+  });
+
+  it("isolates domains: a saturated domain does not block another", async () => {
+    (settings.config as Record<string, unknown>).maxConcurrentUploadH2Requests = 1;
+    const a = deferred();
+    const aTask = withUploadSlot("edge.a", () => a.promise); // holds edge.a's only slot
+    await tick();
+
+    let bRan = false;
+    await withUploadSlot("edge.b", async () => {
+      bRan = true;
+    });
+    expect(bRan).toBe(true); // edge.b proceeds despite edge.a being full
+
+    a.resolve();
+    await aTask;
+  });
+
+  it("is unbounded when the cap is 0 (disabled)", async () => {
+    (settings.config as Record<string, unknown>).maxConcurrentUploadH2Requests = 0;
+    let active = 0;
+    let peak = 0;
+    const gates = Array.from({ length: 4 }, () => deferred());
+    const tasks = gates.map((g) =>
+      withUploadSlot("edge.zero", () => {
+        active++;
+        peak = Math.max(peak, active);
+        return g.promise.then(() => {
+          active--;
+        });
+      }),
+    );
+    await tick();
+    expect(peak).toBe(4); // no cap
+    gates.forEach((g) => g.resolve());
+    await Promise.all(tasks);
+  });
+});

--- a/tests/integration/regressions/browser-stub-parity.test.ts
+++ b/tests/integration/regressions/browser-stub-parity.test.ts
@@ -1,0 +1,102 @@
+// Regression guard: browser / cross-runtime build safety.
+//
+// The browser build (fix-browser-imports.js) replaces the Node-only H2 modules
+// (h2warm, h2pool, h2fetch) with hand-written stubs. If source code imports a
+// symbol from one of those modules that the stub does not export, the browser,
+// cloudflare-workers, and webpack bundles break with a missing-export error.
+// We hit exactly this when ENG-2680 added `withUploadSlot` to h2fetch and the
+// stub had to be updated to match.
+//
+// This test fails fast, with a clear message, whenever src imports a symbol from
+// a stubbed module that the browser stub does not provide — instead of waiting
+// for a confusing downstream bundle failure. No creds, no network.
+import { readdirSync, readFileSync, statSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CORE = join(here, "..", "..", "..", "@blaxel", "core");
+const SRC = join(CORE, "src");
+const FIX = join(CORE, "fix-browser-imports.js");
+
+// Parse the hand-written stub definitions: module name -> set of exported names.
+function parseStubExports(): Record<string, Set<string>> {
+  const text = readFileSync(FIX, "utf8");
+  const result: Record<string, Set<string>> = {};
+  const stubRe = /name:\s*'([^']+)'[\s\S]*?js:\s*`([\s\S]*?)`/g;
+  let match: RegExpExecArray | null;
+  while ((match = stubRe.exec(text)) !== null) {
+    const name = match[1];
+    const js = match[2];
+    const names = new Set<string>();
+    const exportRe = /export\s+(?:async\s+)?(?:function|const|class)\s+(\w+)/g;
+    let ex: RegExpExecArray | null;
+    while ((ex = exportRe.exec(js)) !== null) {
+      names.add(ex[1]);
+    }
+    result[name] = names;
+  }
+  return result;
+}
+
+// The Node-only modules that the browser build replaces wholesale with a stub.
+// Their own imports never ship to the browser, so we do not scan them.
+const STUBBED_MODULES = new Set(["h2warm", "h2pool", "h2fetch"]);
+
+// Collect the RUNTIME named imports of `moduleBase` (e.g. "h2fetch") across src
+// .ts files. Only runtime imports matter for the browser bundle: statement-level
+// `import type { ... }` and inline `import { type X }` are erased at compile
+// time and need no stub export, and the stubbed modules themselves are skipped.
+function collectSrcImports(moduleBase: string): Set<string> {
+  const imported = new Set<string>();
+  // Matches `import { ... } from ".../<module>.js"` but NOT `import type { ... }`
+  // (no `type` keyword is allowed between `import` and `{`).
+  const importRe = new RegExp(
+    "import\\s*\\{([^}]*)\\}\\s*from\\s*[\"'][^\"']*\\/" + moduleBase + "\\.js[\"']",
+    "g",
+  );
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!full.endsWith(".ts") || full.endsWith(".test.ts")) continue;
+      if (STUBBED_MODULES.has(entry.replace(/\.ts$/, ""))) continue;
+      const text = readFileSync(full, "utf8");
+      let m: RegExpExecArray | null;
+      while ((m = importRe.exec(text)) !== null) {
+        for (const raw of m[1].split(",")) {
+          const trimmed = raw.trim();
+          if (!trimmed || trimmed.startsWith("type ")) continue; // erased type import
+          const name = trimmed.split(/\s+as\s+/)[0].trim();
+          if (name) imported.add(name);
+        }
+      }
+    }
+  };
+  walk(SRC);
+  return imported;
+}
+
+describe("browser stub export parity (cross-runtime build safety)", () => {
+  const stubs = parseStubExports();
+
+  it("finds the H2 browser stubs in fix-browser-imports.js", () => {
+    expect(Object.keys(stubs).sort()).toEqual(["h2fetch", "h2pool", "h2warm"]);
+  });
+
+  for (const moduleBase of ["h2fetch", "h2pool", "h2warm"]) {
+    it(`browser stub for ${moduleBase} exports everything src imports from it`, () => {
+      const stubExports = stubs[moduleBase] ?? new Set<string>();
+      const imported = collectSrcImports(moduleBase);
+      const missing = [...imported].filter((name) => !stubExports.has(name));
+      expect(
+        missing,
+        `Browser stub "${moduleBase}" in fix-browser-imports.js is missing exports that src imports: [${missing.join(", ")}]. Add them to the stub, or the browser/cloudflare/webpack build will break.`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/integration/regressions/idempotent-op-retry.test.ts
+++ b/tests/integration/regressions/idempotent-op-retry.test.ts
@@ -1,0 +1,143 @@
+// Regression: idempotent sandbox-op retry (advances ENG-2682; same mechanism as
+// ENG-2680's upload retry, extended to GET-shaped reads/lists).
+//
+// ENG-2680 made only the UPLOAD path self-heal transient connection resets. But
+// the customer's intermittent failures (and the original gist) also hit
+// fs.read/ls, drives.list, and process.get — the reads a file viewer/agent makes
+// after a sandbox resumes. Those are idempotent, so they now retry transient
+// resets too.
+//
+// The critical guard this test locks in: process.exec is a NON-idempotent POST
+// (it creates a process) and must NEVER be retried — retrying it duplicates the
+// process, which is exactly the ENG-2340 bug. read-of-a-404 (a real application
+// error) must also never be retried.
+//
+// Drives the real classes through a fake hey-api client. No creds, no network.
+import { afterEach, describe, expect, it } from "vitest";
+import { SandboxFileSystem } from "../../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+import { SandboxDrive } from "../../../@blaxel/core/src/sandbox/drive/drive.js";
+import { SandboxProcess } from "../../../@blaxel/core/src/sandbox/process/process.js";
+import { settings } from "../../../@blaxel/core/src/common/settings.js";
+
+// A transport reset shaped like the real failure: top-level "fetch failed"
+// wrapping a cause that carries the ECONNRESET code.
+function econnreset(): Error {
+  return Object.assign(new Error("fetch failed"), {
+    cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+  });
+}
+
+const reset = () => {
+  throw econnreset();
+};
+const ok = (data: unknown) => () => ({ response: { ok: true, status: 200 }, data, error: undefined });
+const httpErr = (status: number) => () => ({ response: { ok: false, status }, data: undefined, error: { error: "nope" } });
+// A 4xx/5xx whose error BODY text contains a transport marker ("GOAWAY"/"ERR_HTTP2").
+// Must still be treated as an application error (not retried) because a real HTTP
+// status came back — the response-status guard in the classifier handles this.
+const httpErrMarker = (status: number) => () => ({ response: { ok: false, status }, data: undefined, error: { error: "upstream stream reset: GOAWAY (ERR_HTTP2)" } });
+
+// Build an instance of `Proto` whose generated-client calls (get/post/put/delete)
+// follow `behaviors` by attempt (last entry repeats). A behavior that throws
+// simulates a transport reset; one that returns simulates an HTTP response.
+function makeInstance<T>(Proto: { prototype: object }, behaviors: Array<() => unknown>): { inst: T; calls: () => number } {
+  const inst = Object.create(Proto.prototype) as Record<string, unknown>;
+  // forceUrl makes `this.url` resolve with no network/creds; the fake client
+  // shadows the prototype `client` getter so calls never hit the wire.
+  inst.sandbox = { forceUrl: "http://edge.test", metadata: { name: "t" } };
+  let calls = 0;
+  const handler = () => {
+    const i = calls++;
+    const behavior = behaviors[Math.min(i, behaviors.length - 1)];
+    return Promise.resolve().then(behavior);
+  };
+  Object.defineProperty(inst, "client", {
+    value: { get: handler, post: handler, put: handler, delete: handler },
+    configurable: true,
+  });
+  return { inst: inst as unknown as T, calls: () => calls };
+}
+
+describe("idempotent sandbox-op retry: reads/list self-heal, non-idempotent ops do not", () => {
+  afterEach(() => {
+    delete settings.config.fsPartRetries;
+    delete settings.config.sandboxReadRetries;
+  });
+
+  it("fs.read self-heals a transient reset (default-on)", async () => {
+    expect(settings.sandboxReadRetries).toBe(5); // idempotent-read budget (higher, for cold-start)
+    expect(settings.fsPartRetries).toBe(3); // upload budget stays lower/unchanged
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [reset, reset, ok({ content: "hi" })]);
+    await expect(inst.read("/f")).resolves.toBe("hi");
+    expect(calls()).toBe(3); // 1 attempt + 2 retries
+  });
+
+  it("fs.ls self-heals a transient reset (the file-tree refresh that flaked)", async () => {
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [reset, ok({ files: [], subdirectories: [] })]);
+    await expect(inst.ls("/")).resolves.toBeDefined();
+    expect(calls()).toBe(2);
+  });
+
+  it("drives.list self-heals a transient reset", async () => {
+    const { inst, calls } = makeInstance<SandboxDrive>(SandboxDrive, [reset, ok({ mounts: [] })]);
+    await expect(inst.list()).resolves.toEqual([]);
+    expect(calls()).toBe(2);
+  });
+
+  it("process.get self-heals a transient reset (also hardens the wait() poll loop)", async () => {
+    const { inst, calls } = makeInstance<SandboxProcess>(SandboxProcess, [reset, ok({ pid: "1", status: "completed" })]);
+    await expect(inst.get("1")).resolves.toBeDefined();
+    expect(calls()).toBe(2);
+  });
+
+  it("does NOT retry a non-transient application error on a read (404)", async () => {
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [httpErr(404)]);
+    await expect(inst.read("/missing")).rejects.toBeDefined();
+    expect(calls()).toBe(1); // a 404 is not transient: no retry
+  });
+
+  it("does NOT retry a 4xx/5xx whose body text contains a reset marker (no over-match)", async () => {
+    // The server returned a real HTTP status; even though its error body says
+    // "GOAWAY"/"ERR_HTTP2", it must not be retried as a transport reset.
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [httpErrMarker(500)]);
+    await expect(inst.read("/x")).rejects.toBeDefined();
+    expect(calls()).toBe(1);
+  });
+
+  it("fs.readBinary self-heals a transient reset", async () => {
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [reset, ok("bytes")]);
+    await expect(inst.readBinary("/b")).resolves.toBeInstanceOf(Blob);
+    expect(calls()).toBe(2);
+  });
+
+  it("process.list self-heals a transient reset", async () => {
+    const { inst, calls } = makeInstance<SandboxProcess>(SandboxProcess, [reset, ok({ processes: [] })]);
+    await expect(inst.list()).resolves.toBeDefined();
+    expect(calls()).toBe(2);
+  });
+
+  it("process.logs self-heals a transient reset", async () => {
+    const { inst, calls } = makeInstance<SandboxProcess>(SandboxProcess, [reset, ok({ logs: "hi" })]);
+    await expect(inst.logs("1")).resolves.toBe("hi");
+    expect(calls()).toBe(2);
+  });
+
+  it("uses the higher read budget (5): self-heals after 4 resets", async () => {
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [reset, reset, reset, reset, ok({ content: "ok" })]);
+    await expect(inst.read("/deep")).resolves.toBe("ok");
+    expect(calls()).toBe(5); // 1 attempt + 4 retries, within the budget of 5
+  });
+
+  it("process.exec does NOT retry a transient reset (guards ENG-2340 duplicate-exec)", async () => {
+    const { inst, calls } = makeInstance<SandboxProcess>(SandboxProcess, [reset, reset, reset]);
+    await expect(inst.exec({ command: "echo hi" } as never)).rejects.toBeDefined();
+    expect(calls()).toBe(1); // POST is non-idempotent: exactly one attempt, never retried
+  });
+
+  it("idempotent-read retry can be disabled (sandboxReadRetries=0)", async () => {
+    settings.config.sandboxReadRetries = 0;
+    const { inst, calls } = makeInstance<SandboxFileSystem>(SandboxFileSystem, [reset]);
+    await expect(inst.read("/f")).rejects.toBeDefined();
+    expect(calls()).toBe(1); // retry disabled: exactly one attempt
+  });
+});

--- a/tests/unit/filesystem-part-retry.test.ts
+++ b/tests/unit/filesystem-part-retry.test.ts
@@ -147,15 +147,27 @@ describe("SandboxFileSystem part-upload retry", () => {
   });
 
   describe("retry budget", () => {
-    it("is disabled by default (fsPartRetries unset = 0, no retries)", async () => {
-      // No settings.config.fsPartRetries set.
+    it("is on by default (fsPartRetries unset = 3) so transient resets self-heal", async () => {
+      // No settings.config.fsPartRetries set -> the default (3) applies.
       const { harness, part2Attempts } = harnessFailingPart2(
         Object.assign(new Error("reset"), { code: "ECONNRESET" }),
       );
       await expect(
         harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
       ).rejects.toThrow("reset");
-      // Default-off: exactly one attempt for the failing part, no retry.
+      // 1 initial attempt + 3 default retries = 4 total for the failing part.
+      expect(part2Attempts()).toBe(4);
+    });
+
+    it("can be turned off (fsPartRetries = 0, no retries)", async () => {
+      settings.config.fsPartRetries = 0;
+      const { harness, part2Attempts } = harnessFailingPart2(
+        Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+      );
+      await expect(
+        harness.uploadWithMultipart("/tmp/f.bin", multiPartBlob()),
+      ).rejects.toThrow("reset");
+      // Exactly one attempt for the failing part, no retry.
       expect(part2Attempts()).toBe(1);
     });
 


### PR DESCRIPTION
Makes sandbox file/drive/process calls recover on their own from the transient connection resets some hit (sandbox resuming from standby, or burst load) instead of failing the call.

- Uploads (`fs.writeBinary`, single-PUT and multipart) and idempotent reads (`fs.read`/`readBinary`/`ls`/`search`/`find`/`grep`, `drives.list`, `process.get`/`list`/`logs`) now auto-retry transient resets (`ECONNRESET` / `GOAWAY` / `ENHANCE_YOUR_CALM`) with backoff, and cap concurrent upload streams per domain. On by default.
- Conservative and idempotent: only idempotent ops retry. Non-idempotent ops are never retried — `process.exec`, `drives.mount`, `unmount`/`stop`/`kill` — so a reset can't duplicate a side effect (keeps the ENG-2342/ENG-2340 never-duplicate-a-POST rule intact). A real 4xx/5xx is never read as a transient reset, even if its body text mentions a reset code.
- Reads use a higher retry budget than uploads to span a multi-second standby wake. Opt out with `fsPartRetries: 0` / `sandboxReadRetries: 0` (or `BL_FS_PART_RETRIES` / `BL_SANDBOX_READ_RETRIES`).
- The server-side root cause (the connection dropping on sandbox resume / burst) is tracked separately (ENG-2621); this is the client mitigation that makes the common cases self-heal now.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extends ENG-2680 upload self-healing to all idempotent sandbox ops (fs reads, drives.list, process.get/list/logs), factors the transient-reset classifier and retry loop into a shared `common/transient-retry.ts`, fixes a spurious `CredentialsError` in `writeBinary` for `forceUrl` sessions, and moves the upload slot acquisition inside the retry loop on both the single-PUT and multipart paths so the per-domain cap bounds in-flight streams rather than retry sequences.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e80788977b698dfce01dd1c0951b7677d9969657.</sup>
<!-- /MENDRAL_SUMMARY -->