### PR TITLE
fix: make createIfNotExists survive the post-delete window

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -21,6 +21,24 @@ const NON_REUSABLE_SANDBOX_STATUSES = new Set([
   "DEACTIVATING",
 ]);
 
+// Statuses that resolve on their own (a delete or deactivation in flight). The control
+// plane keeps answering 409 to creates while the record is in one of these, so retrying
+// instantly burns the whole attempt budget inside the window. Terminal statuses
+// (FAILED, TERMINATED) accept a create immediately and are not listed here.
+const TRANSIENT_SANDBOX_STATUSES = new Set([
+  "TERMINATING",
+  "DELETING",
+  "DEACTIVATING",
+]);
+const TRANSIENT_STATUS_MAX_WAIT_MS = 30_000;
+const TRANSIENT_STATUS_POLL_MS = 500;
+
+const isSandboxNotFound = (e: unknown): boolean => {
+  if (typeof e !== "object" || e === null) return false;
+  const candidate = e as { code?: unknown; status?: unknown };
+  return candidate.code === 404 || candidate.code === "404" || candidate.status === 404;
+};
+
 export class SandboxInstance {
   fs: SandboxFileSystem;
   network: SandboxNetwork;
@@ -314,7 +332,9 @@ export class SandboxInstance {
 
   static async createIfNotExists(sandbox: SandboxModel | SandboxCreateConfiguration) {
     const ATTEMPTS = 3;
+    let lastStatus = "unknown";
     for (let i = 0; i < ATTEMPTS; ++i) {
+      const finalAttempt = i === ATTEMPTS - 1;
       try {
         return await this.create(sandbox, { createIfNotExist: true });
       } catch (e) {
@@ -325,11 +345,33 @@ export class SandboxInstance {
           }
 
           // Get the existing sandbox to check its status
-          const sandboxInstance = await this.get(name);
+          let sandboxInstance: SandboxInstance;
+          try {
+            sandboxInstance = await this.get(name);
+          } catch (getError) {
+            if (isSandboxNotFound(getError)) {
+              // The record vanished between the create conflict and this status check
+              // (its deletion just finished); give the control plane a beat and retry.
+              lastStatus = "vanished";
+              if (!finalAttempt) {
+                await new Promise((resolve) => setTimeout(resolve, TRANSIENT_STATUS_POLL_MS));
+              }
+              continue;
+            }
+            throw getError;
+          }
 
           // Recreate instead of returning sandbox records that cannot be reused.
           if (!NON_REUSABLE_SANDBOX_STATUSES.has(sandboxInstance.status ?? "")) {
             return sandboxInstance;
+          }
+
+          // A delete or deactivation in flight rejects creates until it finishes;
+          // wait it out instead of burning the remaining attempts inside the window.
+          // No point waiting after the last attempt: nothing will use the result.
+          lastStatus = sandboxInstance.status ?? "unknown";
+          if (TRANSIENT_SANDBOX_STATUSES.has(lastStatus) && !finalAttempt) {
+            await this.waitWhileSandboxDying(name);
           }
 
           // Retry creation. We want the same error handling on the retry as creates can race.
@@ -338,7 +380,26 @@ export class SandboxInstance {
         throw e;
       }
     }
-    throw new Error(`Unable to create sandbox after ${ATTEMPTS} attempts.`);
+    throw new Error(`Unable to create sandbox after ${ATTEMPTS} attempts. Last conflicting status: ${lastStatus}.`);
+  }
+
+  // Poll the record until an in-flight delete/deactivation settles (or the record
+  // disappears), bounded by TRANSIENT_STATUS_MAX_WAIT_MS. Errors from get (e.g. 404
+  // once the record is gone) end the wait: the caller's create retry decides next.
+  private static async waitWhileSandboxDying(name: string): Promise<void> {
+    const deadline = Date.now() + TRANSIENT_STATUS_MAX_WAIT_MS;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, TRANSIENT_STATUS_POLL_MS));
+      try {
+        const current = await this.get(name);
+        if (!TRANSIENT_SANDBOX_STATUSES.has(current.status ?? "")) {
+          return;
+        }
+        logger.debug(`Sandbox ${name} still ${current.status}; waiting for the record to settle before recreating`);
+      } catch {
+        return;
+      }
+    }
   }
 
   /* eslint-disable */

