### PR TITLE
fix(tests): update sandbox instance tests to handle paginated responses

### DIFF
--- a/tests/integration/sandbox/external-id.test.ts
+++ b/tests/integration/sandbox/external-id.test.ts
@@ -105,16 +105,16 @@ describe('Sandbox externalId', () => {
       createdSandboxes.push(name)
 
       const instances = await SandboxInstance.list({ externalId })
-      expect(instances.length).toBeGreaterThanOrEqual(1)
+      expect(instances.data.length).toBeGreaterThanOrEqual(1)
 
-      const found = instances.find((s) => s.metadata.name === name)
+      const found = instances.data.find((s) => s.metadata.name === name)
       expect(found).toBeDefined()
       expect(found!.metadata.externalId).toBe(externalId)
     })
 
     it('returns empty list for non-existent externalId', async () => {
       const instances = await SandboxInstance.list({ externalId: `nonexistent-${Date.now()}` })
-      expect(instances.length).toBe(0)
+      expect(instances.data.length).toBe(0)
     })
 
     it('hides terminated sandboxes by default', async () => {
@@ -128,7 +128,7 @@ describe('Sandbox externalId', () => {
       await waitForSandboxDeletion(name)
 
       const instances = await SandboxInstance.list({ externalId })
-      const found = instances.find((s) => s.metadata.name === name)
+      const found = instances.data.find((s) => s.metadata.name === name)
       expect(found).toBeUndefined()
     })
   })

--- a/tests/integration/sandbox/helpers.ts
+++ b/tests/integration/sandbox/helpers.ts
@@ -1,5 +1,6 @@
-import { SandboxInstance, VolumeInstance } from "@blaxel/core"
+import { SandboxInstance, settings, VolumeInstance } from "@blaxel/core"
 import { v4 as uuidv4 } from 'uuid'
