### PR TITLE
Add sandbox storageMb support

### DIFF
--- a/@blaxel/core/src/client/types.gen.ts
+++ b/@blaxel/core/src/client/types.gen.ts
@@ -3666,6 +3666,10 @@ export type SandboxRuntime = {
     memory?: number;
     ports?: Ports;
     /**
+     * Disk-backed root storage capacity in megabytes. When omitted, the sandbox uses the default tmpfs overlay sizing based on its memory allocation.
+     */
+    storageMb?: number;
+    /**
      * Duration in seconds the pod needs to terminate gracefully. Defaults to 0 for immediate termination.
      */
     terminationGracePeriodSeconds?: number;

--- a/@blaxel/core/src/image/image.browser.ts
+++ b/@blaxel/core/src/image/image.browser.ts
@@ -29,6 +29,7 @@ export interface ImageBuildContext {
 export interface ImageBuildOptions {
   name: string;
   memory?: number;
+  storageMb?: number;
   timeout?: number;
   onStatusChange?: (status: string) => void;
   sandboxVersion?: string;
@@ -141,4 +142,3 @@ export class ImageInstance {
     throwBrowserError();
   }
 }
-

--- a/@blaxel/core/src/image/image.test.ts
+++ b/@blaxel/core/src/image/image.test.ts
@@ -621,6 +621,14 @@ describe("ImageInstance sandbox-api preparation", () => {
     );
   });
 
+  it("includes storageMb in sandbox payloads for image builds", () => {
+    const image = ImageInstance.fromRegistry("python:3.11-slim");
+    // @ts-expect-error - accessing private method for testing
+    const payload = image._createSandboxPayload("image-storage", 4096, 102400);
+
+    expect(payload.spec?.runtime?.storageMb).toBe(102400);
+  });
+
   it("does not duplicate sandbox-api if base image is sandbox", () => {
     const image = ImageInstance.fromRegistry("ghcr.io/blaxel-ai/sandbox:latest");
     // @ts-expect-error - accessing private method for testing

--- a/@blaxel/core/src/image/image.ts
+++ b/@blaxel/core/src/image/image.ts
@@ -38,6 +38,7 @@ export interface ImageBuildContext {
 export interface ImageBuildOptions {
   name: string;
   memory?: number;
+  storageMb?: number;
   timeout?: number;
   onStatusChange?: (status: string) => void;
   sandboxVersion?: string;
@@ -149,6 +150,7 @@ function sleep(ms: number): Promise<void> {
  * await image.build({
  *   name: "my-sandbox",
  *   memory: 4096,
+ *   storageMb: 102400,
  *   timeout: 900000,
  *   onStatusChange: console.log,
  *   sandboxVersion: "latest",
@@ -745,7 +747,7 @@ export class ImageInstance {
     });
   }
 
-  private _createSandboxPayload(name: string, memory: number = 4096): Sandbox {
+  private _createSandboxPayload(name: string, memory: number = 4096, storageMb?: number): Sandbox {
     const labels: MetadataLabels = {
       "x-blaxel-auto-generated": "true",
     };
@@ -758,6 +760,9 @@ export class ImageInstance {
     const runtime: SandboxRuntime = {
       memory,
     };
+    if (storageMb !== undefined) {
+      runtime.storageMb = storageMb;
+    }
 
     const spec: SandboxSpec = {
       runtime,
@@ -892,7 +897,14 @@ export class ImageInstance {
    * @returns The deployed Sandbox object
    */
   async build(options: ImageBuildOptions): Promise<Sandbox> {
-    const { name, memory = 4096, timeout = 900000, onStatusChange, sandboxVersion = "latest" } = options;
+    const {
+      name,
+      memory = 4096,
+      storageMb,
+      timeout = 900000,
+      onStatusChange,
+      sandboxVersion = "latest",
+    } = options;
 
     // Prepare image for sandbox deployment (add sandbox-api and entrypoint)
     const preparedImage = this._prepareForSandbox(sandboxVersion);
@@ -905,7 +917,7 @@ export class ImageInstance {
       const zipContent = await this._createZip(buildDir);
 
       // Create sandbox payload
-      const sandboxPayload = this._createSandboxPayload(name, memory);
+      const sandboxPayload = this._createSandboxPayload(name, memory, storageMb);
 
       // Create/update sandbox and get upload URL
       const { response, uploadUrl } = await this._createSandboxWithUpload(sandboxPayload);

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -143,6 +143,7 @@ export class SandboxInstance {
       'name' in sandbox ||
       'image' in sandbox ||
       'memory' in sandbox ||
+      'storageMb' in sandbox ||
       'ports' in sandbox ||
       'envs' in sandbox ||
       'volumes' in sandbox ||
@@ -181,6 +182,7 @@ export class SandboxInstance {
           runtime: {
             image: sandbox.image,
             memory: sandbox.memory,
+            ...(sandbox.storageMb !== undefined && { storageMb: sandbox.storageMb }),
             ports: ports,
             envs: envs,
             generation: "mk3",

--- a/@blaxel/core/src/sandbox/types.ts
+++ b/@blaxel/core/src/sandbox/types.ts
@@ -48,6 +48,7 @@ export type SandboxCreateConfiguration = {
   name?: string;
   image?: string;
   memory?: number;
+  storageMb?: number;
   ports?: (Port | Record<string, any>)[];
   envs?: EnvVar[];
   volumes?: (VolumeBinding | VolumeAttachment)[];

--- a/tests/unit/sandbox-create-storage.test.ts
+++ b/tests/unit/sandbox-create-storage.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSandbox: vi.fn(),
+  deleteSandbox: vi.fn(),
+  getSandbox: vi.fn(),
+  getSandboxByExternalId: vi.fn(),
+  h2Get: vi.fn(),
+  h2Warm: vi.fn(),
+  listSandboxes: vi.fn(),
+  updateSandbox: vi.fn(),
+}));
+
+vi.mock("../../@blaxel/core/src/client/index.js", () => ({
+  ...mocks,
+}));
+
+vi.mock("../../@blaxel/core/src/common/h2pool.js", () => ({
+  h2Pool: {
+    get: mocks.h2Get,
+    warm: mocks.h2Warm,
+  },
+}));
+
+import { SandboxInstance } from "../../@blaxel/core/src/sandbox/sandbox.ts";
+
+describe("SandboxInstance.create storage", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards storageMb to the sandbox runtime request body", async () => {
+    mocks.h2Get.mockResolvedValue(null);
+    mocks.createSandbox.mockResolvedValue({
+      data: {
+        metadata: { name: "storage" },
+        spec: { region: "us-pdx-1", runtime: {} },
+        status: "DEPLOYED",
+      },
+    });
+
+    await SandboxInstance.create({
+      name: "storage",
+      image: "blaxel/base-image:latest",
+      memory: 4096,
+      region: "us-pdx-1",
+      storageMb: 102400,
+    });
+
+    const [{ body }] = mocks.createSandbox.mock.calls[0];
+    expect(body.spec.runtime.storageMb).toBe(102400);
+  });
+
+  it("omits storageMb from the runtime request body when unset", async () => {
+    mocks.h2Get.mockResolvedValue(null);
+    mocks.createSandbox.mockResolvedValue({
+      data: {
+        metadata: { name: "default-storage" },
+        spec: { region: "us-pdx-1", runtime: {} },
+        status: "DEPLOYED",
+      },
+    });
+
+    await SandboxInstance.create({
+      name: "default-storage",
+      image: "blaxel/base-image:latest",
+      memory: 4096,
+      region: "us-pdx-1",
+    });
+
+    const [{ body }] = mocks.createSandbox.mock.calls[0];
+    expect(Object.hasOwn(body.spec.runtime, "storageMb")).toBe(false);
+  });
+});


### PR DESCRIPTION
- Adds storageMb to sandbox create and runtime types.
- Forwards root storage through sandbox creation and image builds.
- Covers create and image-build payload behavior.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `storageMb` optional field to sandbox creation and image build flows, with type updates, conditional forwarding logic, and unit tests covering both presence and absence of the field.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d46cd79d788b171bdd6dba22d769e1cea31ec0f2.</sup>
<!-- /MENDRAL_SUMMARY -->