### PR TITLE
fix(test): pin minWorkers to avoid Tinypool conflict on high-core machines

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     globals: true,
     reporters: ['verbose'],
     fileParallelism: true,
+    minWorkers: 1,
     maxWorkers: 10,
     sequence: {
       concurrent: false,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     globals: true,
     reporters: ['verbose'],
     fileParallelism: true,
+    minWorkers: 1,
     maxWorkers: 10,
     sequence: {
       concurrent: false,


### PR DESCRIPTION
Fixes ENG-3132

## Problem

`vitest run` crashes locally with:

```
RangeError: options.minThreads and options.maxThreads must not conflict
```

But it passes in CI.

## Cause

`vitest.config.ts` set `maxWorkers: 10` without `minWorkers`. For the `forks` pool, vitest then defaults `minThreads` to `numCpus - 1`. On a machine with 12+ cores that gives `minThreads = 11`, which is greater than `maxThreads = 10`, so Tinypool throws.

CI runners have only a few cores (`numCpus - 1 <= 10`), so the conflict never showed up there. The failure was purely a function of local core count.

## Fix

Set `minWorkers: 1` in both `vitest.config.ts` and `vitest.e2e.config.ts` so `minThreads <= maxThreads` regardless of how many cores the machine has.

## Verification

`bun run vitest run tests/integration` now starts and runs the suite without the Tinypool error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Pins `minWorkers: 1` in both vitest configs to prevent Tinypool from defaulting `minThreads` to `numCpus - 1`, which exceeds `maxWorkers: 10` on high-core machines.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d69b3de3c305b64322ba7f7634ed4ee46960eef5.</sup>
<!-- /MENDRAL_SUMMARY -->