+import { expect } from 'vitest'
 
 /**
  * Environment-aware configuration
@@ -114,6 +115,75 @@ export async function waitForVolumeDeletion(volumeName: string, maxAttempts: num
  */
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+type SandboxTtlEnforcement = {
+  /** True on accounts where the control plane re-applies a floor TTL (tier_0/free, `sandbox_enforced_ttl=1`). */
+  enforced: boolean
+  /** The TTL string (e.g. "7d") the server re-applies whenever ttl/expires is unset, when enforced. */
+  defaultTtl: string
+}
+
+let cachedTtlEnforcement: SandboxTtlEnforcement | null = null
+
+/**
+ * Resolves whether the current workspace's account enforces a minimum sandbox TTL.
+ *
+ * On enforced accounts (tier_0/free by default), the control plane's
+ * `Sandbox.ApplyDefaultTTL` re-stamps a default TTL (e.g. "7d") any time
+ * `spec.runtime.ttl` comes back nil after unmarshalling -- which is indistinguishable
+ * from an explicit `updateTtl(name, null)` clear. So on these accounts, clearing the
+ * TTL does not result in no TTL; it results in the tier's default TTL. Tests that
+ * assert "TTL cleared" must account for this instead of asserting falsy unconditionally.
+ *
+ * There's no generated SDK client for the quotas endpoint yet, so this does a raw
+ * fetch: GET /workspaces/{name} for accountId, then GET /quotas/account/{accountId}.
+ * Result is cached for the process lifetime since it's account-wide, not per-sandbox.
+ */
+export async function getSandboxTtlEnforcement(): Promise<SandboxTtlEnforcement> {
+  if (cachedTtlEnforcement) return cachedTtlEnforcement
+
+  const fallback: SandboxTtlEnforcement = { enforced: false, defaultTtl: "" }
+
+  try {
+    const workspaceRes = await fetch(`${settings.baseUrl}/workspaces/${settings.workspace}`, {
+      headers: settings.headers,
+    })
+    if (!workspaceRes.ok) return (cachedTtlEnforcement = fallback)
+
+    const workspace = await workspaceRes.json() as { accountId?: string }
+    if (!workspace.accountId) return (cachedTtlEnforcement = fallback)
+
+    const quotasRes = await fetch(`${settings.baseUrl}/quotas/account/${workspace.accountId}`, {
+      headers: settings.headers,
+    })
+    if (!quotasRes.ok) return (cachedTtlEnforcement = fallback)
+
+    const quotas = await quotasRes.json() as Array<{ resourceType: string; value: number }>
+    const enforcedValue = quotas.find(q => q.resourceType === "sandbox_enforced_ttl")?.value ?? 0
+    const sandboxTtlDays = quotas.find(q => q.resourceType === "sandbox_ttl")?.value ?? 0
+
+    return (cachedTtlEnforcement = {
+      enforced: enforcedValue !== 0,
+      defaultTtl: sandboxTtlDays > 0 ? `${sandboxTtlDays}d` : "",
+    })
+  } catch {
+    return (cachedTtlEnforcement = fallback)
+  }
+}
+
+/**
+ * Asserts a sandbox's ttl matches what "cleared" means for the current account:
+ * falsy on unenforced accounts, or the account's floor TTL on enforced (free-tier) accounts.
+ */
+export async function expectTtlCleared(ttl: string | null | undefined): Promise<void> {
+  const { enforced, defaultTtl } = await getSandboxTtlEnforcement()
+  if (enforced) {
+    expect(defaultTtl).toBeTruthy()
+    expect(ttl).toBe(defaultTtl)
+  } else {
+    expect(ttl).toBeFalsy()
+  }
 }
 
 /**

--- a/tests/integration/sandbox/lifecycle.test.ts
+++ b/tests/integration/sandbox/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll } from 'vitest'
 import { SandboxInstance, updateSandbox, Sandbox } from "@blaxel/core"
-import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep, waitForSandboxDeployed, retry } from './helpers.js'
+import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep, waitForSandboxDeployed, retry, expectTtlCleared } from './helpers.js'
 
 describe('Sandbox Lifecycle and Expiration', () => {
   const createdSandboxes: string[] = []
@@ -337,8 +337,9 @@ describe('Sandbox Lifecycle and Expiration', () => {
       await waitForSandboxDeployed(name)
       const updatedSandbox = await SandboxInstance.get(name)
 
-      // TTL should be cleared on the server
-      expect(updatedSandbox.spec.runtime?.ttl).toBeFalsy()
+      // TTL should be cleared on the server (or reset to the account's enforced
+      // floor TTL on tier_0/free accounts -- see expectTtlCleared)
+      await expectTtlCleared(updatedSandbox.spec.runtime?.ttl)
 
       // File should still exist (no recreation)
       expect(await updatedSandbox.fs.read(testFilePath)).toBe(testContent)
@@ -367,7 +368,9 @@ describe('Sandbox Lifecycle and Expiration', () => {
       // Clear the TTL before it expires
       await SandboxInstance.updateTtl(name, null)
       await waitForSandboxDeployed(name)
-      expect((await SandboxInstance.get(name)).spec.runtime?.ttl).toBeFalsy()
+      // TTL should be cleared (or reset to the account's enforced floor TTL on
+      // tier_0/free accounts -- either way it must be far beyond the 20s window below)
+      await expectTtlCleared((await SandboxInstance.get(name)).spec.runtime?.ttl)
 
       // Wait well past the original 20s window
       await sleep(25000)
@@ -405,8 +408,9 @@ describe('Sandbox Lifecycle and Expiration', () => {
       await waitForSandboxDeployed(name)
       const updatedSandbox = await SandboxInstance.get(name)
 
-      // TTL should be cleared on the server
-      expect(updatedSandbox.spec.runtime?.ttl).toBeFalsy()
+      // TTL should be cleared on the server (or reset to the account's enforced
+      // floor TTL on tier_0/free accounts -- see expectTtlCleared)
+      await expectTtlCleared(updatedSandbox.spec.runtime?.ttl)
 
       // File should still exist (no recreation)
       expect(await updatedSandbox.fs.read(testFilePath)).toBe(testContent)


### PR DESCRIPTION
Fixes ENG-3693

This commit modifies the sandbox instance tests to correctly access the paginated response structure, ensuring that the tests check the length of the `data` array instead of the top-level response. Additionally, a new helper function `expectTtlCleared` is introduced to assert the expected behavior of sandbox TTLs based on account settings, enhancing the clarity and reliability of the lifecycle tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates sandbox integration tests to access `.data` on paginated list responses and introduces `expectTtlCleared` helper to handle TTL assertions on accounts that enforce a minimum sandbox TTL (free-tier).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cddc4ea8e20d537df259a427bb54a3fa74f7e28a.</sup>
<!-- /MENDRAL_SUMMARY -->