### PR TITLE
fix(auth): clear errors for missing BL_WORKSPACE/BL_API_KEY (ENG-2698)

### DIFF
--- a/@blaxel/core/src/authentication/credentials.ts
+++ b/@blaxel/core/src/authentication/credentials.ts
@@ -15,3 +15,12 @@ export class Credentials {
     return "";
   }
 }
+
+/**
+ * Marker returned by `authentication()` when no usable Blaxel credentials were
+ * resolved (no env vars, no matching config workspace). Construction is
+ * side-effect free so importing `@blaxel/core` never fails; the actionable
+ * error is raised when an authenticated request is actually attempted
+ * (see `Settings.assertCredentials`).
+ */
+export class MissingCredentials extends Credentials {}

--- a/@blaxel/core/src/authentication/index.ts
+++ b/@blaxel/core/src/authentication/index.ts
@@ -4,7 +4,7 @@ import { env } from "../common/env.js";
 import { fs, os, path } from "../common/node.js";
 import { ApiKey } from "./apikey.js";
 import { ClientCredentials } from "./clientcredentials.js";
-import { Credentials } from "./credentials.js";
+import { Credentials, MissingCredentials } from "./credentials.js";
 import { DeviceMode } from "./deviceMode.js";
 import { CredentialsType } from "./types.js";
 
@@ -69,7 +69,9 @@ function getCredentials(): CredentialsType | null {
 export function authentication() {
   const credentials = getCredentials();
   if (!credentials) {
-    return new Credentials();
+    // Never silently fall back to empty headers: a marker that triggers a
+    // clear CredentialsError when an authenticated request is attempted.
+    return new MissingCredentials();
   }
 
   if (credentials.apiKey) {

--- a/@blaxel/core/src/common/credentials.test.ts
+++ b/@blaxel/core/src/common/credentials.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ApiKey } from '../authentication/apikey.js';
+import { Credentials, MissingCredentials } from '../authentication/credentials.js';
+import { authentication } from '../authentication/index.js';
+import { CredentialsError } from './errors.js';
+import { settings } from './settings.js';
+
+/**
+ * ENG-2698: missing / partial BL_WORKSPACE / BL_API_KEY must fail fast with a
+ * clear, actionable error instead of silently sending empty headers and
+ * surfacing the server's misleading "workspace is required".
+ *
+ * `env` reads through to `process.env`, so env state is controlled there.
+ */
+describe('credential validation', () => {
+  const AUTH_ENV = ['BL_API_KEY', 'BL_WORKSPACE', 'BL_CLIENT_CREDENTIALS'] as const;
+  let savedEnv: Record<string, string | undefined>;
+  let savedCredentials: Credentials;
+  let savedConfig: typeof settings.config;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of AUTH_ENV) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    savedCredentials = settings.credentials;
+    savedConfig = settings.config;
+    settings.config = { proxy: '', apikey: '', workspace: '' };
+  });
+
+  afterEach(() => {
+    for (const key of AUTH_ENV) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    settings.credentials = savedCredentials;
+    settings.config = savedConfig;
+  });
+
+  it('API key without workspace throws a clear BL_WORKSPACE error from headers', () => {
+    settings.credentials = new ApiKey({ apiKey: 'test-key' });
+    expect(() => settings.headers).toThrow(CredentialsError);
+    expect(() => settings.headers).toThrow(/BL_WORKSPACE/);
+  });
+
+  it('API key without workspace rejects from authenticate()', async () => {
+    settings.credentials = new ApiKey({ apiKey: 'test-key' });
+    await expect(settings.authenticate()).rejects.toThrow(/BL_WORKSPACE/);
+  });
+
+  it('workspace set but no API key names the missing API key', () => {
+    process.env.BL_WORKSPACE = 'my-workspace';
+    settings.credentials = new MissingCredentials();
+    expect(() => settings.headers).toThrow(/API key is missing/);
+  });
+
+  it('no credentials at all names both env vars', () => {
+    settings.credentials = new MissingCredentials();
+    expect(() => settings.headers).toThrow(CredentialsError);
+    expect(() => settings.headers).toThrow(/BL_API_KEY and BL_WORKSPACE/);
+  });
+
+  it('api key + workspace builds clean headers with no empty values', () => {
+    settings.credentials = new ApiKey({ apiKey: 'test-key', workspace: 'my-workspace' });
+    const headers = settings.headers;
+    expect(headers['x-blaxel-workspace']).toBe('my-workspace');
+    expect(headers['x-blaxel-authorization']).toBe('Bearer test-key');
+    expect(Object.values(headers)).not.toContain('');
+  });
+
+  it('authentication() returns a real ApiKey when BL_API_KEY is set', () => {
+    process.env.BL_API_KEY = 'test-key';
+    expect(authentication()).toBeInstanceOf(ApiKey);
+  });
+});

