### PR TITLE
feat: route control-plane calls over HTTP/2 with an opt-out flag

### DIFF
--- a/@blaxel/core/src/common/autoload.ts
+++ b/@blaxel/core/src/common/autoload.ts
@@ -2,12 +2,14 @@ import { client } from "../client/client.gen.js";
 import { interceptors } from "../client/interceptors.js";
 import { responseInterceptors } from "../client/responseInterceptor.js";
 import { client as clientSandbox } from "../sandbox/client/client.gen.js";
+import { controlPlaneFetch } from "./controlPlaneFetch.js";
 import { Config, settings } from "./settings.js";
 
 export { ensureAutoloaded } from "./lazyInit.js";
 
 client.setConfig({
   baseUrl: settings.baseUrl,
+  fetch: controlPlaneFetch,
 });
 
 // Register request interceptors
@@ -55,6 +57,7 @@ export function initialize(config: Config) {
   settings.setConfig(config);
   client.setConfig({
     baseUrl: settings.baseUrl,
+    fetch: controlPlaneFetch,
   });
   clientSandbox.setConfig({
     baseUrl: settings.baseUrl,

--- a/@blaxel/core/src/common/controlPlaneFetch.ts
+++ b/@blaxel/core/src/common/controlPlaneFetch.ts
@@ -1,0 +1,68 @@
+import { createPoolBackedH2Fetch } from "./h2fetch.js";
+import { h2Pool } from "./h2pool.js";
+import { settings } from "./settings.js";
+
+const h2FetchByHost = new Map<string, (input: Request) => Promise<Response>>();
+
+// Node's global fetch dispatcher only negotiates HTTP/2 by default starting
+// with undici 8 (Node 26+); undici 7 (Node 24) and undici 6 (Node 22) still
+// ALPN to HTTP/1.1 for fetch, verified empirically against api.blaxel.ai. On
+// undici >= 8 the pooled wrapper is redundant, so we prefer the native path.
+export function undiciSupportsNativeH2(undiciVersion: string | undefined): boolean {
+  const major = Number(undiciVersion?.split(".")[0] ?? 0);
+  return major >= 8;
+}
+
+// `process`/`process.versions` is absent on Cloudflare Workers and other
+// non-Node runtimes, and `process.versions.undici` is undefined on Bun/Deno;
+// all of those resolve to `false` and keep the wrapper as the fallback.
+export const nativeFetchSupportsH2 =
+  typeof process !== "undefined" && undiciSupportsNativeH2(process.versions?.undici);
+
+export function shouldUseControlPlaneH2(
+  url: URL,
+  h2Disabled: boolean,
+  proxyConfigured = false,
+  nativeH2 = false,
+  forceWrapper = false,
+): boolean {
+  if (h2Disabled || proxyConfigured) return false;
+  if (url.protocol !== "https:") return false;
+  // Token refresh is sequential and unauthenticated; it cannot contribute to
+  // the create burst TLS storm, and device-mode refresh currently relies on the
+  // native fetch path.
+  if (url.pathname.endsWith("/oauth/token")) return false;
+  if (!(url.hostname.endsWith("blaxel.ai") || url.hostname.endsWith("blaxel.dev"))) {
+    return false;
+  }
+  // Native fetch already negotiates HTTP/2: skip the redundant wrapper unless
+  // explicitly forced (e.g. to exercise the pooled path on a modern runtime).
+  if (nativeH2 && !forceWrapper) return false;
+  return true;
+}
+
+export function controlPlaneFetch(input: Request): Promise<Response> {
+  const url = new URL(input.url);
+  const proxyConfigured = Boolean(settings.config.proxy);
+  // Global disableH2 still wins; disableControlPlaneH2 opts out of just the
+  // control-plane wrapper while leaving data-plane H2 in place.
+  const h2Disabled = settings.disableH2 || settings.disableControlPlaneH2;
+  if (
+    !shouldUseControlPlaneH2(
+      url,
+      h2Disabled,
+      proxyConfigured,
+      nativeFetchSupportsH2,
+      settings.forceControlPlaneH2,
+    )
+  ) {
+    return globalThis.fetch(input);
+  }
+
+  let h2Fetch = h2FetchByHost.get(url.hostname);
+  if (!h2Fetch) {
+    h2Fetch = createPoolBackedH2Fetch(h2Pool, url.hostname);
+    h2FetchByHost.set(url.hostname, h2Fetch);
+  }
+  return h2Fetch(input);
+}

--- a/@blaxel/core/src/common/lazyInit.ts
+++ b/@blaxel/core/src/common/lazyInit.ts
@@ -1,5 +1,6 @@
 import { client } from "../client/client.gen.js";
 import { client as clientSandbox } from "../sandbox/client/client.gen.js";
+import { controlPlaneFetch } from "./controlPlaneFetch.js";
 import { initSentry } from "./sentry.js";
 import { settings } from "./settings.js";
 
@@ -36,7 +37,7 @@ export function ensureAutoloaded(): void {
   // Keep the clients' baseUrl in sync with the now-resolved env. Without
   // this, the module-load `client.setConfig({ baseUrl })` would be stuck on
   // the prod default for users who rely on `config.yaml` (no env vars).
-  client.setConfig({ baseUrl: settings.baseUrl });
+  client.setConfig({ baseUrl: settings.baseUrl, fetch: controlPlaneFetch });
   clientSandbox.setConfig({ baseUrl: settings.baseUrl });
 
   // Initialize Sentry for SDK error tracking.
@@ -50,9 +51,9 @@ export function ensureAutoloaded(): void {
   if (isNode && !isBrowser && !settings.disableH2) {
     try {
       // Pre-warm edge H2 for the configured region so the first
-      // SandboxInstance.create() gets an instant session via the pool.
-      // The control-plane client (api.blaxel.ai) stays on regular fetch
-      // which already benefits from undici's built-in connection pooling.
+      // SandboxInstance.create() gets an instant data-plane session via the
+      // pool. Control-plane H2 is intentionally not warmed; its cold burst
+      // relies on pool deduplication instead.
       const region = settings.region;
       if (region) {
         import("./h2pool.js").then(({ h2Pool }) => {

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -38,6 +38,22 @@ export type Config = {
   workspace?: string;
   disableH2?: boolean;
   /**
+   * Disables only the control-plane HTTP/2 wrapper, leaving data-plane (edge)
+   * H2 untouched. Use this to route control-plane calls (api.blaxel.{ai,dev})
+   * over native fetch while keeping sandbox/data-plane traffic on the H2 pool.
+   * The global `disableH2` flag still wins: when it is true, both planes use
+   * native fetch regardless of this value. Defaults to `false` (wrapper on).
+   */
+  disableControlPlaneH2?: boolean;
+  /**
+   * Forces the control-plane HTTP/2 wrapper on even when the runtime's native
+   * fetch already negotiates HTTP/2 (undici >= 8 / Node 26+), where it is
+   * otherwise skipped as redundant. Mainly for exercising the pooled path on a
+   * modern runtime. `disableH2` and `disableControlPlaneH2` still win.
+   * Defaults to `false`.
+   */
+  forceControlPlaneH2?: boolean;
+  /**
    * Maximum number of concurrent in-flight HTTP/2 requests across the shared
    * H2 session pool. `0` or `undefined` means unlimited (current behavior).
    */
@@ -351,6 +367,33 @@ class Settings {
       return ["1", "true", "yes", "on"].includes(value.toLowerCase());
     }
     return isDenoRuntime();
+  }
+
+  // Control-plane-only escape hatch: disables the control-plane H2 wrapper
+  // without affecting data-plane (edge) H2. `disableH2` is the global override
+  // and is checked separately by callers, so it always wins.
+  get disableControlPlaneH2(): boolean {
+    if (typeof this.config.disableControlPlaneH2 === "boolean") {
+      return this.config.disableControlPlaneH2;
+    }
+    const value = env.BL_DISABLE_CONTROL_PLANE_H2;
+    if (value) {
+      return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+    }
+    return false;
+  }
+
+  // Forces the control-plane H2 wrapper on even when native fetch already
+  // supports H2 (undici >= 7). `disableH2`/`disableControlPlaneH2` still win.
+  get forceControlPlaneH2(): boolean {
+    if (typeof this.config.forceControlPlaneH2 === "boolean") {
+      return this.config.forceControlPlaneH2;
+    }
+    const value = env.BL_FORCE_CONTROL_PLANE_H2;
+    if (value) {
+      return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+    }
+    return false;
   }
 
   get maxConcurrentH2Requests(): number {

--- a/tests/unit/control-plane-fetch.test.ts
+++ b/tests/unit/control-plane-fetch.test.ts
@@ -1,0 +1,122 @@
+import { client } from "../../@blaxel/core/src/client/client.gen.js";
+import { initialize } from "../../@blaxel/core/src/common/autoload.js";
+import { controlPlaneFetch, shouldUseControlPlaneH2, undiciSupportsNativeH2 } from "../../@blaxel/core/src/common/controlPlaneFetch.js";
+import { settings } from "../../@blaxel/core/src/common/settings.js";
+import { describe, expect, it } from "vitest";
+
+describe("control-plane H2 routing predicate", () => {
+  // Proves Blaxel API hosts engage the H2 pool, which is the TLS storm fix.
+  it("routes HTTPS Blaxel control-plane hosts through the H2 pool so bursts share one TLS connection", () => {
+    expect(shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/sandboxes"), false)).toBe(true);
+    expect(shouldUseControlPlaneH2(new URL("https://api.blaxel.dev/v0/sandboxes"), false)).toBe(true);
+  });
+
+  // Proves custom control-plane hosts stay on native fetch to avoid repeated failed H2 setup.
+  it("keeps custom hosts on native fetch so non-Blaxel gateways do not pay failed H2 setup per request", () => {
+    expect(shouldUseControlPlaneH2(new URL("https://api.example.com/v0/sandboxes"), false)).toBe(false);
+  });
+
+  // Proves non-TLS URLs stay off the H2 pool because the pool establishes TLS sessions only.
+  it("keeps non-HTTPS requests on native fetch because the H2 pool only establishes TLS sessions", () => {
+    expect(shouldUseControlPlaneH2(new URL("http://api.blaxel.ai/v0/sandboxes"), false)).toBe(false);
+  });
+
+  // Proves the existing disable flag remains the single escape hatch for SDK H2 transport.
+  it("honors the H2 disable flag as the single transport escape hatch", () => {
+    expect(shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/sandboxes"), true)).toBe(false);
+  });
+
+  // Proves explicit proxy configuration preserves native fetch routing for control-plane calls.
+  it("keeps proxy-configured control-plane URLs on native fetch so proxy routing remains unchanged", () => {
+    expect(shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/proxy/api/sandboxes"), false, true)).toBe(false);
+  });
+
+  // Proves device-mode/client-credential token refresh stays on native fetch;
+  // auth refresh is sequential and must not block the create-burst H2 fix.
+  it("keeps oauth token refresh on native fetch", () => {
+    expect(shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/oauth/token"), false)).toBe(false);
+  });
+
+  // Pins the empirical native-H2 boundary: Node's global fetch dispatcher only
+  // ALPNs h2 by default from undici 8 (Node 26+). undici 6 (Node 22) and undici
+  // 7 (Node 24) still negotiate HTTP/1.1, so they must keep the wrapper.
+  it("treats undici >= 8 as native-H2 capable and undici <= 7 / unknown as not", () => {
+    expect(undiciSupportsNativeH2("6.24.1")).toBe(false); // Node 22
+    expect(undiciSupportsNativeH2("7.25.0")).toBe(false); // Node 24
+    expect(undiciSupportsNativeH2("8.3.0")).toBe(true); // Node 26
+    expect(undiciSupportsNativeH2(undefined)).toBe(false); // Bun/Deno/CF Workers
+  });
+
+  // Proves modern runtimes (undici >= 8) skip the redundant wrapper and use
+  // native fetch, which already negotiates HTTP/2 via ALPN.
+  it("skips the wrapper when native fetch already negotiates HTTP/2", () => {
+    expect(
+      shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/sandboxes"), false, false, true),
+    ).toBe(false);
+  });
+
+  // Proves old/unknown runtimes (undici <= 6 or undefined on Bun/Deno) keep the
+  // wrapper, since native fetch there is HTTP/1.1 only.
+  it("uses the wrapper when native fetch lacks HTTP/2", () => {
+    expect(
+      shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/sandboxes"), false, false, false),
+    ).toBe(true);
+  });
+
+  // Proves the force flag re-enables the pooled path on modern runtimes so the
+  // wrapper stays testable where native fetch would otherwise win.
+  it("forces the wrapper on modern runtimes when forceWrapper is set", () => {
+    expect(
+      shouldUseControlPlaneH2(new URL("https://api.blaxel.ai/v0/sandboxes"), false, false, true, true),
+    ).toBe(true);
+  });
+
+  // Proves forceControlPlaneH2 reads from config and env.
+  it("honors forceControlPlaneH2 as a settings flag", () => {
+    const originalSettingsConfig = settings.config;
+    try {
+      settings.setConfig({ ...settings.config, forceControlPlaneH2: true });
+      expect(settings.forceControlPlaneH2).toBe(true);
+      settings.setConfig({ ...settings.config, forceControlPlaneH2: false });
+      expect(settings.forceControlPlaneH2).toBe(false);
+    } finally {
+      settings.setConfig(originalSettingsConfig);
+    }
+  });
+
+  // Proves the control-plane-only disable flag routes control-plane calls
+  // through native fetch while leaving data-plane H2 untouched.
+  it("honors disableControlPlaneH2 as a control-plane-only escape hatch", () => {
+    const originalSettingsConfig = settings.config;
+    try {
+      settings.setConfig({ ...settings.config, disableControlPlaneH2: false });
+      expect(settings.disableControlPlaneH2).toBe(false);
+
+      settings.setConfig({ ...settings.config, disableControlPlaneH2: true });
+      expect(settings.disableControlPlaneH2).toBe(true);
+      // The merged flag the wrapper computes routes control-plane calls to native fetch.
+      expect(
+        shouldUseControlPlaneH2(
+          new URL("https://api.blaxel.ai/v0/sandboxes"),
+          settings.disableH2 || settings.disableControlPlaneH2,
+        ),
+      ).toBe(false);
+    } finally {
+      settings.setConfig(originalSettingsConfig);
+    }
+  });
+
+  // Proves programmatic SDK config cannot drop the custom generated-client
+  // fetch hook that routes sandbox creates through the control-plane H2 pool.
+  it("keeps controlPlaneFetch installed after initialize reconfigures the generated client", () => {
+    const originalClientConfig = client.getConfig();
+    const originalSettingsConfig = settings.config;
+    try {
+      initialize({ ...settings.config });
+      expect(client.getConfig().fetch).toBe(controlPlaneFetch);
+    } finally {
+      settings.setConfig(originalSettingsConfig);
+      client.setConfig(originalClientConfig);
+    }
+  });
+});


### PR DESCRIPTION
Route control-plane requests to api.blaxel.{ai,dev} through the shared H2 pool so concurrent bursts reuse one TLS connection instead of opening a connection per request. Token refresh, proxied, non-HTTPS, and non-Blaxel hosts stay on native fetch.

Skip the wrapper automatically when the runtime's native fetch already negotiates HTTP/2 (undici >= 7 / Node 24+), where it is redundant and the native path is equal-or-faster. Older/unknown runtimes (undici <= 6, or Bun/Deno where process.versions.undici is undefined) keep the wrapper as the fallback that prevents the HTTP/1.1 connection-per-request TLS storm.

Flags (config + env), in precedence order:
- disableH2 / BL_DISABLE_H2: global, disables both planes (pre-existing)
- disableControlPlaneH2 / BL_DISABLE_CONTROL_PLANE_H2: opt out of just the control-plane wrapper, leaving data-plane H2 in place
- forceControlPlaneH2 / BL_FORCE_CONTROL_PLANE_H2: force the pooled path on even when native fetch supports H2 (for testing)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Routes control-plane API requests through the shared HTTP/2 pool to prevent per-request TLS connection storms during concurrent bursts. Auto-detects modern runtimes (undici ≥ 7) where native fetch already negotiates H2, and adds granular opt-out/force flags.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 638611d98081879fa316430c5c631b7fc88614a4.</sup>
<!-- /MENDRAL_SUMMARY -->