### PR TITLE
fix(sandbox): poll sandbox after create 504 gateway timeout instead of failing

### DIFF
--- a/@blaxel/core/src/common/transient-retry.ts
+++ b/@blaxel/core/src/common/transient-retry.ts
@@ -112,8 +112,9 @@ const DEFAULT_MAX_DELAY_MS = 2000;
 // single wait never blocks unreasonably long. Exponential (rather than linear)
 // gives a later attempt room to span a multi-second sandbox cold-start/standby
 // wake, which is the window a first-call reset falls into, while early attempts
-// stay fast for the common quick-reset case.
-function backoffDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+// stay fast for the common quick-reset case. Exported so other polling paths
+// (e.g. the create-504 wait in sandbox.ts) share the same delay curve.
+export function backoffDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
   const exponential = baseDelayMs * Math.pow(2, attempt - 1);
   const capped = Math.min(exponential, maxDelayMs);
   const jitter = Math.floor(Math.random() * baseDelayMs);

--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import type http2 from "http2";
 import { createSandbox, deleteSandbox, getSandbox, getSandboxByExternalId, listSandboxes, type ListSandboxesData, type SandboxLifecycle, type Sandbox as SandboxModel, updateSandbox } from "../client/index.js";
 import { logger } from "../common/logger.js";
+import { backoffDelayMs } from "../common/transient-retry.js";
 import { createPaginatedList } from "../common/pagination.js";
 import { settings } from "../common/settings.js";
 import { SandboxCodegen } from "./codegen/index.js";
@@ -36,6 +37,16 @@ const TRANSIENT_SANDBOX_STATUSES = new Set([
 ]);
 const TRANSIENT_STATUS_MAX_WAIT_MS = 30_000;
 const TRANSIENT_STATUS_POLL_MS = 500;
+
+// A create that outlives the edge's 60s origin-read timeout gets a 504 from
+// CloudFront while the control plane keeps deploying the sandbox for up to
+// 300s (ENG-3662 timeout ladder inversion). The 504 body is edge HTML with no
+// usable payload, so the record is polled instead until it settles.
+// Polling backs off exponentially (1s, 2s, 4s, then 5s + jitter) so a fleet of
+// clients stuck in this window does not hammer the control plane every second.
+const CREATE_GATEWAY_TIMEOUT_MAX_WAIT_MS = 120_000;
+const CREATE_GATEWAY_TIMEOUT_BASE_POLL_MS = 1_000;
+const CREATE_GATEWAY_TIMEOUT_MAX_POLL_MS = 5_000;
 
 const isSandboxNotFound = (e: unknown): boolean => {
   if (typeof e !== "object" || e === null) return false;
@@ -227,14 +238,24 @@ export class SandboxInstance {
       import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.warm(edgeDomain)).catch(() => { });
     }
 
-    const [{ data }, h2Session] = await Promise.all([
+    const [createResult, h2Session] = await Promise.all([
       createSandbox({
         body: sandbox,
         query: createIfNotExist ? { createIfNotExist } : undefined,
-        throwOnError: true,
       }),
       edgeDomain && !settings.disableH2 ? import("../common/h2pool.js").then(({ h2Pool }) => h2Pool.get(edgeDomain)).catch(() => null) : Promise.resolve(null),
     ]);
+    let data = createResult.data;
+    if (createResult.error !== undefined) {
+      const name = sandbox.metadata.name;
+      if (createResult.response.status === 504 && name) {
+        // The edge gave up on the connection but the creation is still running
+        // server-side; wait for the record instead of failing (ENG-3662).
+        data = await SandboxInstance.waitAfterCreateGatewayTimeout(name, createResult.error);
+      } else {
+        throw createResult.error;
+      }
+    }
     // Inject the H2 session into the config so subsystems can use it
     const config = { ...data, h2Session, h2Domain: settings.disableH2 ? null : edgeDomain } as SandboxConfiguration;
     const instance = new SandboxInstance(config);
@@ -432,6 +453,35 @@ export class SandboxInstance {
       }
     }
     throw new Error(`Unable to create sandbox after ${ATTEMPTS} attempts. Last conflicting status: ${lastStatus}.`);
+  }
+
+  // Poll the record after a create was cut by the edge with a 504 while the
+  // control plane is still deploying it. Resolves with the sandbox once it
+  // reaches DEPLOYED; throws on FAILED or once the wait budget is spent.
+  private static async waitAfterCreateGatewayTimeout(name: string, createError: unknown): Promise<SandboxModel> {
+    logger.debug(`Sandbox ${name} creation timed out at the edge (504); polling the record while it finishes deploying`);
+    const deadline = Date.now() + CREATE_GATEWAY_TIMEOUT_MAX_WAIT_MS;
+    let attempt = 0;
+    while (Date.now() < deadline) {
+      attempt++;
+      await new Promise((resolve) =>
+        setTimeout(resolve, backoffDelayMs(attempt, CREATE_GATEWAY_TIMEOUT_BASE_POLL_MS, CREATE_GATEWAY_TIMEOUT_MAX_POLL_MS)),
+      );
+      let current: SandboxModel;
+      try {
+        const { data } = await getSandbox({ path: { sandboxName: name }, throwOnError: true });
+        current = data;
+      } catch (e) {
+        // The record can lag behind the accepted create; keep waiting on 404.
+        if (isSandboxNotFound(e)) continue;
+        throw e;
+      }
+      if (current.status === "DEPLOYED") return current;
+      if (current.status === "FAILED") {
+        throw new Error(`Sandbox ${name} failed to deploy after the create timed out at the edge (504).`);
+      }
+    }
+    throw createError;
   }
 
   // Poll the record until an in-flight delete/deactivation settles (or the record