--- a/@blaxel/core/src/common/errors.ts
+++ b/@blaxel/core/src/common/errors.ts
@@ -1,3 +1,17 @@
+/**
+ * Thrown when Blaxel credentials are missing or incomplete.
+ *
+ * Surfaced eagerly with an actionable message (which env var / login step is
+ * missing) instead of silently sending empty workspace/authorization headers
+ * and letting the user hit a misleading server-side "workspace is required".
+ */
+export class CredentialsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialsError";
+  }
+}
+
 export function handleDynamicImportError(err: any) {
   if (err instanceof Error) {
     // We check if it's module import error and retrieve package name from the error message with a regex

--- a/@blaxel/core/src/common/settings.test.ts
+++ b/@blaxel/core/src/common/settings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ApiKey } from '../authentication/apikey.js';
 import { env } from './env.js';
 
 describe('Settings.apiVersion', () => {
@@ -19,6 +20,13 @@ describe('Settings.apiVersion', () => {
   it('headers include Blaxel-Version set to the default', async () => {
     delete (env as Record<string, unknown>).BL_API_VERSION;
     const { settings } = await import('./settings.js');
-    expect(settings.headers['Blaxel-Version']).toBe('2026-04-16');
+    // headers now requires resolvable credentials; run in an authenticated context
+    const previous = settings.credentials;
+    settings.credentials = new ApiKey({ apiKey: 'test-key', workspace: 'test-ws' });
+    try {
+      expect(settings.headers['Blaxel-Version']).toBe('2026-04-16');
+    } finally {
+      settings.credentials = previous;
+    }
   });
 });

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -1,10 +1,27 @@
 import yaml from 'yaml';
 import { ApiKey } from "../authentication/apikey.js";
 import { ClientCredentials } from "../authentication/clientcredentials.js";
-import { Credentials } from "../authentication/credentials.js";
+import { Credentials, MissingCredentials } from "../authentication/credentials.js";
 import { authentication } from "../authentication/index.js";
 import { env } from "../common/env.js";
+import { CredentialsError } from "../common/errors.js";
 import { fs, os, path } from "../common/node.js";
+
+/**
+ * Build an actionable "credentials missing" message naming exactly which piece
+ * is absent, based on the env vars currently set.
+ */
+function missingCredentialsMessage(): string {
+  const hasWorkspace = !!env.BL_WORKSPACE;
+  const hasApiKey = !!env.BL_API_KEY;
+  if (hasWorkspace && !hasApiKey) {
+    return "Blaxel API key is missing. Set the BL_API_KEY environment variable, or run `bl login`, to authenticate (BL_WORKSPACE is already set).";
+  }
+  if (hasApiKey && !hasWorkspace) {
+    return "Blaxel workspace is missing. Set the BL_WORKSPACE environment variable, or run `bl login`, to authenticate (BL_API_KEY is already set).";
+  }
+  return "No Blaxel credentials found. Set the BL_API_KEY and BL_WORKSPACE environment variables, or run `bl login`.";
+}
 
 /**
  * Client credentials as a `{ clientId, clientSecret }` pair.
@@ -233,6 +250,7 @@ class Settings {
   }
 
   get headers(): Record<string, string> {
+    this.assertCredentials();
     const osArch = getOsArch();
     return {
       "x-blaxel-authorization": this.authorization,
@@ -331,7 +349,32 @@ class Settings {
     return 0;
   }
 
+  /**
+   * Fail fast with a clear, actionable error when credentials are missing or
+   * incomplete, instead of sending empty workspace/authorization headers and
+   * surfacing a misleading server-side "workspace is required". Skipped for
+   * `forceUrl` sandbox sessions, which carry their own headers and never read
+   * `settings.headers`. Leaves `workspace` itself non-throwing so telemetry
+   * tagging stays safe.
+   */
+  private assertCredentials() {
+    const hasConfigCredentials = !!(
+      this.config.apikey ||
+      this.config.apiKey ||
+      this.config.clientCredentials
+    );
+    if (!hasConfigCredentials && this.credentials instanceof MissingCredentials) {
+      throw new CredentialsError(missingCredentialsMessage());
+    }
+    if (!this.workspace) {
+      throw new CredentialsError(
+        "Blaxel workspace is missing. Set the BL_WORKSPACE environment variable, or run `bl login`, to authenticate your requests."
+      );
+    }
+  }
+
   async authenticate() {
+    this.assertCredentials();
     await this.credentials.authenticate();
   }
 }


### PR DESCRIPTION
Fixes ENG-2698.

- Missing or partial credentials silently coalesced to empty strings, so the SDK sent empty workspace/auth headers and the user hit the server's misleading "workspace is required" with no client-side guidance.
- The SDK now fails fast with one clear error naming what to set (BL_API_KEY, BL_WORKSPACE, or `bl login`) before any request goes out.

Mirrors the Python fix (blaxel-ai/sdk-python#153).

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds fail-fast credential validation to the TypeScript SDK. When `BL_API_KEY` or `BL_WORKSPACE` are missing, `authentication()` now returns a `MissingCredentials` marker instead of an empty `Credentials`. A new `assertCredentials()` method called from both `settings.headers` and `settings.authenticate()` throws a `CredentialsError` with an actionable message naming the missing piece before any HTTP request goes out. Mirrors the Python SDK fix (sdk-python#153).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3a82dc8ce394c83c3f636c3707ee8279c870f3b4.</sup>
<!-- /MENDRAL_SUMMARY -->