### PR TITLE
[codex] Raise H2 listener budget for concurrent sandbox requests

### DIFF
--- a/@blaxel/core/src/common/h2fetch.ts
+++ b/@blaxel/core/src/common/h2fetch.ts
@@ -18,7 +18,7 @@ type H2SendOptions = {
   releaseSlot?: () => void;
 };
 
-const MIN_H2_SESSION_MAX_LISTENERS = 64;
+const MIN_H2_SESSION_MAX_LISTENERS = 256;
 const sessionsWithListenerBudget = new WeakSet<http2.ClientHttp2Session>();
 
 /**

--- a/tests/integration/common/h2fetch.test.ts
+++ b/tests/integration/common/h2fetch.test.ts
@@ -218,7 +218,7 @@ describe('h2fetch: no silent retry after session.request()', () => {
       { method: 'POST', body: 'payload' },
     );
 
-    expect(session.getMaxListeners()).toBeGreaterThan(10);
+    expect(session.getMaxListeners()).toBeGreaterThanOrEqual(100);
 
     session.lastStream!.emit('response', { ':status': 200 });
     session.lastStream!.emit('end');

--- a/tests/integration/fault-injection/h2-protocol-races.test.ts
+++ b/tests/integration/fault-injection/h2-protocol-races.test.ts
@@ -180,6 +180,6 @@ describe("_h2Send protocol-race ordering", () => {
 
     // The listener budget was raised once for the session (h2fetch.ts:442-450),
     // so the per-request adds never tripped MaxListenersExceededWarning.
-    expect(session!.getMaxListeners()).toBeGreaterThanOrEqual(64);
+    expect(session!.getMaxListeners()).toBeGreaterThanOrEqual(256);
   });
 });


### PR DESCRIPTION
Fixes ENG-2689

## Summary

- raise the per-session HTTP/2 listener budget from 64 to 256
- keep the transport listener hygiene tests aligned with 100 concurrent sandbox process requests
- avoid Node MaxListenersExceededWarning when many requests share one H2 session

## Context

The Blaxel concurrent sandbox benchmark launches 100 sandboxes and then runs process exec requests over a shared regional H2 session. With the old listener budget, Node emitted MaxListenersExceededWarning at 65 close/error/goaway listeners. In local A/B runs against the unchanged benchmark, raising the budget removed those warnings.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Raises the per-session HTTP/2 `maxListeners` budget from 64 to 256 to avoid Node `MaxListenersExceededWarning` when many concurrent sandbox requests share a single H2 session. Test assertions are updated to match.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a1197fc26b4de8ce3143d485dee4efd4da2c3216.</sup>
<!-- /MENDRAL_SUMMARY -->