--- a/tests/unit/sandbox-create-504-poll.test.ts
+++ b/tests/unit/sandbox-create-504-poll.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the generated client so create/get can be scripted per test. sandbox.ts
+// imports the same module ("../client/index.js"), so vitest rewires both.
+vi.mock("../../@blaxel/core/src/client/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../@blaxel/core/src/client/index.js")>();
+  return { ...actual, createSandbox: vi.fn(), getSandbox: vi.fn() };
+});
+
+import { createSandbox, getSandbox } from "../../@blaxel/core/src/client/index.js";
+import { SandboxInstance } from "../../@blaxel/core/src/sandbox/sandbox.js";
+
+const mockedCreate = vi.mocked(createSandbox);
+const mockedGet = vi.mocked(getSandbox);
+
+// What hey-api returns (without throwOnError) when CloudFront cuts the origin
+// connection at 60s: an HTML body, no parsable JSON error payload.
+const EDGE_504_BODY = "<html><body>504 Gateway Time-out</body></html>";
+const edge504 = () =>
+  ({ error: EDGE_504_BODY, response: { status: 504 }, request: {} }) as never;
+
+const record = (status: string) =>
+  ({ data: { metadata: { name: "slow" }, spec: { runtime: {} }, status } }) as never;
+
+describe("SandboxInstance.create 504 gateway-timeout handling (ENG-3662)", () => {
+  beforeEach(() => {
+    // Keep edgeDomain null so create() skips the real H2 warm-up path.
+    vi.stubEnv("BL_REGION", "");
+    vi.useFakeTimers();
+    // Zero the backoff jitter so poll delays are exactly 1s, 2s, 4s, 5s, ...
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    mockedCreate.mockReset();
+    mockedGet.mockReset();
+  });
+
+  it("polls the record after a create 504 and resolves once the sandbox is DEPLOYED", async () => {
+    mockedCreate.mockResolvedValueOnce(edge504());
+    mockedGet
+      .mockResolvedValueOnce(record("DEPLOYING"))
+      .mockResolvedValueOnce(record("DEPLOYED"));
+
+    const pending = SandboxInstance.create({ name: "slow" });
+    // Backoff polls at +1s then +2s.
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const instance = await pending;
+    expect(instance.status).toBe("DEPLOYED");
+    expect(instance.metadata.name).toBe("slow");
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps polling through transient 404s on the record", async () => {
+    mockedCreate.mockResolvedValueOnce(edge504());
+    mockedGet
+      .mockRejectedValueOnce({ code: 404 })
+      .mockResolvedValueOnce(record("DEPLOYED"));
+
+    const pending = SandboxInstance.create({ name: "slow" });
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(pending).resolves.toBeInstanceOf(SandboxInstance);
+  });
+
+  it("throws the original edge error when the sandbox never lands within the wait budget", async () => {
+    mockedCreate.mockResolvedValueOnce(edge504());
+    mockedGet.mockResolvedValue(record("DEPLOYING"));
+
+    const pending = SandboxInstance.create({ name: "slow" });
+    const expectation = expect(pending).rejects.toBe(EDGE_504_BODY);
+    // Capped backoff needs the last 5s tick past the 120s deadline to land.
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    await expectation;
+  });
+
+  it("throws when the sandbox lands FAILED after the create 504", async () => {
+    mockedCreate.mockResolvedValueOnce(edge504());
+    mockedGet.mockResolvedValueOnce(record("FAILED"));
+
+    const pending = SandboxInstance.create({ name: "slow" });
+    const expectation = expect(pending).rejects.toThrow(/failed to deploy/);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expectation;
+  });
+
+  it("rethrows non-504 create errors untouched without polling", async () => {
+    const conflict = { code: 409, message: "already exists" };
+    mockedCreate.mockResolvedValueOnce(
+      ({ error: conflict, response: { status: 409 }, request: {} }) as never,
+    );
+
+    await expect(SandboxInstance.create({ name: "slow" })).rejects.toBe(conflict);
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes ENG-3777

## What

When a sandbox takes more than 60 seconds to create, CloudFront cuts the connection and the SDK threw an opaque 504 error, even though the sandbox was still deploying fine server-side (the control plane keeps going for up to 300s).

Now, on a create 504, the SDK polls the sandbox record until it is ready instead of failing.

## How

- `SandboxInstance.create()` detects the 504 via the HTTP status (the CloudFront error body is HTML, not parsable JSON).
- It then polls `GET /sandboxes/{name}` with exponential backoff (1s, 2s, 4s, then capped at 5s + jitter, reusing the existing `backoffDelayMs` helper) for up to 2 minutes.
- `DEPLOYED` → returns the sandbox. `FAILED` → explicit error. Budget exhausted → rethrows the original 504.
- Transient 404s on the record during polling are tolerated.
- Any non-504 error is rethrown unchanged, and `createIfNotExists` benefits automatically since it goes through `create()`.

## Testing

- 5 new unit tests (`tests/unit/sandbox-create-504-poll.test.ts`) covering the poll-to-DEPLOYED path, 404 tolerance, budget exhaustion, FAILED, and non-504 passthrough.
- `sandbox-crud.test.ts` integration suite: 22/22 green against the real API (validates the restructured create error handling on the happy and 409/404 paths).
- Not verified end to end: a real 504 (needs a creation genuinely slower than 60s, not deterministically reproducible).

Related: ENG-3662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds resilience to sandbox creation by detecting 504 Gateway Timeout responses from CloudFront and polling the sandbox record with exponential backoff until it reaches DEPLOYED or FAILED state, instead of immediately failing. Exports the existing `backoffDelayMs` helper for reuse and adds unit tests for the new polling behavior.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fb6141e1717716bf3c10a84cf81abc500572de8a.</sup>
<!-- /MENDRAL_SUMMARY -->