### PR TITLE
Fix readBinary to always return Blob

### DIFF
--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -24,6 +24,34 @@ export function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
   return retryOnTransientReset(fn, { retries: settings.fsPartRetries });
 }
 
+async function blobFromReadableStream(stream: ReadableStream<Uint8Array>): Promise<Blob> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return new Blob(chunks);
+}
+
+async function normalizeBinaryDownload(data: unknown, response: Response): Promise<Blob> {
+  if (data instanceof Blob) return data;
+  if (typeof data === "string") return new Blob([data]);
+  if (data instanceof ArrayBuffer) return new Blob([data]);
+  if (ArrayBuffer.isView(data)) {
+    const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    return new Blob([bytes]);
+  }
+  if (data instanceof ReadableStream) return blobFromReadableStream(data);
+  if (response.body) return blobFromReadableStream(response.body);
+  throw new Error(`Unsupported binary download response: ${data === null ? "null" : typeof data}`);
+}
+
 export class SandboxFileSystem extends SandboxAction {
   constructor(sandbox: Sandbox, private process: SandboxProcess) {
     super(sandbox);
@@ -200,12 +228,10 @@ export class SandboxFileSystem extends SandboxAction {
         headers: {
           'Accept': 'application/octet-stream',
         },
+        parseAs: 'blob',
       }));
       this.handleResponseError(response, data, error);
-      if (typeof data === 'string') {
-        return new Blob([data]);
-      }
-      return data as Blob;
+      return normalizeBinaryDownload(data, response);
     });
   }
 

--- a/tests/unit/sandbox-filesystem-read-binary.test.ts
+++ b/tests/unit/sandbox-filesystem-read-binary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { SandboxFileSystem } from "../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+
+type ReadBinaryHarness = SandboxFileSystem & {
+  readBinary(path: string): Promise<Blob>;
+};
+
+function createReadBinaryHarness(data: unknown, response?: Response) {
+  const client = {
+    get: vi.fn((options: unknown) => Promise.resolve({
+      response: response ?? new Response("ok", { status: 200 }),
+      data,
+      error: undefined,
+      options,
+    })),
+  };
+  const filesystem = Object.create(SandboxFileSystem.prototype) as ReadBinaryHarness;
+  Object.defineProperty(filesystem, "client", {
+    get: () => client,
+  });
+  Object.defineProperty(filesystem, "url", {
+    get: () => "https://sandbox.example",
+  });
+  return { filesystem, client };
+}
+
+async function blobText(blob: Blob): Promise<string> {
+  return new TextDecoder().decode(await blob.arrayBuffer());
+}
+
+describe("SandboxFileSystem.readBinary", () => {
+  it("requests blob parsing for headerless binary downloads", async () => {
+    const { filesystem, client } = createReadBinaryHarness(
+      new Blob([new Uint8Array([1, 2, 3])]),
+    );
+
+    const blob = await filesystem.readBinary("/tmp/file.bin");
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+    expect(client.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parseAs: "blob",
+        headers: { Accept: "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("normalizes a ReadableStream result into a Blob", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("streamed"));
+        controller.close();
+      },
+    });
+    const { filesystem } = createReadBinaryHarness(stream);
+
+    const blob = await filesystem.readBinary("/tmp/file.bin");
+
+    expect(blob).toBeInstanceOf(Blob);
+    await expect(blobText(blob)).resolves.toBe("streamed");
+  });
+
+  it("falls back to the response body when data is not binary-like", async () => {
+    const response = new Response("body-bytes", { status: 200 });
+    const { filesystem } = createReadBinaryHarness(undefined, response);
+
+    const blob = await filesystem.readBinary("/tmp/file.bin");
+
+    expect(blob).toBeInstanceOf(Blob);
+    await expect(blobText(blob)).resolves.toBe("body-bytes");
+  });
+
+  it("normalizes string and ArrayBuffer data into Blob values", async () => {
+    const stringHarness = createReadBinaryHarness("text-data").filesystem;
+    const bufferHarness = createReadBinaryHarness(
+      new TextEncoder().encode("buffer-data").buffer,
+    ).filesystem;
+
+    await expect(blobText(await stringHarness.readBinary("/tmp/a"))).resolves.toBe(
+      "text-data",
+    );
+    await expect(blobText(await bufferHarness.readBinary("/tmp/b"))).resolves.toBe(
+      "buffer-data",
+    );
+  });
+});


### PR DESCRIPTION
Fixes ENG-3230

## Summary
- force sandbox binary reads through blob parsing
- normalize Blob, ReadableStream, response body, string, ArrayBuffer, and typed-array results into a Blob
- add regression coverage for headerless binary downloads and fallback response-body reads

Fixes #343.

## Checks
- bun --filter @blaxel/core build:cjs
- bun --filter @blaxel/core build:esm
- ./@blaxel/core/node_modules/.bin/eslint --no-warn-ignored @blaxel/core/src/sandbox/filesystem/filesystem.ts tests/unit/sandbox-filesystem-read-binary.test.ts
- git diff --check

## Notes
- I could not run the focused Vitest file locally because Rollup's macOS optional native package fails to load with a code-signature error in this checkout.
- The broader tests TypeScript config also has existing workspace package resolution errors outside this change.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Normalizes `readBinary` to always return a `Blob` by adding a `parseAs: 'blob'` hint and a `normalizeBinaryDownload` helper that handles various response data types (Blob, string, ArrayBuffer, TypedArray, ReadableStream, response body fallback). Includes unit tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 411456a894ab5a1f2bb73aa7b9ae1915124db76e.</sup>
<!-- /MENDRAL_SUMMARY -->