### PR TITLE
feat(network): add firewall rulesets + proxy allow/forbid domains

### DIFF
--- a/@blaxel/core/src/client/types.gen.ts
+++ b/@blaxel/core/src/client/types.gen.ts
@@ -783,6 +783,16 @@ export type ExpirationPolicy = {
 };
 
 /**
+ * Firewall configuration specifying which network lockdown rulesets to apply. Valid rulesets are "default" (no-op), "proxy" (restrict egress to proxy), and "dedicated-ip" (restrict egress to dedicated IP gateway).
+ */
+export type FirewallConfig = {
+    /**
+     * List of firewall rulesets to apply. Valid values: "default" (no-op), "proxy" (restrict egress to proxy), "dedicated-ip" (restrict egress to dedicated IP gateway).
+     */
+    rulesets?: Array<string>;
+};
+
+/**
  * A type of hardware available for deployments
  */
 export type Flavor = {
@@ -2746,9 +2756,17 @@ export type PrivateLocation = {
  */
 export type ProxyConfig = {
     /**
+     * List of allowed external domains (allowlist). When set, only these domains are reachable. Supports wildcards (e.g. *.s3.amazonaws.com).
+     */
+    allowedDomains?: Array<string>;
+    /**
      * Domains that bypass the proxy entirely via the NO_PROXY directive. Traffic to these destinations goes direct, not through the CONNECT tunnel. Supports wildcards. Note that localhost, private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), 169.254.169.254, .local and .internal are always bypassed by default.
      */
     bypass?: Array<string>;
+    /**
+     * List of forbidden external domains (denylist). When set, all domains except these are reachable. Supports wildcards (e.g. *.malware.com). If both allowedDomains and forbiddenDomains are set, allowedDomains takes precedence.
+     */
+    forbiddenDomains?: Array<string>;
     /**
      * Per-destination routing rules with header/body injection and secrets. Use destinations ["*"] for global rules that apply to all destinations.
      */
@@ -3220,19 +3238,24 @@ export type SandboxLifecycle = {
 };
 
 /**
- * Network configuration for a sandbox including domain filtering, egress IP binding, and proxy settings
+ * Network configuration for a sandbox including subnet, firewall rulesets, domain filtering, egress IP binding, and proxy settings
  */
 export type SandboxNetwork = {
     /**
-     * List of allowed external domains (allowlist). When set, only these domains are reachable. Supports wildcards (e.g. *.s3.amazonaws.com).
+     * Deprecated: use proxy.allowedDomains instead. List of allowed external domains (allowlist). Kept for backward compatibility.
      */
     allowedDomains?: Array<string>;
     egress?: EgressConfig;
+    firewall?: FirewallConfig;
     /**
-     * List of forbidden external domains (denylist). When set, all domains except these are reachable. Supports wildcards (e.g. *.malware.com). If both allowedDomains and forbiddenDomains are set, allowedDomains takes precedence.
+     * Deprecated: use proxy.forbiddenDomains instead. List of forbidden external domains (denylist). Kept for backward compatibility.
      */
     forbiddenDomains?: Array<string>;
     proxy?: ProxyConfig;
+    /**
+     * Subnet name for the sandbox. Takes priority over any subnet derived from egress config. Defaults to "default" when absent.
+     */
+    subnet?: string;
 };
 
 /**

--- a/tests/integration/sandbox/proxy/firewall.test.ts
+++ b/tests/integration/sandbox/proxy/firewall.test.ts
@@ -41,6 +41,52 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 60_000)
   })
 
+  describe('no proxy bypass (firewall ruleset: proxy)', () => {
+    let bypassSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+    beforeAll(async () => {
+      const readyStart = Date.now()
+      bypassSandbox = await createReadyProxySandbox(
+        async () => {
+          const name = uniqueName("fw-bypass")
+          console.log(`[fw-bypass] creating sandbox ${name}...`)
+          const createStart = Date.now()
+          const sandbox = await SandboxInstance.create({
+            name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
+            network: {
+              firewall: { rulesets: ["proxy"] },
+              allowedDomains: ["httpbin.org"],
+              proxy: { routing: [] },
+            },
+          })
+          console.log(`[fw-bypass] SandboxInstance.create took ${Date.now() - createStart}ms`)
+          return { name, sandbox }
+        },
+        createdSandboxes,
+        'node /tmp/proxy-test.js GET https://httpbin.org/get',
+      )
+      console.log(`[fw-bypass] sandbox ready (create + proxy warmup) took ${Date.now() - readyStart}ms`)
+
+      // // Give the "proxy" firewall ruleset a moment to be fully enforced at the
+      // // network level before we assert that a direct (no-proxy) call is blocked.
+      // await new Promise((resolve) => setTimeout(resolve, 15_000))
+    }, 180_000)
+
+    it('blocks requests even when proxy env vars are unset (no proxy bypass)', async () => {
+      // Strip every proxy hint so the helper attempts a direct connection,
+      // bypassing the proxy entirely. With the "proxy" firewall ruleset egress is
+      // enforced at the network level by dropping packets, so a direct connection
+      // won't be refused — it just hangs. `timeout` turns that hang into a
+      // non-zero exit (124), proving the bypass is blocked rather than silently
+      // succeeding.
+      const result = await bypassSandbox.process.exec({
+        command: 'timeout 10 env -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy node /tmp/proxy-test.js GET https://httpbin.org/get',
+        waitForCompletion: true,
+      })
+      expect(result.exitCode, result.logs).not.toBe(0)
+    }, 60_000)
+  })
+
   describe('forbiddenDomains (denylist)', () => {
     let denySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 


### PR DESCRIPTION
Fixes ENG-3078

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `FirewallConfig` type with rulesets, moves `allowedDomains`/`forbiddenDomains` into `ProxyConfig` (deprecating the old `SandboxNetwork` fields), adds a `subnet` field, and introduces an integration test for the "proxy" firewall ruleset blocking direct egress.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 87a3ae7efec9dfbd93553d6fece9a3bb6d49e24e.</sup>
<!-- /MENDRAL_SUMMARY -->