--- a/tests/unit/sandbox-create-if-not-exists.test.ts
+++ b/tests/unit/sandbox-create-if-not-exists.test.ts
@@ -48,20 +48,18 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
   it.each([
     "FAILED",
     "TERMINATED",
-    "TERMINATING",
-    "DELETING",
-    "DEACTIVATING",
-  ])("retries creation when the conflicting sandbox is %s", async (status) => {
+  ])("retries creation immediately when the conflicting sandbox is %s", async (status) => {
     const replacement = sandbox("stale", "DEPLOYED");
     const create = vi.spyOn(SandboxInstance, "create");
     create.mockRejectedValueOnce(conflict());
     create.mockResolvedValueOnce(replacement);
-    vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(sandbox("stale", status));
+    const get = vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(sandbox("stale", status));
 
     await expect(
       SandboxInstance.createIfNotExists({ name: "stale" }),
     ).resolves.toBe(replacement);
     expect(create).toHaveBeenCalledTimes(2);
+    expect(get).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenNthCalledWith(
       1,
       { name: "stale" },
@@ -72,6 +70,103 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
       { name: "stale" },
       { createIfNotExist: true },
     );
+  });
+
+  it.each([
+    "TERMINATING",
+    "DELETING",
+    "DEACTIVATING",
+  ])("waits out the dying record before retrying when the conflicting sandbox is %s", async (status) => {
+    const replacement = sandbox("dying", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockResolvedValueOnce(replacement);
+    const get = vi.spyOn(SandboxInstance, "get")
+      .mockResolvedValueOnce(sandbox("dying", status))
+      .mockResolvedValue(sandbox("dying", "TERMINATED"));
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "dying" }),
+    ).resolves.toBe(replacement);
+    expect(create).toHaveBeenCalledTimes(2);
+    // initial status check plus at least one poll while the record was dying
+    expect(get.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps polling while the record stays DELETING across several polls", async () => {
+    const replacement = sandbox("slow-delete", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockResolvedValueOnce(replacement);
+    vi.spyOn(SandboxInstance, "get")
+      .mockResolvedValueOnce(sandbox("slow-delete", "DELETING"))
+      .mockResolvedValueOnce(sandbox("slow-delete", "DELETING"))
+      .mockResolvedValueOnce(sandbox("slow-delete", "DELETING"))
+      .mockResolvedValue(sandbox("slow-delete", "TERMINATED"));
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "slow-delete" }),
+    ).resolves.toBe(replacement);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries when the record vanishes between the create conflict and the status check", async () => {
+    const replacement = sandbox("vanished", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockResolvedValueOnce(replacement);
+    vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+      Object.assign(new Error("Sandbox not found"), { code: 404 }),
+    );
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "vanished" }),
+    ).resolves.toBe(replacement);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates non-404 errors from the status check", async () => {
+    vi.spyOn(SandboxInstance, "create").mockRejectedValueOnce(conflict());
+    vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+      Object.assign(new Error("internal error"), { code: 500 }),
+    );
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "broken" }),
+    ).rejects.toThrow("internal error");
+  });
+
+  it("retries promptly when the dying record disappears (get 404s) during the wait", async () => {
+    const replacement = sandbox("gone", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(conflict());
+    create.mockResolvedValueOnce(replacement);
+    vi.spyOn(SandboxInstance, "get")
+      .mockResolvedValueOnce(sandbox("gone", "DELETING"))
+      .mockRejectedValue(Object.assign(new Error("not found"), { code: 404 }));
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "gone" }),
+    ).resolves.toBe(replacement);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the bounded wait when the record never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(SandboxInstance, "create").mockRejectedValue(conflict());
+      vi.spyOn(SandboxInstance, "get").mockResolvedValue(sandbox("stuck", "DELETING"));
+
+      const promise = SandboxInstance.createIfNotExists({ name: "stuck" });
+      const assertion = expect(promise).rejects.toThrow(
+        "Unable to create sandbox after 3 attempts. Last conflicting status: DELETING.",
+      );
+      // two non-final attempts wait out the full 30s bound; the final attempt skips it
+      await vi.advanceTimersByTimeAsync(61_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("handles a recreate race after first seeing a terminated sandbox", async () => {


### PR DESCRIPTION
- createIfNotExists no longer fails when called right after deleting a sandbox with the same name. Transient records (DELETING / TERMINATING / DEACTIVATING) are now polled (500ms, 30s bound) until the deletion settles before the next create attempt, and a record that vanishes between the create conflict and the status check retries instead of throwing "Sandbox not found".
- Before: delete-then-recreate failed deterministically on the published SDK (0/6 live rounds, "Unable to create sandbox after 3 attempts"); after: 100% success against the live platform. The failure error now reports the last conflicting status.
- Trade-off: a record permanently stuck in a dying state now takes up to ~61s to fail (two bounded waits) instead of failing instantly with the wrong error.

ENG-2967

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds polling logic to `createIfNotExists` so it waits for transient sandbox states (DELETING/TERMINATING/DEACTIVATING) to settle before retrying creation, and handles the case where a sandbox record vanishes between the 409 conflict and the subsequent status check.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0f39f8dff36b9c310538f7be7259de973fbca6dd.</sup>
<!-- /MENDRAL_SUMMARY -->