### PR TITLE
feat(h2): introduce configurable HTTP/2 flow-control window sizes

### DIFF
--- a/@blaxel/core/src/common/h2warm.ts
+++ b/@blaxel/core/src/common/h2warm.ts
@@ -2,6 +2,7 @@ import dns from "dns/promises";
 import http2 from "http2";
 import tls from "tls";
 import { markH2SessionIdleUnref } from "./h2ref.js";
+import { settings } from "./settings.js";
 
 export async function establishH2(sniHostname: string): Promise<http2.ClientHttp2Session> {
   let timedOut = false;
@@ -34,8 +35,13 @@ async function _establishH2(sniHostname: string): Promise<http2.ClientHttp2Sessi
     ALPNProtocols: ["h2"],
   });
 
+  // Raise the per-stream receive window (SETTINGS_INITIAL_WINDOW_SIZE) well above
+  // Node's 64KB default. With the default, the server can only send one 64KB
+  // burst per round trip, capping a single download at window/RTT (~3MB/s at
+  // 20ms RTT) no matter the payload size.
   const session = http2.connect(`https://${sniHostname}:443`, {
     createConnection: () => tlsSocket,
+    settings: { initialWindowSize: settings.h2StreamWindowSize },
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -46,6 +52,17 @@ async function _establishH2(sniHostname: string): Promise<http2.ClientHttp2Sessi
       reject(err instanceof Error ? err : new Error(String(err)));
     });
   });
+
+  // Raise the connection-level receive window too. Node defaults it to 64KB and
+  // never grows it, so it throttles the entire session (shared across every
+  // stream) — which is why adding read concurrency does not help. setLocalWindowSize
+  // is best-effort: guard it so an older runtime without it never breaks warm-up.
+  try {
+    (session as unknown as { setLocalWindowSize?: (n: number) => void })
+      .setLocalWindowSize?.(settings.h2ConnectionWindowSize);
+  } catch {
+    // ignore — fall back to the default window
+  }
 
   // Complete the SETTINGS exchange so the first real request has zero
   // protocol overhead. This RTT is hidden by the parallel createSandbox() call.

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -66,6 +66,20 @@ export type Config = {
    */
   sandboxReadRetries?: number;
   /**
+   * Per-stream HTTP/2 flow-control window in bytes, advertised to the server as
+   * SETTINGS_INITIAL_WINDOW_SIZE. Node defaults this to 64KB, which caps a single
+   * download at window/RTT (~3MB/s at 20ms RTT) regardless of payload size.
+   * Defaults to 16MB so large reads are bandwidth-bound, not latency-bound.
+   */
+  h2StreamWindowSize?: number;
+  /**
+   * Connection-level HTTP/2 flow-control window in bytes, applied via
+   * session.setLocalWindowSize(). Node defaults this to 64KB and never grows it,
+   * so it throttles the WHOLE session (shared across all streams) — which is why
+   * adding read concurrency does not help. Defaults to 32MB.
+   */
+  h2ConnectionWindowSize?: number;
+  /**
    * Client credentials for OAuth2 client_credentials flow.
    *
    * Accepts either:
@@ -365,6 +379,34 @@ class Settings {
       }
     }
     return 2;
+  }
+
+  get h2StreamWindowSize(): number {
+    if (typeof this.config.h2StreamWindowSize === "number") {
+      return this.config.h2StreamWindowSize;
+    }
+    const value = env.BL_H2_STREAM_WINDOW;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+    return 16 * 1024 * 1024;
+  }
+
+  get h2ConnectionWindowSize(): number {
+    if (typeof this.config.h2ConnectionWindowSize === "number") {
+      return this.config.h2ConnectionWindowSize;
+    }
+    const value = env.BL_H2_CONNECTION_WINDOW;
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+    return 32 * 1024 * 1024;
   }
 
   get fsPartRetries(): number {


### PR DESCRIPTION
Fixes ENG-2990

Added settings for per-stream and connection-level HTTP/2 flow-control window sizes to enhance performance. The defaults are set to 16MB for per-stream and 32MB for connection-level, addressing Node's default limitations. Updated the h2warm module to utilize these settings, improving download efficiency and reducing latency issues.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds configurable HTTP/2 flow-control window sizes (per-stream and connection-level) to overcome Node.js's default 64KB limits, with defaults of 16MB and 32MB respectively. Settings are exposed via config and environment variables.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0cf77e61277b9561621376e3d8b676ad898334e4.</sup>
<!-- /MENDRAL_SUMMARY -->