### PR TITLE
Add sandbox operation diagnostics recorder

### DIFF
--- a/@blaxel/core/README.md
+++ b/@blaxel/core/README.md
@@ -380,6 +380,34 @@ Enable automatic telemetry by importing the `@blaxel/telemetry` package:
 import "@blaxel/telemetry";
 ```
 
+### Sandbox operation diagnostics
+
+For hard-to-reproduce sandbox failures, you can record a privacy-safe operation
+artifact around the workflow you are debugging:
+
+```typescript
+const sandbox = await SandboxInstance.get("my-sandbox");
+const recorder = sandbox.startOperationRecording();
+
+try {
+  await sandbox.process.exec({
+    command: "npm test",
+    waitForCompletion: true
+  });
+  await sandbox.fs.ls("/app");
+  await sandbox.fetch(3000, "/health");
+} finally {
+  sandbox.stopOperationRecording();
+}
+
+console.log(recorder.toString());
+```
+
+Commands, headers, env values, and file contents are redacted by default. The
+artifact keeps timings, transport metadata, process exit status, byte counts,
+HTTP status, and errors so support can inspect what happened without collecting
+application secrets.
+
 ## Requirements
 
 - Node.js v18 or later

--- a/@blaxel/core/src/sandbox/action.ts
+++ b/@blaxel/core/src/sandbox/action.ts
@@ -6,6 +6,7 @@ import { h2Pool } from "../common/h2pool.js";
 import { getForcedUrl, getGlobalUniqueHash } from "../common/internal.js";
 import { settings } from "../common/settings.js";
 import { client as defaultClient } from "./client/client.gen.js";
+import type { SandboxDiagnosticValue } from "./diagnostics.js";
 import { SandboxConfiguration } from "./types.js";
 
 export class ResponseError extends Error {
@@ -128,5 +129,43 @@ export class SandboxAction {
     if (!response.ok || !data) {
       throw new ResponseError(response, data, error);
     }
+  }
+
+  protected async recordOperation<T>(
+    subsystem: string,
+    operation: string,
+    attributes: Record<string, unknown>,
+    run: () => Promise<T>,
+    summarize?: (result: T) => Record<string, unknown>,
+  ): Promise<T> {
+    const recorder = this.sandbox.operationRecorder;
+    if (!recorder) return run();
+
+    const pending = recorder.start({
+      sandboxName: this.name,
+      subsystem,
+      operation,
+      attributes,
+      transport: {
+        h2Domain: this.sandbox.h2Domain ?? null,
+        forcedUrl: Boolean(this.sandbox.forceUrl),
+      },
+    });
+
+    try {
+      const result = await run();
+      recorder.end(pending, "ok", summarize?.(result));
+      return result;
+    } catch (error) {
+      recorder.end(pending, "error", undefined, error);
+      throw error;
+    }
+  }
+
+  protected commandDiagnostics(command: string): Record<string, SandboxDiagnosticValue> {
+    return this.sandbox.operationRecorder?.command(command) ?? {
+      commandLength: command.length,
+      commandText: "[redacted]",
+    };
   }
 }

--- a/@blaxel/core/src/sandbox/diagnostics.ts
+++ b/@blaxel/core/src/sandbox/diagnostics.ts
@@ -1,0 +1,228 @@
+export type SandboxDiagnosticPrimitive = string | number | boolean | null;
+export type SandboxDiagnosticValue =
+  | SandboxDiagnosticPrimitive
+  | SandboxDiagnosticValue[]
+  | { [key: string]: SandboxDiagnosticValue };
+
+export type SandboxOperationStatus = "ok" | "error";
+
+export type SandboxOperationEvent = {
+  id: string;
+  sandboxName?: string;
+  subsystem: string;
+  operation: string;
+  status: SandboxOperationStatus;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  transport?: {
+    h2Domain?: string;
+    forcedUrl: boolean;
+  };
+  attributes?: Record<string, SandboxDiagnosticValue>;
+  result?: Record<string, SandboxDiagnosticValue>;
+  error?: {
+    name: string;
+    message: string;
+    status?: number;
+    code?: string | number;
+  };
+};
+
+export type SandboxOperationRecorderOptions = {
+  maxEvents?: number;
+  maxStringLength?: number;
+  captureCommandText?: boolean;
+  redactKeys?: string[];
+  clock?: () => number;
+  now?: () => string;
+  idFactory?: () => string;
+};
+
+export type SandboxOperationStart = {
+  sandboxName?: string;
+  subsystem: string;
+  operation: string;
+  attributes?: Record<string, unknown>;
+  transport?: {
+    h2Domain?: string | null;
+    forcedUrl?: boolean;
+  };
+};
+
+type PendingSandboxOperation = {
+  id: string;
+  startedAtMs: number;
+  startedAt: string;
+} & SandboxOperationStart;
+
+const DEFAULT_MAX_EVENTS = 200;
+const DEFAULT_MAX_STRING_LENGTH = 512;
+const DEFAULT_REDACT_KEYS = [
+  "authorization",
+  "api_key",
+  "apikey",
+  "cookie",
+  "password",
+  "secret",
+  "token",
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasRedactedKey(key: string, redactKeys: string[]): boolean {
+  const normalized = key.toLowerCase().replace(/[-_\s]/g, "");
+  return redactKeys.some((redactKey) => normalized.includes(redactKey.toLowerCase().replace(/[-_\s]/g, "")));
+}
+
+function errorField(error: unknown, field: "status" | "code"): string | number | undefined {
+  if (!isPlainObject(error) || !(field in error)) return undefined;
+  const value = error[field];
+  return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+export class SandboxOperationRecorder {
+  private events: SandboxOperationEvent[] = [];
+  private sequence = 0;
+  private readonly maxEvents: number;
+  private readonly maxStringLength: number;
+  private readonly captureCommandText: boolean;
+  private readonly redactKeys: string[];
+  private readonly clock: () => number;
+  private readonly now: () => string;
+  private readonly idFactory?: () => string;
+
+  constructor(options: SandboxOperationRecorderOptions = {}) {
+    this.maxEvents = Math.max(1, options.maxEvents ?? DEFAULT_MAX_EVENTS);
+    this.maxStringLength = Math.max(16, options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH);
+    this.captureCommandText = options.captureCommandText ?? false;
+    this.redactKeys = [...DEFAULT_REDACT_KEYS, ...(options.redactKeys ?? [])];
+    this.clock = options.clock ?? Date.now;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idFactory = options.idFactory;
+  }
+
+  start(operation: SandboxOperationStart): PendingSandboxOperation {
+    const id = this.idFactory?.() ?? `sandbox-op-${++this.sequence}`;
+    return {
+      id,
+      startedAtMs: this.clock(),
+      startedAt: this.now(),
+      ...operation,
+    };
+  }
+
+  end(
+    pending: PendingSandboxOperation,
+    status: SandboxOperationStatus,
+    result?: Record<string, unknown>,
+    error?: unknown,
+  ): SandboxOperationEvent {
+    const event: SandboxOperationEvent = {
+      id: pending.id,
+      sandboxName: pending.sandboxName,
+      subsystem: pending.subsystem,
+      operation: pending.operation,
+      status,
+      startedAt: pending.startedAt,
+      endedAt: this.now(),
+      durationMs: Math.max(0, this.clock() - pending.startedAtMs),
+      transport: pending.transport
+        ? {
+            h2Domain: pending.transport.h2Domain ?? undefined,
+            forcedUrl: pending.transport.forcedUrl ?? false,
+          }
+        : undefined,
+      attributes: pending.attributes ? this.sanitizeRecord(pending.attributes) : undefined,
+      result: result ? this.sanitizeRecord(result) : undefined,
+      error: error ? this.sanitizeError(error) : undefined,
+    };
+
+    this.events.push(event);
+    if (this.events.length > this.maxEvents) {
+      this.events.splice(0, this.events.length - this.maxEvents);
+    }
+    return event;
+  }
+
+  command(command: string): Record<string, SandboxDiagnosticValue> {
+    const attributes: Record<string, SandboxDiagnosticValue> = {
+      commandLength: command.length,
+      commandText: "[redacted]",
+    };
+    if (this.captureCommandText) {
+      attributes.commandText = this.truncate(command);
+    }
+    return attributes;
+  }
+
+  sanitizeRecord(record: Record<string, unknown>): Record<string, SandboxDiagnosticValue> {
+    const sanitized = this.sanitize(record);
+    return isPlainObject(sanitized) ? sanitized as Record<string, SandboxDiagnosticValue> : {};
+  }
+
+  snapshot(): SandboxOperationEvent[] {
+    return JSON.parse(JSON.stringify(this.events)) as SandboxOperationEvent[];
+  }
+
+  toJSON(): { events: SandboxOperationEvent[] } {
+    return { events: this.snapshot() };
+  }
+
+  toString(): string {
+    return JSON.stringify(this.toJSON(), null, 2);
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+
+  private sanitize(value: unknown, key = "", depth = 0): SandboxDiagnosticValue {
+    if (hasRedactedKey(key, this.redactKeys)) return "[redacted]";
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") return this.truncate(value);
+    if (typeof value === "number" || typeof value === "boolean") return value;
+    if (typeof value === "bigint") return value.toString();
+    if (value instanceof Error) return this.truncate(value.message);
+    if (value instanceof Date) return value.toISOString();
+    if (value instanceof Blob) return { type: "Blob", size: value.size, mediaType: value.type || null };
+    if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+      return { type: "Buffer", byteLength: value.byteLength };
+    }
+    if (ArrayBuffer.isView(value)) {
+      return { type: value.constructor.name, byteLength: value.byteLength };
+    }
+    if (value instanceof ArrayBuffer) return { type: "ArrayBuffer", byteLength: value.byteLength };
+    if (typeof value === "function" || typeof value === "symbol") return `[${typeof value}]`;
+    if (depth >= 4) return Array.isArray(value) ? "[array]" : "[object]";
+    if (Array.isArray(value)) return value.slice(0, 25).map((item) => this.sanitize(item, key, depth + 1));
+    if (isPlainObject(value)) {
+      const output: Record<string, SandboxDiagnosticValue> = {};
+      for (const [childKey, childValue] of Object.entries(value)) {
+        output[childKey] = this.sanitize(childValue, childKey, depth + 1);
+      }
+      return output;
+    }
+    return this.truncate(Object.prototype.toString.call(value));
+  }
+
+  private sanitizeError(error: unknown): SandboxOperationEvent["error"] {
+    const name = error instanceof Error ? error.name : "Error";
+    const message = error instanceof Error ? error.message : String(error);
+    const status = errorField(error, "status");
+    const code = errorField(error, "code");
+    return {
+      name,
+      message: this.truncate(message),
+      status: typeof status === "number" ? status : undefined,
+      code,
+    };
+  }
+
+  private truncate(value: string): string {
+    if (value.length <= this.maxStringLength) return value;
+    return `${value.slice(0, this.maxStringLength)}...`;
+  }
+}

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -24,6 +24,44 @@ export function retryOnTransient<T>(fn: () => Promise<T>): Promise<T> {
   return retryOnTransientReset(fn, { retries: settings.fsPartRetries });
 }
 
+function contentDiagnostics(content: Buffer | Blob | File | Uint8Array | string) {
+  if (typeof content === "string") {
+    return {
+      contentKind: "string",
+      contentBytes: new Blob([content]).size,
+    };
+  }
+  if (content instanceof Blob || content instanceof File) {
+    return {
+      contentKind: content.constructor.name,
+      contentBytes: content.size,
+      mediaType: content.type || null,
+    };
+  }
+  if (Buffer.isBuffer(content)) {
+    return {
+      contentKind: "Buffer",
+      contentBytes: content.byteLength,
+    };
+  }
+  if (ArrayBuffer.isView(content)) {
+    return {
+      contentKind: content.constructor.name,
+      contentBytes: content.byteLength,
+    };
+  }
+  return {
+    contentKind: typeof content,
+  };
+}
+
+function directoryDiagnostics(directory: Directory) {
+  return {
+    files: directory.files?.length ?? 0,
+    subdirectories: directory.subdirectories?.length ?? 0,
+  };
+}
+
 export class SandboxFileSystem extends SandboxAction {
   constructor(sandbox: Sandbox, private process: SandboxProcess) {
     super(sandbox);
@@ -32,18 +70,33 @@ export class SandboxFileSystem extends SandboxAction {
 
   async mkdir(path: string, permissions: string = "0755"): Promise<SuccessResponse> {
     path = this.formatPath(path);
-    const { response, data, error } = await putFilesystemByPath(this.withClient({
-      path: { path },
-      body: { isDirectory: true, permissions },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as SuccessResponse;
+    return this.recordOperation(
+      "filesystem",
+      "mkdir",
+      { path, permissions },
+      async () => {
+        const { response, data, error } = await putFilesystemByPath(this.withClient({
+          path: { path },
+          body: { isDirectory: true, permissions },
+          baseUrl: this.url,
+        }));
+        this.handleResponseError(response, data, error);
+        return data as SuccessResponse;
+      },
+    );
   }
 
   async write(path: string, content: string): Promise<SuccessResponse> {
     path = this.formatPath(path);
+    return this.recordOperation(
+      "filesystem",
+      "write",
+      { path, ...contentDiagnostics(content) },
+      () => this.writeInternal(path, content),
+    );
+  }
 
+  private async writeInternal(path: string, content: string): Promise<SuccessResponse> {
     // Calculate content size in bytes
     const contentSize = new Blob([content]).size;
 
@@ -65,7 +118,15 @@ export class SandboxFileSystem extends SandboxAction {
 
   async writeBinary(path: string, content: Buffer | Blob | File | Uint8Array | string): Promise<SuccessResponse> {
     path = this.formatPath(path);
+    return this.recordOperation(
+      "filesystem",
+      "writeBinary",
+      { path, ...contentDiagnostics(content) },
+      () => this.writeBinaryInternal(path, content),
+    );
+  }
 
+  private async writeBinaryInternal(path: string, content: Buffer | Blob | File | Uint8Array | string): Promise<SuccessResponse> {
     // Convert content to Blob regardless of input type
     let fileBlob: Blob;
 
@@ -152,6 +213,19 @@ export class SandboxFileSystem extends SandboxAction {
   }
 
   async writeTree(files: SandboxFilesystemFile[], destinationPath: string | null = null) {
+    return this.recordOperation(
+      "filesystem",
+      "writeTree",
+      {
+        destinationPath,
+        files: files.length,
+        totalBytes: files.reduce((sum, file) => sum + new Blob([file.content]).size, 0),
+      },
+      () => this.writeTreeInternal(files, destinationPath),
+    );
+  }
+
+  private async writeTreeInternal(files: SandboxFilesystemFile[], destinationPath: string | null = null) {
     const options = {
       body: {
         files: files.reduce((acc, file) => {
@@ -175,79 +249,131 @@ export class SandboxFileSystem extends SandboxAction {
 
   async read(path: string): Promise<string> {
     path = this.formatPath(path);
-    // Idempotent GET: self-heal a transient connection reset (e.g. first call
-    // after sandbox resume). Non-transient errors (404, etc.) are not retried.
-    return retryOnTransientReset(async () => {
-      const { response, data, error } = await getFilesystemByPath(this.withClient({
-        path: { path },
-        baseUrl: this.url,
-      }));
-      this.handleResponseError(response, data, error);
-      if (data && 'content' in data) {
-        return data.content;
-      }
-      throw new Error("Unsupported file type");
-    });
+    return this.recordOperation(
+      "filesystem",
+      "read",
+      { path },
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset (e.g. first call
+        // after sandbox resume). Non-transient errors (404, etc.) are not retried.
+        return retryOnTransientReset(async () => {
+          const { response, data, error } = await getFilesystemByPath(this.withClient({
+            path: { path },
+            baseUrl: this.url,
+          }));
+          this.handleResponseError(response, data, error);
+          if (data && 'content' in data) {
+            return data.content;
+          }
+          throw new Error("Unsupported file type");
+        });
+      },
+      (content) => ({ bytes: new Blob([content]).size }),
+    );
   }
 
   async readBinary(path: string): Promise<Blob> {
     path = this.formatPath(path);
-    // Idempotent GET: self-heal a transient connection reset.
-    return retryOnTransientReset(async () => {
-      const { response, data, error } = await getFilesystemByPath(this.withClient({
-        path: { path },
-        baseUrl: this.url,
-        headers: {
-          'Accept': 'application/octet-stream',
-        },
-      }));
-      this.handleResponseError(response, data, error);
-      if (typeof data === 'string') {
-        return new Blob([data]);
-      }
-      return data as Blob;
-    });
+    return this.recordOperation(
+      "filesystem",
+      "readBinary",
+      { path },
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset.
+        return retryOnTransientReset(async () => {
+          const { response, data, error } = await getFilesystemByPath(this.withClient({
+            path: { path },
+            baseUrl: this.url,
+            headers: {
+              'Accept': 'application/octet-stream',
+            },
+          }));
+          this.handleResponseError(response, data, error);
+          if (typeof data === 'string') {
+            return new Blob([data]);
+          }
+          return data as Blob;
+        });
+      },
+      (blob) => ({ bytes: blob.size, mediaType: blob.type || null }),
+    );
   }
 
   async download(src: string, destinationPath: string, { mode = 0o644 }: { mode?: number } = {}): Promise<void> {
-    if (!fs) {
-      throw new Error("File download to local filesystem is only supported in Node.js environments");
-    }
-    const blob = await this.readBinary(src);
-    const arrayBuffer = await blob.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    fs.writeFileSync(destinationPath, buffer, { mode: mode ?? 0o644 });
+    return this.recordOperation(
+      "filesystem",
+      "download",
+      { src, destinationPath, mode },
+      async () => {
+        if (!fs) {
+          throw new Error("File download to local filesystem is only supported in Node.js environments");
+        }
+        const blob = await this.readBinary(src);
+        const arrayBuffer = await blob.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+        fs.writeFileSync(destinationPath, buffer, { mode: mode ?? 0o644 });
+      },
+    );
   }
 
   async rm(path: string, recursive: boolean = false): Promise<SuccessResponse> {
     path = this.formatPath(path);
-    const { response, data, error } = await deleteFilesystemByPath(this.withClient({
-      path: { path },
-      query: { recursive },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as SuccessResponse;
+    return this.recordOperation(
+      "filesystem",
+      "rm",
+      { path, recursive },
+      async () => {
+        const { response, data, error } = await deleteFilesystemByPath(this.withClient({
+          path: { path },
+          query: { recursive },
+          baseUrl: this.url,
+        }));
+        this.handleResponseError(response, data, error);
+        return data as SuccessResponse;
+      },
+    );
   }
 
   async ls(path: string): Promise<Directory> {
     path = this.formatPath(path);
-    // Idempotent GET: self-heal a transient connection reset (the file-tree
-    // refresh that customers hit as intermittent 500s after sandbox resume).
-    return retryOnTransientReset(async () => {
-      const { response, data, error } = await getFilesystemByPath(this.withClient({
-        path: { path },
-        baseUrl: this.url,
-      }));
-      this.handleResponseError(response, data, error);
-      if (!data || !('files' in data || 'subdirectories' in data)) {
-        throw new Error(JSON.stringify({ error: "Directory not found" }));
-      }
-      return data as Directory;
-    });
+    return this.recordOperation(
+      "filesystem",
+      "ls",
+      { path },
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset (the file-tree
+        // refresh that customers hit as intermittent 500s after sandbox resume).
+        return retryOnTransientReset(async () => {
+          const { response, data, error } = await getFilesystemByPath(this.withClient({
+            path: { path },
+            baseUrl: this.url,
+          }));
+          this.handleResponseError(response, data, error);
+          if (!data || !('files' in data || 'subdirectories' in data)) {
+            throw new Error(JSON.stringify({ error: "Directory not found" }));
+          }
+          return data as Directory;
+        });
+      },
+      directoryDiagnostics,
+    );
   }
 
   async search(
+    query: string,
+    path: string = "/",
+    options?: FilesystemSearchOptions
+  ): Promise<FuzzySearchResponse> {
+    return this.recordOperation(
+      "filesystem",
+      "search",
+      { path, queryLength: query.length, options: options ?? {} },
+      () => this.searchInternal(query, path, options),
+      (result) => ({ matches: result.matches.length, total: result.total }),
+    );
+  }
+
+  private async searchInternal(
     query: string,
     path: string = "/",
     options?: FilesystemSearchOptions
@@ -286,6 +412,19 @@ export class SandboxFileSystem extends SandboxAction {
   }
 
   async find(
+    path: string,
+    options?: FilesystemFindOptions
+  ): Promise<FindResponse> {
+    return this.recordOperation(
+      "filesystem",
+      "find",
+      { path, options: options ?? {} },
+      () => this.findInternal(path, options),
+      (result) => ({ matches: result.matches.length, total: result.total }),
+    );
+  }
+
+  private async findInternal(
     path: string,
     options?: FilesystemFindOptions
   ): Promise<FindResponse> {
@@ -331,6 +470,20 @@ export class SandboxFileSystem extends SandboxAction {
     path: string = "/",
     options?: FilesystemGrepOptions
   ): Promise<ContentSearchResponse> {
+    return this.recordOperation(
+      "filesystem",
+      "grep",
+      { path, queryLength: query.length, options: options ?? {} },
+      () => this.grepInternal(query, path, options),
+      (result) => ({ matches: result.matches.length, total: result.total }),
+    );
+  }
+
+  private async grepInternal(
+    query: string,
+    path: string = "/",
+    options?: FilesystemGrepOptions
+  ): Promise<ContentSearchResponse> {
     const formattedPath = this.formatPath(path);
 
     const queryParams: {
@@ -372,18 +525,25 @@ export class SandboxFileSystem extends SandboxAction {
   }
 
   async cp(source: string, destination: string, { maxWait = 180000 }: { maxWait?: number } = {}): Promise<CopyResponse> {
-    let process = await this.process.exec({
-      command: `cp -r ${source} ${destination}`,
-    })
-    process = await this.process.wait(process.pid, { maxWait, interval: 100 })
-    if (process.status === "failed") {
-      throw new Error(`Could not copy ${source} to ${destination} cause: ${process.logs}`)
-    }
-    return {
-      message: "Files copied",
-      source,
-      destination,
-    }
+    return this.recordOperation(
+      "filesystem",
+      "cp",
+      { source, destination, maxWait },
+      async () => {
+        let process = await this.process.exec({
+          command: `cp -r ${source} ${destination}`,
+        })
+        process = await this.process.wait(process.pid, { maxWait, interval: 100 })
+        if (process.status === "failed") {
+          throw new Error(`Could not copy ${source} to ${destination} cause: ${process.logs}`)
+        }
+        return {
+          message: "Files copied",
+          source,
+          destination,
+        }
+      },
+    );
   }
 
   watch(

--- a/@blaxel/core/src/sandbox/index.ts
+++ b/@blaxel/core/src/sandbox/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./client/index.js";
 export * from "./filesystem/index.js";
 export * from "./codegen/index.js";
+export * from "./diagnostics.js";
 export { SandboxDrive, type DriveMountRequest, type DriveMountResponse, type DriveMountInfo, type DriveUnmountResponse } from "./drive/index.js";
 export * from "./preview.js";
 export * from "./session.js";
@@ -16,4 +17,3 @@ export * from "./system.js";
 export * from "./types.js";
 export * from "./interpreter.js";
 // Re-export everything from client except ClientOptions to avoid conflict
-

--- a/@blaxel/core/src/sandbox/network/network.ts
+++ b/@blaxel/core/src/sandbox/network/network.ts
@@ -18,25 +18,43 @@ export class SandboxNetwork extends SandboxAction {
   async fetch(port: number, path = "/", init?: RequestInit): Promise<Response> {
     const normalizedPath = path.startsWith("/") ? path : `/${path}`;
     const url = `${this.url}/port/${port}${normalizedPath}`;
-    const headers = (this.sandbox.forceUrl ? this.sandbox.headers : undefined) ?? settings.headers;
-    const initHeaders: Record<string, string> = {};
-    if (init?.headers) {
-      const entries =
-        init.headers instanceof Headers
-          ? init.headers.entries()
-          : Array.isArray(init.headers)
-            ? (init.headers as [string, string][]).values()
-            : Object.entries(init.headers as Record<string, string>).values();
-      for (const [key, value] of entries) {
-        initHeaders[key] = value;
-      }
-    }
-    return this.h2Fetch(url, {
-      ...init,
-      headers: {
-        ...headers,
-        ...initHeaders,
+    return this.recordOperation(
+      "network",
+      "fetch",
+      {
+        port,
+        path: normalizedPath,
+        method: init?.method ?? "GET",
+        hasBody: Boolean(init?.body),
       },
-    });
+      async () => {
+        const headers = (this.sandbox.forceUrl ? this.sandbox.headers : undefined) ?? settings.headers;
+        const initHeaders: Record<string, string> = {};
+        if (init?.headers) {
+          const entries =
+            init.headers instanceof Headers
+              ? init.headers.entries()
+              : Array.isArray(init.headers)
+                ? (init.headers as [string, string][]).values()
+                : Object.entries(init.headers as Record<string, string>).values();
+          for (const [key, value] of entries) {
+            initHeaders[key] = value;
+          }
+        }
+        return this.h2Fetch(url, {
+          ...init,
+          headers: {
+            ...headers,
+            ...initHeaders,
+          },
+        });
+      },
+      (response) => ({
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        requestId: response.headers.get("x-blaxel-request-id") ?? null,
+      }),
+    );
   }
 }

--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -5,6 +5,35 @@ import { retryOnTransientReset } from "../../common/transient-retry.js";
 import { DeleteProcessByIdentifierKillResponse, DeleteProcessByIdentifierResponse, GetProcessByIdentifierResponse, GetProcessResponse, PostProcessResponse, ProcessRequest, deleteProcessByIdentifier, deleteProcessByIdentifierKill, getProcess, getProcessByIdentifier, getProcessByIdentifierLogs, postProcess } from "../client/index.js";
 import { ProcessRequestWithLog, ProcessResponseWithLog } from "../types.js";
 
+function summarizeProcessRequest(process: ProcessRequest, commandDiagnostics: Record<string, unknown>) {
+  return {
+    ...commandDiagnostics,
+    envNames: process.env ? Object.keys(process.env).sort() : [],
+    hasEnv: Boolean(process.env && Object.keys(process.env).length > 0),
+    keepAlive: process.keepAlive ?? false,
+    maxRestarts: process.maxRestarts ?? null,
+    name: process.name ?? null,
+    restartOnFailure: process.restartOnFailure ?? false,
+    timeout: process.timeout ?? null,
+    waitForCompletion: process.waitForCompletion ?? false,
+    waitForPorts: process.waitForPorts ?? [],
+    workingDir: process.workingDir ?? null,
+  };
+}
+
+function summarizeProcessResponse(process: PostProcessResponse) {
+  return {
+    exitCode: "exitCode" in process ? process.exitCode ?? null : null,
+    name: process.name ?? null,
+    pid: process.pid ?? null,
+    restartCount: "restartCount" in process ? process.restartCount ?? null : null,
+    status: process.status ?? null,
+    stdoutBytes: "stdout" in process && process.stdout ? new Blob([process.stdout]).size : 0,
+    stderrBytes: "stderr" in process && process.stderr ? new Blob([process.stderr]).size : 0,
+    logsBytes: "logs" in process && process.logs ? new Blob([process.logs]).size : 0,
+  };
+}
+
 export class SandboxProcess extends SandboxAction {
   constructor(sandbox: Sandbox) {
     super(sandbox);
@@ -100,6 +129,18 @@ export class SandboxProcess extends SandboxAction {
   }
 
   async exec(
+    process: ProcessRequest | ProcessRequestWithLog,
+  ): Promise<PostProcessResponse | ProcessResponseWithLog> {
+    return this.recordOperation(
+      "process",
+      "exec",
+      summarizeProcessRequest(process, this.commandDiagnostics(process.command)),
+      () => this.execInternal(process),
+      summarizeProcessResponse,
+    );
+  }
+
+  private async execInternal(
     process: ProcessRequest | ProcessRequestWithLog,
   ): Promise<PostProcessResponse | ProcessResponseWithLog> {
     let onLog: ((log: string) => void) | undefined;
@@ -313,84 +354,130 @@ export class SandboxProcess extends SandboxAction {
   }
 
   async wait(identifier: string, { maxWait = 60000, interval = 1000 }: { maxWait?: number, interval?: number } = {}): Promise<GetProcessByIdentifierResponse> {
-    const startTime = Date.now();
-    let status = "running";
-    let data = await this.get(identifier);
-    while (status === "running") {
-      await new Promise((resolve) => setTimeout(resolve, interval));
-      try {
-        data = await this.get(identifier);
-        status = data.status ?? "running";
-      } catch {
-        break;
-      }
-      if (Date.now() - startTime > maxWait) {
-        throw new Error("Process did not finish in time");
-      }
-    }
-    return data;
+    return this.recordOperation(
+      "process",
+      "wait",
+      { identifier, maxWait, interval },
+      async () => {
+        const startTime = Date.now();
+        let status = "running";
+        let data = await this.get(identifier);
+        while (status === "running") {
+          await new Promise((resolve) => setTimeout(resolve, interval));
+          try {
+            data = await this.get(identifier);
+            status = data.status ?? "running";
+          } catch {
+            break;
+          }
+          if (Date.now() - startTime > maxWait) {
+            throw new Error("Process did not finish in time");
+          }
+        }
+        return data;
+      },
+      summarizeProcessResponse,
+    );
   }
 
   async get(identifier: string): Promise<GetProcessByIdentifierResponse> {
-    // Idempotent GET: self-heal a transient connection reset (also makes the
-    // wait() poll loop resilient). exec() stays un-retried — it is a
-    // non-idempotent POST and retrying it duplicates the process (ENG-2340).
-    return retryOnTransientReset(async () => {
-      const { response, data, error } = await getProcessByIdentifier(this.withClient({
-        path: { identifier },
-        baseUrl: this.url,
-      }));
-      this.handleResponseError(response, data, error);
-      return data as GetProcessByIdentifierResponse;
-    });
+    return this.recordOperation(
+      "process",
+      "get",
+      { identifier },
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset (also makes the
+        // wait() poll loop resilient). exec() stays un-retried — it is a
+        // non-idempotent POST and retrying it duplicates the process (ENG-2340).
+        return retryOnTransientReset(async () => {
+          const { response, data, error } = await getProcessByIdentifier(this.withClient({
+            path: { identifier },
+            baseUrl: this.url,
+          }));
+          this.handleResponseError(response, data, error);
+          return data as GetProcessByIdentifierResponse;
+        });
+      },
+      summarizeProcessResponse,
+    );
   }
 
   async list(): Promise<GetProcessResponse> {
-    // Idempotent GET: self-heal a transient connection reset.
-    return retryOnTransientReset(async () => {
-      const { response, data, error } = await getProcess(this.withClient({
-        baseUrl: this.url,
-      }));
-      this.handleResponseError(response, data, error);
-      return data as GetProcessResponse;
-    });
+    return this.recordOperation(
+      "process",
+      "list",
+      {},
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset.
+        return retryOnTransientReset(async () => {
+          const { response, data, error } = await getProcess(this.withClient({
+            baseUrl: this.url,
+          }));
+          this.handleResponseError(response, data, error);
+          return data as GetProcessResponse;
+        });
+      },
+      (processes) => ({ count: Array.isArray(processes) ? processes.length : 0 }),
+    );
   }
 
   async stop(identifier: string): Promise<DeleteProcessByIdentifierResponse> {
-    const { response, data, error } = await deleteProcessByIdentifier(this.withClient({
-      path: { identifier },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as DeleteProcessByIdentifierResponse;
+    return this.recordOperation(
+      "process",
+      "stop",
+      { identifier },
+      async () => {
+        const { response, data, error } = await deleteProcessByIdentifier(this.withClient({
+          path: { identifier },
+          baseUrl: this.url,
+        }));
+        this.handleResponseError(response, data, error);
+        return data as DeleteProcessByIdentifierResponse;
+      }
+    );
   }
 
   async kill(identifier: string): Promise<DeleteProcessByIdentifierKillResponse> {
-    const { response, data, error } = await deleteProcessByIdentifierKill(this.withClient({
-      path: { identifier },
-      baseUrl: this.url,
-    }));
-    this.handleResponseError(response, data, error);
-    return data as DeleteProcessByIdentifierKillResponse;
+    return this.recordOperation(
+      "process",
+      "kill",
+      { identifier },
+      async () => {
+        const { response, data, error } = await deleteProcessByIdentifierKill(this.withClient({
+          path: { identifier },
+          baseUrl: this.url,
+        }));
+        this.handleResponseError(response, data, error);
+        return data as DeleteProcessByIdentifierKillResponse;
+      },
+    );
   }
 
   async logs(identifier: string, type: "stdout" | "stderr" | "all" = "all"): Promise<string> {
-    // Idempotent GET: self-heal a transient connection reset.
-    const data = await retryOnTransientReset(async () => {
-      const { response, data, error } = await getProcessByIdentifierLogs(this.withClient({
-        path: { identifier },
-        baseUrl: this.url,
-      }));
-      this.handleResponseError(response, data, error);
-      return data;
-    });
-    if (type === "all") {
-      return data?.logs || "";
-    } else if (type === "stdout") {
-      return data?.stdout || "";
-    } else if (type === "stderr") {
-      return data?.stderr || "";
-    }
-    throw new Error("Unsupported log type");
+    return this.recordOperation(
+      "process",
+      "logs",
+      { identifier, type },
+      async () => {
+        // Idempotent GET: self-heal a transient connection reset.
+        const data = await retryOnTransientReset(async () => {
+          const { response, data, error } = await getProcessByIdentifierLogs(this.withClient({
+            path: { identifier },
+            baseUrl: this.url,
+          }));
+          this.handleResponseError(response, data, error);
+          return data;
+        });
+        if (type === "all") {
+          return data?.logs || "";
+        } else if (type === "stdout") {
+          return data?.stdout || "";
+        } else if (type === "stderr") {
+          return data?.stderr || "";
+        }
+        throw new Error("Unsupported log type");
+      },
+      (logs) => ({ bytes: new Blob([logs]).size }),
+    );
   }
 }

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -4,6 +4,7 @@ import { createSandbox, deleteSandbox, getSandbox, getSandboxByExternalId, listS
 import { logger } from "../common/logger.js";
 import { settings } from "../common/settings.js";
 import { SandboxCodegen } from "./codegen/index.js";
+import { SandboxOperationRecorder, type SandboxOperationRecorderOptions } from "./diagnostics.js";
 import { SandboxDrive } from "./drive/index.js";
 import { SandboxFileSystem } from "./filesystem/index.js";
 import { SandboxNetwork } from "./network/index.js";
@@ -84,6 +85,22 @@ export class SandboxInstance {
 
   get h2Domain() {
     return this.sandbox.h2Domain ?? null;
+  }
+
+  startOperationRecording(options: SandboxOperationRecorderOptions = {}): SandboxOperationRecorder {
+    const recorder = new SandboxOperationRecorder(options);
+    this.sandbox.operationRecorder = recorder;
+    return recorder;
+  }
+
+  stopOperationRecording(): SandboxOperationRecorder | null {
+    const recorder = this.sandbox.operationRecorder ?? null;
+    delete this.sandbox.operationRecorder;
+    return recorder;
+  }
+
+  get operationRecorder() {
+    return this.sandbox.operationRecorder ?? null;
   }
 
   /**

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -1,6 +1,7 @@
 import type http2 from "http2";
 import { Port, Sandbox, SandboxLifecycle, VolumeAttachment, SandboxNetwork } from "../client/types.gen";
 import { PostProcessResponse, ProcessRequest } from "./client";
+import type { SandboxOperationRecorder } from "./diagnostics.js";
 
 export interface SessionCreateOptions {
   expiresAt?: Date;
@@ -32,6 +33,7 @@ export type SandboxConfiguration = {
   params?: Record<string, string>;
   h2Session?: http2.ClientHttp2Session | null;
   h2Domain?: string | null;
+  operationRecorder?: SandboxOperationRecorder;
 } & Sandbox;
 
 export type SandboxUpdateMetadata = {

--- a/tests/unit/sandbox-operation-recorder.test.ts
+++ b/tests/unit/sandbox-operation-recorder.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { SandboxAction } from "../../@blaxel/core/src/sandbox/action.js";
+import { SandboxOperationRecorder } from "../../@blaxel/core/src/sandbox/diagnostics.js";
+import { SandboxInstance } from "../../@blaxel/core/src/sandbox/sandbox.js";
+import type { SandboxConfiguration } from "../../@blaxel/core/src/sandbox/types.js";
+
+class TestSandboxAction extends SandboxAction {
+  async succeed() {
+    return this.recordOperation(
+      "test",
+      "succeed",
+      {
+        authorization: "Bearer secret",
+        command: this.commandDiagnostics("echo super-secret-token"),
+      },
+      () => Promise.resolve({ bytes: 42 }),
+      (result) => ({ resultBytes: result.bytes }),
+    );
+  }
+
+  async fail() {
+    return this.recordOperation(
+      "test",
+      "fail",
+      { path: "/tmp/output.txt" },
+      () => Promise.reject(Object.assign(new Error("upstream reset"), { code: "ECONNRESET", status: 503 })),
+    );
+  }
+}
+
+function sandboxConfig(recorder: SandboxOperationRecorder): SandboxConfiguration {
+  return {
+    metadata: {
+      name: "recorder-test",
+    },
+    status: "READY",
+    h2Domain: "any.us-pdx-1.bl.run",
+    operationRecorder: recorder,
+  } as SandboxConfiguration;
+}
+
+describe("SandboxOperationRecorder", () => {
+  it("records bounded privacy-safe operation artifacts", async () => {
+    let now = 1000;
+    const recorder = new SandboxOperationRecorder({
+      maxEvents: 1,
+      clock: () => {
+        now += 25;
+        return now;
+      },
+      now: () => `t-${now}`,
+      idFactory: () => `id-${now}`,
+    });
+    const action = new TestSandboxAction(sandboxConfig(recorder));
+
+    await action.succeed();
+    await expect(action.fail()).rejects.toThrow("upstream reset");
+
+    const events = recorder.snapshot();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: "id-1050",
+      sandboxName: "recorder-test",
+      subsystem: "test",
+      operation: "fail",
+      status: "error",
+      durationMs: 25,
+      transport: {
+        h2Domain: "any.us-pdx-1.bl.run",
+        forcedUrl: false,
+      },
+      attributes: {
+        path: "/tmp/output.txt",
+      },
+      error: {
+        name: "Error",
+        message: "upstream reset",
+        code: "ECONNRESET",
+        status: 503,
+      },
+    });
+  });
+
+  it("redacts secret fields and command text unless explicitly enabled", async () => {
+    const recorder = new SandboxOperationRecorder({
+      captureCommandText: false,
+      clock: () => 0,
+      now: () => "now",
+    });
+    const action = new TestSandboxAction(sandboxConfig(recorder));
+
+    await action.succeed();
+
+    const [event] = recorder.snapshot();
+    expect(event.attributes?.authorization).toBe("[redacted]");
+    expect(event.attributes?.command).toMatchObject({
+      commandLength: 23,
+      commandText: "[redacted]",
+    });
+    expect(event.result).toEqual({ resultBytes: 42 });
+    expect(recorder.toString()).not.toContain("super-secret-token");
+    expect(recorder.toString()).not.toContain("Bearer secret");
+  });
+
+  it("can be attached and detached from a SandboxInstance", () => {
+    const sandbox = new SandboxInstance({
+      metadata: { name: "attach-test" },
+      status: "READY",
+    } as SandboxConfiguration);
+
+    const recorder = sandbox.startOperationRecording({ maxEvents: 3 });
+    expect(sandbox.operationRecorder).toBe(recorder);
+    expect(sandbox.stopOperationRecording()).toBe(recorder);
+    expect(sandbox.operationRecorder).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes ENG-3374

## What changed

Adds an opt-in sandbox operation recorder for `@blaxel/core`. A user can call `sandbox.startOperationRecording()` around a failing sandbox workflow and export `recorder.toString()` as a structured support artifact.

The artifact captures process, filesystem, and port-fetch operations with timings, H2 or forceUrl routing metadata, process status and exit code, byte counts, HTTP status, request id, and errors.

## Privacy defaults

Commands, env values, headers, and file contents are not recorded by default. Command text stays redacted unless the caller explicitly opts into `captureCommandText`. Secret-looking keys are redacted recursively.

## Why

When an agent sandbox failure is hard to reproduce, support usually needs more than a stack trace. This gives users and FDE/SREs a bounded replay-adjacent timeline without asking them to paste raw prompts, credentials, or file payloads.

## Validation

- `/Users/ritwij/.bun/bin/bun ./node_modules/vitest/vitest.mjs run tests/unit/sandbox-operation-recorder.test.ts --reporter=verbose`
- `PATH="$PWD/node_modules/.bin:$PWD/@blaxel/core/node_modules/.bin:$PATH" /Users/ritwij/.bun/bin/bun --filter @blaxel/core build:cjs`
- `PATH="$PWD/node_modules/.bin:$PWD/@blaxel/core/node_modules/.bin:$PATH" /Users/ritwij/.bun/bin/bun --filter @blaxel/core build:esm`
- `PATH="$PWD/node_modules/.bin:$PWD/@blaxel/core/node_modules/.bin:$PATH" /Users/ritwij/.bun/bin/bun --filter @blaxel/core build:browser`
- From `@blaxel/core`: `PATH="$PWD/node_modules/.bin:$PATH" /Users/ritwij/.bun/bin/bun ./node_modules/eslint/bin/eslint.js --no-warn-ignored src/sandbox/diagnostics.ts src/sandbox/action.ts src/sandbox/sandbox.ts src/sandbox/process/process.ts src/sandbox/filesystem/filesystem.ts src/sandbox/network/network.ts src/sandbox/types.ts`

Note: the focused Vitest run passes. The repo global cleanup logs missing Blaxel credentials in this shell after the test finishes.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an opt-in `SandboxOperationRecorder` that wraps process, filesystem, and network operations to capture privacy-safe diagnostics (timings, transport metadata, status codes, byte counts, errors) for debugging hard-to-reproduce sandbox failures.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0e12a49f7943c494e15e62cccdaa5ea29eb5952e.</sup>
<!-- /MENDRAL_SUMMARY -->