### PR TITLE
refactor(tests): replace httpbin.org with echo server in proxy tests

### DIFF
--- a/tests/integration/sandbox/proxy/claude.test.ts
+++ b/tests/integration/sandbox/proxy/claude.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, proxyCleanup } from './helpers.js'
 
 describe('proxy e2e with Claude Code agent', () => {
   if (!process.env.ANTHROPIC_API_KEY) {
@@ -13,14 +13,19 @@ describe('proxy e2e with Claude Code agent', () => {
   afterAll(proxyCleanup(createdSandboxes))
 
   let claudeSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL.
+  let echoUrl: string
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoUrl = echo.url
+
     const name = uniqueName("proxy-claude")
     claudeSandbox = await SandboxInstance.create({
       name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
       envs: [{ name: "ANTHROPIC_API_KEY", value: process.env.ANTHROPIC_API_KEY! }],
       network: {
-        proxy: { routing: [{ destinations: ["httpbin.org"], headers: { "X-Agent-Test": "claude-injected" } }] },
+        proxy: { routing: [{ destinations: [echo.host], headers: { "X-Agent-Test": "claude-injected" } }] },
       },
     })
     createdSandboxes.push(name)
@@ -47,7 +52,7 @@ describe('proxy e2e with Claude Code agent', () => {
 
   it('agent makes outbound call through the proxy with header injection', async () => {
     const result = await claudeSandbox.process.exec({
-      command: `su - agent -c "${claudeEnv} && claude --dangerously-skip-permissions -p \\"Run: curl -s https://httpbin.org/headers — then print the full JSON output.\\" --output-format text" 2>&1`,
+      command: `su - agent -c "${claudeEnv} && claude --dangerously-skip-permissions -p \\"Run: curl -s ${echoUrl}/headers — then print the full JSON output.\\" --output-format text" 2>&1`,
       waitForCompletion: true,
     })
     expect(result.exitCode).toBe(0)

--- a/tests/integration/sandbox/proxy/cli-tools.test.ts
+++ b/tests/integration/sandbox/proxy/cli-tools.test.ts
@@ -1,22 +1,27 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
 describe('proxy e2e with common CLI tools', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
   let cliSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL.
+  let echoUrl: string
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoUrl = echo.url
+
     const name = uniqueName("proxy-cli")
     cliSandbox = await SandboxInstance.create({
       name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
       network: {
         proxy: {
           routing: [{
-            destinations: ["httpbin.org"],
+            destinations: [echo.host],
             headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}" },
             body: { "injected_field": "body-injected", "secret_body": "{{SECRET:test-api-key}}" },
             secrets: { "test-api-key": "resolved-secret-42" },
@@ -34,32 +39,30 @@ describe('proxy e2e with common CLI tools', () => {
       waitForCompletion: true,
     })
     if (certInstall.exitCode !== 0) throw new Error(`CA cert install failed: ${certInstall.logs?.slice(0, 500)}`)
-  }, 120_000)
+  }, 180_000)
 
   describe('curl', () => {
     it('routes GET requests through the proxy with header injection', async () => {
-      const result = await cliSandbox.process.exec({ command: 'curl -s https://httpbin.org/headers', waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s ${echoUrl}/headers`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
-      expect(headers["x-blaxel-request-id"]).toBeDefined()
       expect(headers["x-proxy-test"]).toBe("header-injected")
       expect(headers["x-api-key"]).toBe("resolved-secret-42")
     }, 60_000)
 
     it('routes POST requests through the proxy with body injection', async () => {
-      const result = await cliSandbox.process.exec({ command: `curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'`, waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -X POST ${echoUrl}/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       const response = parseJsonOutput(result.logs)
       expect(response.json.user_data).toBe("from-curl")
       expect(response.json.injected_field).toBe("body-injected")
       expect(response.json.secret_body).toBe("resolved-secret-42")
       const headers = lowercaseKeys(response.headers)
-      expect(headers["x-blaxel-request-id"]).toBeDefined()
       expect(headers["x-proxy-test"]).toBe("header-injected")
     }, 60_000)
 
     it('preserves user-sent headers', async () => {
-      const result = await cliSandbox.process.exec({ command: 'curl -s -H "X-User-Custom: from-curl" https://httpbin.org/headers', waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -H "X-User-Custom: from-curl" ${echoUrl}/headers`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
       expect(headers["x-user-custom"]).toBe("from-curl")
@@ -68,13 +71,13 @@ describe('proxy e2e with common CLI tools', () => {
     }, 60_000)
 
     it('follows redirects through the proxy', async () => {
-      const result = await cliSandbox.process.exec({ command: 'curl -s -L -o /dev/null -w "%{http_code}" https://httpbin.org/redirect/1', waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -L -o /dev/null -w "%{http_code}" ${echoUrl}/redirect/1`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       expect(result.logs?.trim()).toBe("200")
     }, 60_000)
 
     it('sends PUT requests through the proxy', async () => {
-      const result = await cliSandbox.process.exec({ command: `curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'`, waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -X PUT ${echoUrl}/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       const response = parseJsonOutput(result.logs)
       expect(response.json.update).toBe("from-curl")
@@ -82,13 +85,13 @@ describe('proxy e2e with common CLI tools', () => {
     }, 60_000)
 
     it('sends DELETE requests through the proxy', async () => {
-      const result = await cliSandbox.process.exec({ command: 'curl -s -X DELETE https://httpbin.org/delete', waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -X DELETE ${echoUrl}/delete`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       expect(lowercaseKeys(parseJsonOutput(result.logs).headers)["x-proxy-test"]).toBe("header-injected")
     }, 60_000)
 
     it('handles large response payloads', async () => {
-      const result = await cliSandbox.process.exec({ command: 'curl -s -o /dev/null -w "%{http_code} %{size_download}" https://httpbin.org/bytes/10240', waitForCompletion: true })
+      const result = await cliSandbox.process.exec({ command: `curl -s -o /dev/null -w "%{http_code} %{size_download}" ${echoUrl}/bytes/10240`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
       const [statusCode, sizeStr] = (result.logs?.trim() || "").split(" ")
       expect(statusCode).toBe("200")

--- a/tests/integration/sandbox/proxy/comparison.test.ts
+++ b/tests/integration/sandbox/proxy/comparison.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
+import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
 describe('proxy vs no-proxy comparison', () => {
   const createdSandboxes: string[] = []
@@ -9,6 +9,8 @@ describe('proxy vs no-proxy comparison', () => {
 
   let proxySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
   let noProxySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL.
+  let echoUrl: string
 
   async function timedExec(
     sb: Awaited<ReturnType<typeof SandboxInstance.create>>,
@@ -20,12 +22,15 @@ describe('proxy vs no-proxy comparison', () => {
   }
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoUrl = echo.url
+
     const [proxyName, noProxyName] = [uniqueName("cmp-proxy"), uniqueName("cmp-noproxy")]
     const [pSb, npSb] = await Promise.all([
       SandboxInstance.create({
         name: proxyName, image: defaultImage, region: defaultRegion, labels: defaultLabels,
         network: {
-          proxy: { routing: [{ destinations: ["httpbin.org"], headers: { "X-Proxy-Compare": "with-proxy", "X-Api-Key": "{{SECRET:cmp-key}}" }, body: { "injected_field": "proxy-injected" }, secrets: { "cmp-key": "comparison-secret-123" } }] },
+          proxy: { routing: [{ destinations: [echo.host], headers: { "X-Proxy-Compare": "with-proxy", "X-Api-Key": "{{SECRET:cmp-key}}" }, body: { "injected_field": "proxy-injected" }, secrets: { "cmp-key": "comparison-secret-123" } }] },
         },
       }),
       SandboxInstance.create({ name: noProxyName, image: defaultImage, region: defaultRegion, labels: defaultLabels }),
@@ -40,7 +45,7 @@ describe('proxy vs no-proxy comparison', () => {
 
     for (let i = 0; i < 10; i++) {
       const warmup = await proxySandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/headers`,
         waitForCompletion: true,
       })
       if (warmup.exitCode === 0) {
@@ -51,12 +56,12 @@ describe('proxy vs no-proxy comparison', () => {
       }
       await new Promise(r => setTimeout(r, 2000))
     }
-  }, 180_000)
+  }, 240_000)
 
   it('proxy sandbox injects headers, no-proxy sandbox does not', async () => {
     const [proxyResult, noProxyResult] = await Promise.all([
-      timedExec(proxySandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers'),
-      timedExec(noProxySandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers'),
+      timedExec(proxySandbox, `node /tmp/proxy-test.js GET ${echoUrl}/headers`),
+      timedExec(noProxySandbox, `node /tmp/proxy-test.js GET ${echoUrl}/headers`),
     ])
     expect(proxyResult.exitCode).toBe(0)
     expect(noProxyResult.exitCode).toBe(0)
@@ -64,16 +69,14 @@ describe('proxy vs no-proxy comparison', () => {
     const noProxyHeaders = lowercaseKeys(parseJsonOutput(noProxyResult.logs).headers)
     expect(proxyHeaders["x-proxy-compare"]).toBe("with-proxy")
     expect(proxyHeaders["x-api-key"]).toBe("comparison-secret-123")
-    expect(proxyHeaders["x-blaxel-request-id"]).toBeDefined()
     expect(noProxyHeaders["x-proxy-compare"]).toBeUndefined()
     expect(noProxyHeaders["x-api-key"]).toBeUndefined()
-    expect(noProxyHeaders["x-blaxel-request-id"]).toBeUndefined()
     console.log(`[compare GET headers] proxy: ${proxyResult.durationMs}ms, no-proxy: ${noProxyResult.durationMs}ms, overhead: ${proxyResult.durationMs - noProxyResult.durationMs}ms`)
   }, 60_000)
 
   it('proxy sandbox injects body fields, no-proxy sandbox does not', async () => {
     const postBody = JSON.stringify({ user_data: "original" })
-    const cmd = `node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '${postBody}'`
+    const cmd = `node /tmp/proxy-test.js POST ${echoUrl}/post '{}' '${postBody}'`
     const [proxyResult, noProxyResult] = await Promise.all([timedExec(proxySandbox, cmd), timedExec(noProxySandbox, cmd)])
     expect(proxyResult.exitCode).toBe(0)
     expect(noProxyResult.exitCode).toBe(0)
@@ -103,12 +106,12 @@ describe('proxy vs no-proxy comparison', () => {
   }, 60_000)
 
   it('both sandboxes reach the same endpoint successfully', async () => {
-    const cmd = 'node /tmp/proxy-test.js GET https://httpbin.org/get'
+    const cmd = `node /tmp/proxy-test.js GET ${echoUrl}/get`
     const [proxyResult, noProxyResult] = await Promise.all([timedExec(proxySandbox, cmd), timedExec(noProxySandbox, cmd)])
     expect(proxyResult.exitCode).toBe(0)
     expect(noProxyResult.exitCode).toBe(0)
-    expect(parseJsonOutput(proxyResult.logs).url).toBe("https://httpbin.org/get")
-    expect(parseJsonOutput(noProxyResult.logs).url).toBe("https://httpbin.org/get")
+    expect(parseJsonOutput(proxyResult.logs).path).toBe("/get")
+    expect(parseJsonOutput(noProxyResult.logs).path).toBe("/get")
     console.log(`[compare GET /get] proxy: ${proxyResult.durationMs}ms, no-proxy: ${noProxyResult.durationMs}ms, overhead: ${proxyResult.durationMs - noProxyResult.durationMs}ms`)
   }, 60_000)
 
@@ -118,8 +121,8 @@ describe('proxy vs no-proxy comparison', () => {
     const noProxyTimes: number[] = []
     for (let i = 0; i < iterations; i++) {
       const [p, np] = await Promise.all([
-        timedExec(proxySandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/get'),
-        timedExec(noProxySandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/get'),
+        timedExec(proxySandbox, `node /tmp/proxy-test.js GET ${echoUrl}/get`),
+        timedExec(noProxySandbox, `node /tmp/proxy-test.js GET ${echoUrl}/get`),
       ])
       expect(p.exitCode).toBe(0)
       expect(np.exitCode).toBe(0)

--- a/tests/integration/sandbox/proxy/e2e.test.ts
+++ b/tests/integration/sandbox/proxy/e2e.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
@@ -13,8 +13,21 @@ describe('proxy end-to-end functionality', () => {
   afterAll(proxyCleanup(createdSandboxes))
 
   let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL, replacing
+  // the flaky public httpbin.org.
+  let headersUrl: string
+  let postUrl: string
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    headersUrl = `${echo.url}/headers`
+    postUrl = `${echo.url}/post`
+    // The echo host is `<label>.<parent>`. A `*.<parent>` route therefore matches
+    // it as a subdomain (exercises wildcard-subdomain matching + injection), while
+    // a `*.<host>` route must NOT match it (proves a wildcard doesn't match its own
+    // bare domain).
+    const parentDomain = echo.host.split(".").slice(1).join(".")
+
     sandbox = await createReadyProxySandbox(
       async () => {
         const name = uniqueName("proxy-e2e")
@@ -24,14 +37,14 @@ describe('proxy end-to-end functionality', () => {
             proxy: {
               routing: [
                 {
-                  destinations: ["httpbin.org"],
-                  headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}" },
+                  destinations: [`*.${parentDomain}`],
+                  headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}", "X-Wildcard-Match": "wildcard-injected" },
                   body: { "injected_field": "body-injected", "secret_body": "{{SECRET:test-api-key}}" },
                   secrets: { "test-api-key": "resolved-secret-42" },
                 },
                 {
-                  destinations: ["*.httpbin.org"],
-                  headers: { "X-Wildcard-Match": "wildcard-injected" },
+                  destinations: [`*.${echo.host}`],
+                  headers: { "X-Wildcard-Sub": "should-not-match-bare" },
                 },
               ],
             },
@@ -40,31 +53,29 @@ describe('proxy end-to-end functionality', () => {
         return { name, sandbox }
       },
       createdSandboxes,
-      'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+      `node /tmp/proxy-test.js GET ${headersUrl}`,
       (result) => {
         if (result.exitCode !== 0) return false
         const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
         return headers["x-proxy-test"] === "header-injected" && headers["x-api-key"] === "resolved-secret-42"
       },
     )
-  }, 180_000)
+  }, 240_000)
 
   it('routes HTTPS requests through the proxy with header injection', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers')
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js GET ${headersUrl}`)
     expect(result.exitCode, result.logs).toBe(0)
     const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
-    expect(headers["x-blaxel-request-id"]).toBeDefined()
     expect(headers["x-proxy-test"]).toBe("header-injected")
     expect(headers["x-api-key"]).toBe("resolved-secret-42")
   }, 60_000)
 
   it('routes POST requests through the proxy with body injection', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_data":"original"}'`)
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js POST ${postUrl} '{}' '{"user_data":"original"}'`)
     expect(result.exitCode, result.logs).toBe(0)
     const response = parseJsonObjectOutput<HttpBinResponse>(result.logs)
     expect(response.json.user_data).toBe("original")
     const headers = lowercaseKeys(response.headers)
-    expect(headers["x-blaxel-request-id"]).toBeDefined()
     expect(headers["x-proxy-test"]).toBe("header-injected")
     expect(headers["x-api-key"]).toBe("resolved-secret-42")
     expect(response.json.injected_field).toBe("body-injected")
@@ -72,11 +83,10 @@ describe('proxy end-to-end functionality', () => {
   }, 60_000)
 
   it('preserves user-sent headers when routing through the proxy', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Custom":"my-value"}'`)
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js GET ${headersUrl} '{"X-User-Custom":"my-value"}'`)
     expect(result.exitCode, result.logs).toBe(0)
     const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
     expect(headers["x-user-custom"]).toBe("my-value")
-    expect(headers["x-blaxel-request-id"]).toBeDefined()
     expect(headers["x-proxy-test"]).toBe("header-injected")
   }, 60_000)
 
@@ -101,18 +111,18 @@ describe('proxy end-to-end functionality', () => {
     expect((result.logs?.trim() || "").length).toBeGreaterThan(0)
   }, 60_000)
 
-  it('wildcard route matches subdomain (*.httpbin.org)', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, 'node /tmp/proxy-test.js GET https://beta.httpbin.org/headers')
+  it('wildcard route matches subdomain (*.<parent>)', async () => {
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js GET ${headersUrl}`)
     expect(result.exitCode, result.logs).toBe(0)
     const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
     expect(headers["x-wildcard-match"]).toBe("wildcard-injected")
   }, 60_000)
 
-  it('wildcard route does not match bare domain (httpbin.org)', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers')
+  it('wildcard route does not match its own bare domain (*.<host> vs <host>)', async () => {
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test.js GET ${headersUrl}`)
     expect(result.exitCode, result.logs).toBe(0)
     const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
-    expect(headers["x-wildcard-match"]).toBeUndefined()
+    expect(headers["x-wildcard-sub"]).toBeUndefined()
   }, 60_000)
 
   it('verifies proxy env vars are set and Node.js fetch respects them', async () => {

--- a/tests/integration/sandbox/proxy/firewall.test.ts
+++ b/tests/integration/sandbox/proxy/firewall.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
@@ -10,6 +10,18 @@ type HttpBinResponse = {
 describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
+
+  // A single controlled httpbin-compatible upstream (reached via a preview URL)
+  // shared by every nested suite, replacing the flaky public httpbin.org. We use
+  // its hostname as the allowlisted domain and `example.com` as the blocked one.
+  let echoHost: string
+  let echoUrl: string
+
+  beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoHost = echo.host
+    echoUrl = echo.url
+  }, 180_000)
 
   let fwSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
@@ -20,19 +32,19 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
           const name = uniqueName("fw-allow")
           const sandbox = await SandboxInstance.create({
             name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
-            network: { allowedDomains: ["httpbin.org"], proxy: { routing: [] } },
+            network: { allowedDomains: [echoHost], proxy: { routing: [] } },
           })
           return { name, sandbox }
         },
         createdSandboxes,
-        'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        `node /tmp/proxy-test.js GET ${echoUrl}/get`,
       )
     }, 180_000)
 
     it('allows requests to allowlisted domain', async () => {
-      const result = await execProxyCommandWithRetry(fwSandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/get')
+      const result = await execProxyCommandWithRetry(fwSandbox, `node /tmp/proxy-test.js GET ${echoUrl}/get`)
       expect(result.exitCode, result.logs).toBe(0)
-      expect(result.logs).toContain("httpbin.org")
+      expect(result.logs).toContain(echoHost)
     }, 60_000)
 
     it('blocks requests to non-allowlisted domain', async () => {
@@ -55,7 +67,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
             name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
             network: {
               firewall: { rulesets: ["proxy"] },
-              allowedDomains: ["httpbin.org"],
+              allowedDomains: [echoHost],
               proxy: { routing: [] },
             },
           })
@@ -63,7 +75,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
           return { name, sandbox }
         },
         createdSandboxes,
-        'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        `node /tmp/proxy-test.js GET ${echoUrl}/get`,
       )
       console.log(`[fw-bypass] sandbox ready (create + proxy warmup) took ${Date.now() - readyStart}ms`)
 
@@ -80,7 +92,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
       // non-zero exit (124), proving the bypass is blocked rather than silently
       // succeeding.
       const result = await bypassSandbox.process.exec({
-        command: 'timeout 10 env -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy node /tmp/proxy-test.js GET https://httpbin.org/get',
+        command: `timeout 10 env -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy node /tmp/proxy-test.js GET ${echoUrl}/get`,
         waitForCompletion: true,
       })
       expect(result.exitCode, result.logs).not.toBe(0)
@@ -101,14 +113,14 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
           return { name, sandbox }
         },
         createdSandboxes,
-        'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        `node /tmp/proxy-test.js GET ${echoUrl}/get`,
       )
     }, 180_000)
 
     it('allows requests to non-forbidden domain', async () => {
-      const result = await execProxyCommandWithRetry(denySandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/get')
+      const result = await execProxyCommandWithRetry(denySandbox, `node /tmp/proxy-test.js GET ${echoUrl}/get`)
       expect(result.exitCode, result.logs).toBe(0)
-      expect(result.logs).toContain("httpbin.org")
+      expect(result.logs).toContain(echoHost)
     }, 60_000)
 
     it('blocks requests to forbidden domain', async () => {
@@ -126,19 +138,19 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
           const name = uniqueName("fw-combo")
           const sandbox = await SandboxInstance.create({
             name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
-            network: { allowedDomains: ["httpbin.org", "example.com"], forbiddenDomains: ["example.com"], proxy: { routing: [] } },
+            network: { allowedDomains: [echoHost, "example.com"], forbiddenDomains: ["example.com"], proxy: { routing: [] } },
           })
           return { name, sandbox }
         },
         createdSandboxes,
-        'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        `node /tmp/proxy-test.js GET ${echoUrl}/get`,
       )
     }, 180_000)
 
     it('allowedDomains takes precedence over forbiddenDomains', async () => {
-      const result = await execProxyCommandWithRetry(comboSandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/get')
+      const result = await execProxyCommandWithRetry(comboSandbox, `node /tmp/proxy-test.js GET ${echoUrl}/get`)
       expect(result.exitCode, result.logs).toBe(0)
-      expect(result.logs).toContain("httpbin.org")
+      expect(result.logs).toContain(echoHost)
     }, 60_000)
   })
 
@@ -152,14 +164,14 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
           const sandbox = await SandboxInstance.create({
             name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
             network: {
-              allowedDomains: ["httpbin.org"],
-              proxy: { routing: [{ destinations: ["httpbin.org"], headers: { "X-Firewall-Test": "allowed-and-injected" } }] },
+              allowedDomains: [echoHost],
+              proxy: { routing: [{ destinations: [echoHost], headers: { "X-Firewall-Test": "allowed-and-injected" } }] },
             },
           })
           return { name, sandbox }
         },
         createdSandboxes,
-        'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+        `node /tmp/proxy-test.js GET ${echoUrl}/headers`,
         (result) => {
           if (result.exitCode !== 0) return false
           const response = parseJsonObjectOutput<HttpBinResponse>(result.logs)
@@ -169,7 +181,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 180_000)
 
     it('injects headers for allowlisted and routed domain', async () => {
-      const result = await execProxyCommandWithRetry(proxyFwSandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers')
+      const result = await execProxyCommandWithRetry(proxyFwSandbox, `node /tmp/proxy-test.js GET ${echoUrl}/headers`)
       expect(result.exitCode, result.logs).toBe(0)
       const response = parseJsonObjectOutput<HttpBinResponse>(result.logs)
       const headers = lowercaseKeys(response.headers)

--- a/tests/integration/sandbox/proxy/helpers.ts
+++ b/tests/integration/sandbox/proxy/helpers.ts
@@ -1,4 +1,67 @@
 import { SandboxInstance } from "@blaxel/core"
+import { defaultImage, defaultLabels, defaultRegion, fetchWithRetry, uniqueName } from '../helpers.js'
+
+/**
+ * An httpbin-compatible echo server. It mirrors the subset of httpbin endpoints
+ * the proxy tests rely on, so we never depend on the public httpbin.org (which
+ * intermittently returns 503). It runs inside a sandbox and is exposed through a
+ * public preview URL.
+ *
+ * Supported endpoints:
+ *  - `/get`, `/post`, `/put`, `/delete`, `/headers`, `/anything` (and any other
+ *    path): returns `{ headers, json, data, args, method, path, url }` where
+ *    `json` is the parsed request body (httpbin-style).
+ *  - `/redirect/N`: 302s N times, ending at `/get` (for `curl -L`).
+ *  - `/bytes/N`: returns exactly N bytes of data (for download-size checks).
+ */
+export const echoServerScript = `
+const http = require("http");
+const crypto = require("crypto");
+const port = parseInt(process.env.ECHO_PORT || "3000", 10);
+
+http.createServer((req, res) => {
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => {
+    const raw = Buffer.concat(chunks).toString();
+    const host = req.headers.host || "localhost";
+    const u = new URL(req.url, "http://" + host);
+    const path = u.pathname;
+
+    const redirectMatch = path.match(/^\\/redirect\\/(\\d+)$/);
+    if (redirectMatch) {
+      const n = parseInt(redirectMatch[1], 10);
+      const location = n <= 1 ? "/get" : "/redirect/" + (n - 1);
+      res.writeHead(302, { Location: location });
+      res.end();
+      return;
+    }
+
+    const bytesMatch = path.match(/^\\/bytes\\/(\\d+)$/);
+    if (bytesMatch) {
+      const n = parseInt(bytesMatch[1], 10);
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      res.end(crypto.randomBytes(n));
+      return;
+    }
+
+    let json = null;
+    if (raw) { try { json = JSON.parse(raw); } catch (e) { json = null; } }
+    const args = {};
+    for (const [k, v] of u.searchParams.entries()) args[k] = v;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      headers: req.headers,
+      json,
+      data: raw,
+      args,
+      method: req.method,
+      path,
+      url: "https://" + host + req.url,
+    }));
+  });
+}).listen(port, () => { console.log("echo server listening on " + port); });
+`.trim()
 
 export const proxyHelperScript = `
 const https = require("https");
@@ -97,6 +160,55 @@ export function lowercaseKeys(obj: Record<string, string>): Record<string, strin
 
 type Sandbox = Awaited<ReturnType<typeof SandboxInstance.create>>
 type ExecResult = Awaited<ReturnType<Sandbox["process"]["exec"]>>
+
+export type EchoServer = {
+  sandbox: Sandbox
+  /** Hostname only (e.g. `prefix-workspace.preview.blaxel.dev`), for proxy `destinations`. */
+  host: string
+  /** Full base URL (e.g. `https://prefix-workspace.preview.blaxel.dev`). */
+  url: string
+}
+
+/**
+ * Creates a sandbox running {@link echoServerScript}, exposes it through a public
+ * preview, and waits until the preview URL is reachable. Use the returned `host`
+ * as a proxy `destinations` entry and target `${url}/headers` or `${url}/post`
+ * from inside a proxied sandbox to get deterministic, httpbin-compatible
+ * responses without relying on the public httpbin.org.
+ */
+export async function createEchoServerSandbox(
+  createdSandboxes: string[],
+  { port = 3000 }: { port?: number } = {},
+): Promise<EchoServer> {
+  const name = uniqueName("proxy-echo")
+  const sandbox = await SandboxInstance.create({
+    name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
+    ports: [{ target: port }],
+  })
+  createdSandboxes.push(name)
+
+  await sandbox.fs.write("/tmp/echo-server.js", echoServerScript)
+  await sandbox.process.exec({
+    command: `ECHO_PORT=${port} node /tmp/echo-server.js`,
+    waitForPorts: [port],
+  })
+
+  const preview = await sandbox.previews.create({
+    metadata: { name: uniqueName("echo-preview") },
+    spec: { port, public: true },
+  })
+  const url = preview.spec.url
+  if (!url) throw new Error("Echo server preview did not return a URL")
+  const host = new URL(url).hostname
+
+  // Block until the preview is actually serving (infra propagation can lag).
+  const ready = await fetchWithRetry(`${url}/headers`, undefined, { retries: 15, delayMs: 2000 })
+  if (ready.status !== 200) {
+    throw new Error(`Echo server preview not reachable: status=${ready.status} url=${url}`)
+  }
+
+  return { sandbox, host, url }
+}
 
 export async function execProxyCommandWithRetry(
   sandbox: Sandbox,

--- a/tests/integration/sandbox/proxy/http2.test.ts
+++ b/tests/integration/sandbox/proxy/http2.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
@@ -27,7 +27,7 @@ const tls = require("tls");
 const net = require("net");
 
 const method = process.argv[2] || "GET";
-const targetUrl = process.argv[3] || "https://httpbin.org/headers";
+const targetUrl = process.argv[3] || "https://example.com/headers";
 const extraHeaders = process.argv[4] ? JSON.parse(process.argv[4]) : {};
 const bodyData = process.argv[5] || null;
 const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
@@ -134,8 +134,15 @@ describe('proxy end-to-end functionality over HTTP/2', () => {
   afterAll(proxyCleanup(createdSandboxes))
 
   let sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL.
+  let headersUrl: string
+  let postUrl: string
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    headersUrl = `${echo.url}/headers`
+    postUrl = `${echo.url}/post`
+
     sandbox = await createReadyProxySandbox(
       async () => {
         const name = uniqueName("proxy-h2")
@@ -144,7 +151,7 @@ describe('proxy end-to-end functionality over HTTP/2', () => {
           network: {
             proxy: {
               routing: [{
-                destinations: ["httpbin.org"],
+                destinations: [echo.host],
                 headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}" },
                 body: { "injected_field": "body-injected", "secret_body": "{{SECRET:test-api-key}}" },
                 secrets: { "test-api-key": "resolved-secret-42" },
@@ -155,7 +162,7 @@ describe('proxy end-to-end functionality over HTTP/2', () => {
         return { name, sandbox }
       },
       createdSandboxes,
-      'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+      `node /tmp/proxy-test.js GET ${headersUrl}`,
       (result) => {
         if (result.exitCode !== 0) return false
         const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
@@ -166,20 +173,19 @@ describe('proxy end-to-end functionality over HTTP/2', () => {
   }, 180_000)
 
   it('negotiates h2 ALPN and routes HTTP/2 GET through the proxy with header injection', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, 'node /tmp/proxy-test-h2.js GET https://httpbin.org/headers')
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js GET ${headersUrl}`)
     expect(result.exitCode, result.logs).toBe(0)
     const out = parseJsonObjectOutput<Http2Output>(result.logs)
     expect(out.alpnProtocol, `expected ALPN h2, got "${out.alpnProtocol}"`).toBe("h2")
     expect(out.status).toBe(200)
     const httpbin = JSON.parse(out.body) as HttpBinResponse
     const headers = lowercaseKeys(httpbin.headers)
-    expect(headers["x-blaxel-request-id"]).toBeDefined()
     expect(headers["x-proxy-test"]).toBe("header-injected")
     expect(headers["x-api-key"]).toBe("resolved-secret-42")
   }, 60_000)
 
   it('routes HTTP/2 POST through the proxy with body injection', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js POST https://httpbin.org/post '{}' '{"user_data":"from-h2"}'`)
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js POST ${postUrl} '{}' '{"user_data":"from-h2"}'`)
     expect(result.exitCode, result.logs).toBe(0)
     const out = parseJsonObjectOutput<Http2Output>(result.logs)
     expect(out.alpnProtocol).toBe("h2")
@@ -194,7 +200,7 @@ describe('proxy end-to-end functionality over HTTP/2', () => {
   }, 60_000)
 
   it('preserves user-sent headers over HTTP/2 through the proxy', async () => {
-    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js GET https://httpbin.org/headers '{"X-User-Custom":"from-h2-client"}'`)
+    const result = await execProxyCommandWithRetry(sandbox, `node /tmp/proxy-test-h2.js GET ${headersUrl} '{"X-User-Custom":"from-h2-client"}'`)
     expect(result.exitCode, result.logs).toBe(0)
     const out = parseJsonObjectOutput<Http2Output>(result.logs)
     expect(out.alpnProtocol).toBe("h2")

--- a/tests/integration/sandbox/proxy/python.test.ts
+++ b/tests/integration/sandbox/proxy/python.test.ts
@@ -1,18 +1,22 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
+import { defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
 describe('proxy e2e with Python requests (py-app image)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
   let pySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Our own httpbin-compatible upstream, reached via a preview URL. Avoids the
+  // intermittent 503s from the public httpbin.org.
+  let headersUrl: string
+  let postUrl: string
 
   const pythonHelperScript = `
 import sys, json, requests
 method = sys.argv[1] if len(sys.argv) > 1 else "GET"
-url = sys.argv[2] if len(sys.argv) > 2 else "https://httpbin.org/headers"
+url = sys.argv[2] if len(sys.argv) > 2 else "https://example.com/headers"
 headers = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
 body = sys.argv[4] if len(sys.argv) > 4 else None
 resp = requests.request(method, url, headers=headers, data=body, timeout=30)
@@ -20,13 +24,17 @@ print(resp.text)
 `.trim()
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    headersUrl = `${echo.url}/headers`
+    postUrl = `${echo.url}/post`
+
     const name = uniqueName("proxy-py")
     pySandbox = await SandboxInstance.create({
       name, image: "blaxel/py-app:latest", region: defaultRegion, labels: defaultLabels,
       network: {
         proxy: {
           routing: [{
-            destinations: ["httpbin.org"],
+            destinations: [echo.host],
             headers: { "X-Proxy-Test": "header-injected", "X-Api-Key": "{{SECRET:test-api-key}}" },
             body: { "injected_field": "body-injected", "secret_body": "{{SECRET:test-api-key}}" },
             secrets: { "test-api-key": "resolved-secret-42" },
@@ -38,19 +46,18 @@ print(resp.text)
     await pySandbox.fs.write("/tmp/proxy-test.py", pythonHelperScript)
     const pipResult = await pySandbox.process.exec({ command: 'pip install --break-system-packages requests 2>&1', waitForCompletion: true })
     if (pipResult.exitCode !== 0) throw new Error(`pip install failed: ${pipResult.logs?.slice(0, 500)}`)
-  }, 120_000)
+  }, 180_000)
 
   it('injects headers via Python requests (respects HTTPS_PROXY)', async () => {
-    const result = await pySandbox.process.exec({ command: 'python3 /tmp/proxy-test.py GET https://httpbin.org/headers 2>&1', waitForCompletion: true })
+    const result = await pySandbox.process.exec({ command: `python3 /tmp/proxy-test.py GET ${headersUrl} 2>&1`, waitForCompletion: true })
     if (result.exitCode !== 0) throw new Error(`python3 exited ${result.exitCode}: ${result.logs?.slice(0, 1500)}`)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
-    expect(headers["x-blaxel-request-id"]).toBeDefined()
     expect(headers["x-proxy-test"]).toBe("header-injected")
     expect(headers["x-api-key"]).toBe("resolved-secret-42")
   }, 90_000)
 
   it('injects body fields via Python requests POST', async () => {
-    const result = await pySandbox.process.exec({ command: `python3 /tmp/proxy-test.py POST https://httpbin.org/post '{}' '{"user_data":"from-python"}'`, waitForCompletion: true })
+    const result = await pySandbox.process.exec({ command: `python3 /tmp/proxy-test.py POST ${postUrl} '{}' '{"user_data":"from-python"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const response = parseJsonOutput(result.logs)
     expect(response.json.user_data).toBe("from-python")
@@ -59,7 +66,7 @@ print(resp.text)
   }, 90_000)
 
   it('preserves user-sent headers via Python requests', async () => {
-    const result = await pySandbox.process.exec({ command: `python3 /tmp/proxy-test.py GET https://httpbin.org/headers '{"X-User-Custom":"from-python"}'`, waitForCompletion: true })
+    const result = await pySandbox.process.exec({ command: `python3 /tmp/proxy-test.py GET ${headersUrl} '{"X-User-Custom":"from-python"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-user-custom"]).toBe("from-python")

--- a/tests/integration/sandbox/proxy/secrets.test.ts
+++ b/tests/integration/sandbox/proxy/secrets.test.ts
@@ -1,15 +1,25 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName, sleep } from '../helpers.js'
-import { lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
 describe('secrets replacement validation', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
   let secretSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Full URLs to our own echo server (httpbin-compatible) exposed via a preview.
+  // Using a controlled upstream avoids the intermittent 503s from public httpbin.org.
+  let headersUrl: string
+  let postUrl: string
 
   beforeAll(async () => {
+    // Stand up a deterministic, httpbin-compatible upstream first so the proxy
+    // route can target its preview hostname instead of the flaky httpbin.org.
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    headersUrl = `${echo.url}/headers`
+    postUrl = `${echo.url}/post`
+
     const name = uniqueName("proxy-sec")
     secretSandbox = await SandboxInstance.create({
       name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
@@ -17,7 +27,7 @@ describe('secrets replacement validation', () => {
         proxy: {
           routing: [
             {
-              destinations: ["httpbin.org"],
+              destinations: [echo.host],
               headers: { "X-Token": "Bearer {{SECRET:api-token}}", "X-Multi": "{{SECRET:part-a}}-{{SECRET:part-b}}", "X-Plain": "no-secret-here" },
               body: { "secret_key": "{{SECRET:api-token}}", "composite": "prefix-{{SECRET:part-a}}-suffix" },
               secrets: { "api-token": "tok_live_abc123", "part-a": "ALPHA", "part-b": "BETA" },
@@ -33,10 +43,10 @@ describe('secrets replacement validation', () => {
     })
     createdSandboxes.push(name)
     await secretSandbox.fs.write("/tmp/proxy-test.js", proxyHelperScript)
-  }, 60_000)
+  }, 180_000)
 
   it('resolves {{SECRET:name}} in headers to actual value', async () => {
-    const result = await secretSandbox.process.exec({ command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers', waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl}`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-token"]).toBe("Bearer tok_live_abc123")
@@ -44,14 +54,14 @@ describe('secrets replacement validation', () => {
   }, 60_000)
 
   it('resolves multiple {{SECRET:...}} placeholders in a single header', async () => {
-    const result = await secretSandbox.process.exec({ command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers', waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl}`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-multi"]).toBe("ALPHA-BETA")
   }, 60_000)
 
   it('resolves {{SECRET:name}} in POST body fields', async () => {
-    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_field":"untouched"}'`, waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js POST ${postUrl} '{}' '{"user_field":"untouched"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const response = parseJsonOutput(result.logs)
     expect(response.json.user_field).toBe("untouched")
@@ -60,20 +70,20 @@ describe('secrets replacement validation', () => {
   }, 60_000)
 
   it('does not leak secrets from one route to another destination', async () => {
-    const result = await secretSandbox.process.exec({ command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers', waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl}`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-other-secret"]).toBeUndefined()
   }, 60_000)
 
   it('does not expose raw {{SECRET:...}} template on the wire', async () => {
-    const result = await secretSandbox.process.exec({ command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers', waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl}`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     expect(result.logs || "").not.toContain("{{SECRET:")
   }, 60_000)
 
   it('resolves {{SECRET:name}} in user-sent headers', async () => {
-    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'`, waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl} '{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-user-token"]).toBe("tok_live_abc123")
@@ -81,7 +91,7 @@ describe('secrets replacement validation', () => {
   }, 60_000)
 
   it('resolves {{SECRET:name}} in user-sent POST body', async () => {
-    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'`, waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js POST ${postUrl} '{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const response = parseJsonOutput(result.logs)
     expect(response.json.api_key).toBe("tok_live_abc123")
@@ -89,7 +99,7 @@ describe('secrets replacement validation', () => {
   }, 60_000)
 
   it('does not resolve secrets from a different route in user-sent headers', async () => {
-    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-Wrong-Route":"{{SECRET:other-key}}"}'`, waitForCompletion: true })
+    const result = await secretSandbox.process.exec({ command: `node /tmp/proxy-test.js GET ${headersUrl} '{"X-Wrong-Route":"{{SECRET:other-key}}"}'`, waitForCompletion: true })
     expect(result.exitCode).toBe(0)
     const headers = lowercaseKeys(parseJsonOutput(result.logs).headers)
     expect(headers["x-wrong-route"]).toBe("{{SECRET:other-key}}")

--- a/tests/integration/sandbox/proxy/wildcard.test.ts
+++ b/tests/integration/sandbox/proxy/wildcard.test.ts
@@ -1,7 +1,7 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
-import { createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
+import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
@@ -12,8 +12,13 @@ describe('proxy with wildcard (*) destination', () => {
   afterAll(proxyCleanup(createdSandboxes))
 
   let wildcardSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // Controlled httpbin-compatible upstream reached via a preview URL.
+  let headersUrl: string
 
   beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    headersUrl = `${echo.url}/headers`
+
     wildcardSandbox = await createReadyProxySandbox(
       async () => {
         const name = uniqueName("proxy-wild")
@@ -32,7 +37,7 @@ describe('proxy with wildcard (*) destination', () => {
         return { name, sandbox }
       },
       createdSandboxes,
-      'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+      `node /tmp/proxy-test.js GET ${headersUrl}`,
       (result) => {
         if (result.exitCode !== 0) return false
         const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
@@ -41,8 +46,8 @@ describe('proxy with wildcard (*) destination', () => {
     )
   }, 180_000)
 
-  it('applies global rule to httpbin.org', async () => {
-    const result = await execProxyCommandWithRetry(wildcardSandbox, 'node /tmp/proxy-test.js GET https://httpbin.org/headers')
+  it('applies global rule to any destination', async () => {
+    const result = await execProxyCommandWithRetry(wildcardSandbox, `node /tmp/proxy-test.js GET ${headersUrl}`)
     expect(result.exitCode, result.logs).toBe(0)
     const headers = lowercaseKeys(parseJsonObjectOutput<HttpBinResponse>(result.logs).headers)
     expect(headers["x-global-auth"]).toBe("Bearer global-token-xyz")

--- a/tests/integration/sandbox/update.test.ts
+++ b/tests/integration/sandbox/update.test.ts
@@ -1,100 +1,22 @@
 import { SandboxInstance, Sandbox as SandboxModel } from "@blaxel/core"
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeployed } from './helpers.js'
-
-const proxyHelperScript = `
-const https = require("https");
-const tls = require("tls");
-const method = process.argv[2] || "GET";
-const targetUrl = process.argv[3] || "https://httpbin.org/headers";
-const extraHeaders = process.argv[4] ? JSON.parse(process.argv[4]) : {};
-const bodyData = process.argv[5] || null;
-const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
-                 process.env.HTTP_PROXY || process.env.http_proxy;
-
-function fire(socket) {
-  const t = new URL(targetUrl);
-  const opts = {
-    hostname: t.hostname, port: t.port || 443,
-    path: t.pathname + t.search, method,
-    headers: { ...extraHeaders }, servername: t.hostname,
-  };
-  if (socket) { opts.socket = socket; opts.agent = false; }
-  if (bodyData) {
-    opts.headers["Content-Type"] = "application/json";
-    opts.headers["Content-Length"] = Buffer.byteLength(bodyData);
-  }
-  const req = https.request(opts, (r) => {
-    let d = ""; r.on("data", c => d += c);
-    r.on("end", () => { process.stdout.write(d); process.exit(0); });
-  });
-  req.on("error", (e) => { process.stderr.write("REQ ERR: " + e.message + "\\n"); process.exit(1); });
-  if (bodyData) req.write(bodyData);
-  req.end();
-}
-
-if (!proxyUrl) { fire(null); }
-else {
-  const p = new URL(proxyUrl);
-  const t = new URL(targetUrl);
-  const port = parseInt(p.port) || (p.protocol === "https:" ? 443 : 3128);
-  const auth = (p.username || p.password)
-    ? "Proxy-Authorization: Basic " +
-      Buffer.from(decodeURIComponent(p.username||"") + ":" + decodeURIComponent(p.password||"")).toString("base64") + "\\r\\n"
-    : "";
-  const connectMsg = "CONNECT " + t.hostname + ":443 HTTP/1.1\\r\\n" +
-    "Host: " + t.hostname + ":443\\r\\n" + auth + "\\r\\n";
-
-  function onSocket(sock) {
-    let buf = "";
-    sock.on("data", function h(chunk) {
-      buf += chunk.toString();
-      if (buf.indexOf("\\r\\n\\r\\n") < 0) return;
-      sock.removeListener("data", h);
-      const code = parseInt(buf.split(" ")[1]);
-      if (code !== 200) {
-        process.stderr.write("CONNECT " + code + "\\n");
-        process.exit(1);
-      }
-      fire(sock);
-    });
-    sock.write(connectMsg);
-  }
-
-  const timeout = setTimeout(() => { process.stderr.write("PROXY TIMEOUT\\n"); process.exit(1); }, 15000);
-  if (p.protocol === "https:") {
-    const s = tls.connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onSocket(s); });
-    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TLS: " + e.message + "\\n"); process.exit(1); });
-  } else {
-    const s = require("net").connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onSocket(s); });
-    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TCP: " + e.message + "\\n"); process.exit(1); });
-  }
-}
-`.trim()
-
-function parseJsonOutput(logs: string | undefined): any {
-  if (!logs) throw new Error("No output from command")
-  const trimmed = logs.trim()
-  const jsonStart = trimmed.indexOf('{')
-  if (jsonStart === -1) throw new Error(`No JSON found in output: ${trimmed.slice(0, 200)}`)
-  let depth = 0
-  let jsonEnd = -1
-  for (let i = jsonStart; i < trimmed.length; i++) {
-    if (trimmed[i] === '{') depth++
-    else if (trimmed[i] === '}') { depth--; if (depth === 0) { jsonEnd = i + 1; break } }
-  }
-  if (jsonEnd === -1) throw new Error(`Unterminated JSON in output: ${trimmed.slice(0, 300)}`)
-  return JSON.parse(trimmed.slice(jsonStart, jsonEnd))
-}
-
-function lowercaseKeys(obj: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(obj).map(([k, v]) => [k.toLowerCase(), v])
-  )
-}
+import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyHelperScript } from './proxy/helpers.js'
 
 describe('Sandbox Update Operations', () => {
   const createdSandboxes: string[] = []
+
+  // A controlled httpbin-compatible upstream (reached via a preview URL) shared by
+  // the live-network-call suites below, replacing the flaky public httpbin.org. We
+  // use its hostname as the allow/forbid/route target.
+  let echoHost: string
+  let echoUrl: string
+
+  beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoHost = echo.host
+    echoUrl = echo.url
+  }, 180_000)
 
   afterAll(async () => {
     if (process.env.SKIP_CLEANUP === '1') {
@@ -386,7 +308,7 @@ describe('Sandbox Update Operations', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
-    it('creates sandbox with httpbin.org forbidden', async () => {
+    it('creates sandbox with echo host forbidden', async () => {
       name = uniqueName("upd-fw-live")
       const created = await SandboxInstance.create({
         name,
@@ -394,7 +316,7 @@ describe('Sandbox Update Operations', () => {
         region: defaultRegion,
         labels: defaultLabels,
         network: {
-          forbiddenDomains: ["httpbin.org"],
+          forbiddenDomains: [echoHost],
           proxy: { routing: [] },
         },
       })
@@ -404,9 +326,9 @@ describe('Sandbox Update Operations', () => {
       await sandbox.fs.write("/tmp/proxy-test.js", proxyHelperScript)
     }, 60_000)
 
-    it('httpbin.org is blocked before update', async () => {
+    it('echo host is blocked before update', async () => {
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/get`,
         waitForCompletion: true,
       })
       expect(result.exitCode).not.toBe(0)
@@ -418,19 +340,19 @@ describe('Sandbox Update Operations', () => {
       sandbox = await SandboxInstance.get(name)
     })
 
-    it('httpbin.org is reachable after update', async () => {
+    it('echo host is reachable after update', async () => {
       // Firewall rule propagation may lag behind DEPLOYED status — retry until reachable
       let result: Awaited<ReturnType<typeof sandbox.process.exec>> | undefined
       for (let i = 0; i < 15; i++) {
         result = await sandbox.process.exec({
-          command: 'node /tmp/proxy-test.js GET https://httpbin.org/get',
+          command: `node /tmp/proxy-test.js GET ${echoUrl}/get`,
           waitForCompletion: true,
         })
         if (result.exitCode === 0) break
         await sleep(2000)
       }
       expect(result!.exitCode).toBe(0)
-      expect(result!.logs).toContain("httpbin.org")
+      expect(result!.logs).toContain(echoHost)
     }, 60_000)
   })
 
@@ -438,7 +360,7 @@ describe('Sandbox Update Operations', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
-    it('creates sandbox with only httpbin.org allowed', async () => {
+    it('creates sandbox with only echo host allowed', async () => {
       name = uniqueName("upd-allow-live")
       const created = await SandboxInstance.create({
         name,
@@ -446,7 +368,7 @@ describe('Sandbox Update Operations', () => {
         region: defaultRegion,
         labels: defaultLabels,
         network: {
-          allowedDomains: ["httpbin.org"],
+          allowedDomains: [echoHost],
           proxy: { routing: [] },
         },
       })
@@ -456,9 +378,9 @@ describe('Sandbox Update Operations', () => {
       await sandbox.fs.write("/tmp/proxy-test.js", proxyHelperScript)
     }, 60_000)
 
-    it('httpbin.org is reachable', async () => {
+    it('echo host is reachable', async () => {
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/get`,
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)
@@ -474,10 +396,10 @@ describe('Sandbox Update Operations', () => {
 
     it('expands allowedDomains to include example.com', async () => {
       const updated = await updateNetwork(name, {
-        allowedDomains: ["httpbin.org", "example.com"],
+        allowedDomains: [echoHost, "example.com"],
         proxy: { routing: [] },
       })
-      expect(updated.spec?.network?.allowedDomains).toEqual(["httpbin.org", "example.com"])
+      expect(updated.spec?.network?.allowedDomains).toEqual([echoHost, "example.com"])
       sandbox = await SandboxInstance.get(name)
     })
 
@@ -490,9 +412,9 @@ describe('Sandbox Update Operations', () => {
       expect(result.logs!.length).toBeGreaterThan(0)
     }, 60_000)
 
-    it('httpbin.org is still reachable', async () => {
+    it('echo host is still reachable', async () => {
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/get',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/get`,
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)
@@ -514,7 +436,7 @@ describe('Sandbox Update Operations', () => {
           proxy: {
             routing: [
               {
-                destinations: ["httpbin.org"],
+                destinations: [echoHost],
                 headers: { "X-Update-Test": "initial-value" },
               },
             ],
@@ -529,7 +451,7 @@ describe('Sandbox Update Operations', () => {
 
     it('initial routing rule injects headers', async () => {
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/headers`,
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)
@@ -537,7 +459,6 @@ describe('Sandbox Update Operations', () => {
       const response = parseJsonOutput(result.logs)
       const headers = lowercaseKeys(response.headers)
       expect(headers["x-update-test"]).toBe("initial-value")
-      expect(headers["x-blaxel-request-id"]).toBeDefined()
     }, 60_000)
 
     it('updates routing rule with new header and secret', async () => {
@@ -545,7 +466,7 @@ describe('Sandbox Update Operations', () => {
         proxy: {
           routing: [
             {
-              destinations: ["httpbin.org"],
+              destinations: [echoHost],
               headers: {
                 "X-Update-Test": "changed-via-update",
                 "X-Api-Key": "{{SECRET:test-key}}",
@@ -563,7 +484,7 @@ describe('Sandbox Update Operations', () => {
 
     it('updated headers and resolved secret appear', async () => {
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/headers`,
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)
@@ -579,7 +500,7 @@ describe('Sandbox Update Operations', () => {
         proxy: {
           routing: [
             {
-              destinations: ["httpbin.org"],
+              destinations: [echoHost],
               headers: {
                 "X-Update-Test": "third-value",
               },
@@ -590,7 +511,7 @@ describe('Sandbox Update Operations', () => {
       sandbox = await SandboxInstance.get(name)
 
       const result = await sandbox.process.exec({
-        command: 'node /tmp/proxy-test.js GET https://httpbin.org/headers',
+        command: `node /tmp/proxy-test.js GET ${echoUrl}/headers`,
         waitForCompletion: true,
       })
       expect(result.exitCode).toBe(0)


### PR DESCRIPTION
Fixes ENG-3481

- Updated integration tests to utilize a controlled echo server instead of the unreliable public httpbin.org. This change enhances test reliability by providing consistent responses.
- Adjusted test cases across various files to reference the new echo server for allowed and forbidden domain checks, ensuring all proxy-related tests are aligned with the new setup.
- Introduced helper functions to create and manage the echo server within the test environment, streamlining the setup process for future tests.

This refactor aims to improve the stability and predictability of the proxy tests.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the unreliable public httpbin.org dependency in proxy integration tests with a controlled echo server running inside a sandbox, exposed via a preview URL. Introduces `createEchoServerSandbox` helper and updates all proxy test files to use it. Also removes now-duplicated helper code from `update.test.ts` in favor of importing from the shared `proxy/helpers.ts`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b8be0983f255734f5d2e02f0c2438230e3a75905.</sup>
<!-- /MENDRAL_SUMMARY -->