### PR TITLE
feat(sandbox): paginate schedules and schedule executions

### DIFF
--- a/@blaxel/core/README.md
+++ b/@blaxel/core/README.md
@@ -70,7 +70,7 @@ await existing.delete();
 
 #### Listing resources
 
-List methods return one page at a time. The result contains `data`, `meta`, and helpers for fetching more pages when you want them.
+List methods return one page at a time. The result contains `data`, `meta`, and helpers for fetching more pages when you want them. The same shape is returned by `VolumeInstance.list()`, `DriveInstance.list()`, and the sandbox-scoped `sandbox.schedules.list()` / `sandbox.schedules.executions()`.
 
 ```typescript
 import { SandboxInstance } from "@blaxel/core";

--- a/@blaxel/core/src/sandbox/schedule.ts
+++ b/@blaxel/core/src/sandbox/schedule.ts
@@ -1,5 +1,6 @@
 import { createSandboxSchedule, deleteSandboxSchedule, getSandboxSchedule, listSandboxScheduleExecutions, listSandboxSchedules, updateSandboxSchedule } from "../client/index.js";
 import type { ListSandboxScheduleExecutionsData, ListSandboxSchedulesData, Sandbox, SandboxScheduleEntry, SandboxScheduleExecution } from "../client/index.js";
+import { createPaginatedList, type ListResponse } from "../common/pagination.js";
 
 // Derive option types from the generated query shapes so they stay in sync with
 // the API (new sort values, filters, etc.) without re-typing the literals here.
@@ -8,15 +9,6 @@ export type SandboxScheduleListOptions = NonNullable<ListSandboxSchedulesData["q
 
 /** Optional filters for listing schedule executions (`q`, `limit`, `cursor`, `sort`). */
 export type SandboxScheduleExecutionListOptions = NonNullable<ListSandboxScheduleExecutionsData["query"]>;
-
-// Schedule list endpoints return a bare array on older API versions and a
-// cursor-paginated `{ data, meta }` envelope starting on Blaxel-Version
-// 2026-04-28. Handle both so the wrapper works regardless of the SDK's default
-// version.
-function unwrapPage<T>(data: T[] | { data?: T[] } | undefined): T[] {
-  if (Array.isArray(data)) return data;
-  return data?.data ?? [];
-}
 
 // SandboxSchedules manages a sandbox's schedules. A schedule entry is a flat
 // record (id/type/value/input) with no sub-resource of its own, so methods
@@ -29,15 +21,38 @@ export class SandboxSchedules {
     return this.sandbox.metadata.name;
   }
 
-  async list(options: SandboxScheduleListOptions = {}): Promise<SandboxScheduleEntry[]> {
-    const { data } = await listSandboxSchedules({
-      path: {
-        sandboxName: this.sandboxName,
-      },
+  /**
+   * List one page of the sandbox's schedules.
+   *
+   * The returned page exposes `data` for the current page, `meta` for cursor
+   * metadata, and `nextPage()` / `autoPagingEach()` / `autoPagingToArray()`
+   * helpers. Iterate it directly with `for await` to walk every page.
+   *
+   * @example
+   * ```ts
+   * const page = await sandbox.schedules.list({ limit: 50 });
+   * for await (const schedule of page) {
+   *   console.log(schedule.id);
+   * }
+   * ```
+   */
+  async list(options: SandboxScheduleListOptions = {}) {
+    const fetchPage = async (query?: SandboxScheduleListOptions) => {
+      const { data } = await listSandboxSchedules({
+        path: {
+          sandboxName: this.sandboxName,
+        },
+        query,
+        throwOnError: true,
+      });
+      return data as unknown as ListResponse<SandboxScheduleEntry>;
+    };
+    return createPaginatedList({
+      response: await fetchPage(options),
+      fetchPage,
+      mapItem: (entry: SandboxScheduleEntry) => entry,
       query: options,
-      throwOnError: true,
     });
-    return unwrapPage<SandboxScheduleEntry>(data as unknown as SandboxScheduleEntry[] | { data?: SandboxScheduleEntry[] });
   }
 
   async create(schedule: SandboxScheduleEntry): Promise<SandboxScheduleEntry> {
@@ -88,14 +103,29 @@ export class SandboxSchedules {
   // List the execution history of every schedule on the sandbox, newest first.
   // Executions are sandbox-scoped, not per-schedule; filter by `scheduleId` on
   // the returned records to isolate a single schedule's runs.
-  async executions(options: SandboxScheduleExecutionListOptions = {}): Promise<SandboxScheduleExecution[]> {
-    const { data } = await listSandboxScheduleExecutions({
-      path: {
-        sandboxName: this.sandboxName,
-      },
+  /**
+   * List one page of schedule executions, newest first.
+   *
+   * The returned page exposes `data`, `meta`, and `nextPage()` /
+   * `autoPagingEach()` / `autoPagingToArray()` helpers. Iterate it directly
+   * with `for await` to walk every page.
+   */
+  async executions(options: SandboxScheduleExecutionListOptions = {}) {
+    const fetchPage = async (query?: SandboxScheduleExecutionListOptions) => {
+      const { data } = await listSandboxScheduleExecutions({
+        path: {
+          sandboxName: this.sandboxName,
+        },
+        query,
+        throwOnError: true,
+      });
+      return data as unknown as ListResponse<SandboxScheduleExecution>;
+    };
+    return createPaginatedList({
+      response: await fetchPage(options),
+      fetchPage,
+      mapItem: (execution: SandboxScheduleExecution) => execution,
       query: options,
-      throwOnError: true,
     });
-    return unwrapPage<SandboxScheduleExecution>(data as unknown as SandboxScheduleExecution[] | { data?: SandboxScheduleExecution[] });
   }
 }

--- a/tests/integration/sandbox/schedules.test.ts
+++ b/tests/integration/sandbox/schedules.test.ts
@@ -26,7 +26,7 @@ const FIRE_TIMEOUT_MS = 75_000
 async function waitUntilGone(sandbox: SandboxInstance, scheduleId: string): Promise<boolean> {
   const deadline = Date.now() + FIRE_TIMEOUT_MS
   while (Date.now() < deadline) {
-    const list = await sandbox.schedules.list().catch(() => [])
+    const list = await sandbox.schedules.list().then((p) => p.data).catch(() => [])
     if (!list.find((s) => s.id === scheduleId)) return true
     await sleep(3000)
   }
@@ -98,9 +98,18 @@ describe('Sandbox Schedule Operations', () => {
 
     it('lists the created schedules', async () => {
       const schedules = await sandbox.schedules.list()
-      expect(schedules.length).toBeGreaterThanOrEqual(createdIds.length)
+      expect(schedules.data.length).toBeGreaterThanOrEqual(createdIds.length)
       for (const id of createdIds) {
-        expect(schedules.find((s) => s.id === id)).toBeDefined()
+        expect(schedules.data.find((s) => s.id === id)).toBeDefined()
+      }
+    })
+
+    it('walks every schedule across pages with autoPagingToArray', async () => {
+      // limit:1 forces multiple pages so the cursor walk is actually exercised.
+      const page = await sandbox.schedules.list({ limit: 1 })
+      const all = await page.autoPagingToArray({ limit: 100000 })
+      for (const id of createdIds) {
+        expect(all.find((s) => s.id === id)).toBeDefined()
       }
     })
 
@@ -109,8 +118,8 @@ describe('Sandbox Schedule Operations', () => {
       // it from Blaxel-Version 2026-04-28 on, so just assert the call works and
       // still surfaces the cron we created (subset, not exact match).
       const crons = await sandbox.schedules.list({ type: "cron" })
-      expect(Array.isArray(crons)).toBe(true)
-      expect(crons.find((s) => s.id === createdIds[0])).toBeDefined()
+      expect(Array.isArray(crons.data)).toBe(true)
+      expect(crons.data.find((s) => s.id === createdIds[0])).toBeDefined()
     })
 
     it('gets a single schedule by id', async () => {
@@ -136,7 +145,7 @@ describe('Sandbox Schedule Operations', () => {
       const id = createdIds.pop()!
       await sandbox.schedules.delete(id)
       const schedules = await sandbox.schedules.list()
-      expect(schedules.find((s) => s.id === id)).toBeUndefined()
+      expect(schedules.data.find((s) => s.id === id)).toBeUndefined()
     })
   })
 
@@ -157,7 +166,7 @@ describe('Sandbox Schedule Operations', () => {
 
       // Visible in list() right after creation, gone once it has fired.
       const before = await sandbox.schedules.list()
-      expect(before.find((s) => s.id === at.id)).toBeDefined()
+      expect(before.data.find((s) => s.id === at.id)).toBeDefined()
 
       const fired = await waitUntilGone(sandbox, at.id!)
       expect(fired).toBe(true)
@@ -166,7 +175,7 @@ describe('Sandbox Schedule Operations', () => {
       // populated from Blaxel-Version 2026-04-28 on, so just assert the wrapper
       // call works and returns an array (no firing-count assertion).
       const executions = await sandbox.schedules.executions()
-      expect(Array.isArray(executions)).toBe(true)
+      expect(Array.isArray(executions.data)).toBe(true)
     }, FIRE_TIMEOUT_MS + 30_000)
   })
 })


### PR DESCRIPTION
Fixes ENG-3522

## What

`sandbox.schedules.list()` and `sandbox.schedules.executions()` now return a paginated page instead of a bare array.

## Why

These were the last sandbox list methods still returning a plain array. They now match the pagination contract already used by `VolumeInstance.list()` and `DriveInstance.list()` (the `createPaginatedList` helper from #306), so large schedule and execution histories can be walked page by page.

## Details

The returned page exposes the standard helpers:

- `.data`, `.meta`, `.hasMore`, `.nextCursor`
- `.nextPage()`
- `.autoPagingEach()` / `.autoPagingToArray()`
- `for await (const item of page)` to walk every page

## Breaking change

Callers that treated the result as an array (`result.find(...)`, `result.length`, `for (const x of result)`) must now use `result.data`, or iterate with `for await`. The integration tests are updated accordingly.

## Tests

`tsc`, build, eslint, and the pagination unit tests pass. Integration tests updated to the new page shape and a cursor-walk assertion added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Converts `sandbox.schedules.list()` and `sandbox.schedules.executions()` from returning bare arrays to returning `PaginatedList` pages using the existing `createPaginatedList` helper, adding cursor-based pagination support consistent with other list methods.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4384d99253bc1ac40ccd628ef86403b9e4775bdd.</sup>
<!-- /MENDRAL_SUMMARY -->