### PR TITLE
fix(sandbox): wait out the vanished window in createIfNotExists

### DIFF
--- a/@blaxel/core/src/sandbox/sandbox.ts
+++ b/@blaxel/core/src/sandbox/sandbox.ts
@@ -384,6 +384,12 @@ export class SandboxInstance {
   static async createIfNotExists(sandbox: SandboxModel | SandboxCreateConfiguration) {
     const ATTEMPTS = 3;
     let lastStatus = "unknown";
+    // The 'vanished' window (create 409s while get 404s) is driven by the same
+    // transient causes as 'dying': an in-flight delete finishing, or a
+    // concurrent create whose row is not readable yet. Give it the same time
+    // budget as waitWhileSandboxDying instead of burning the attempt budget
+    // 500ms apart (~1s total), which threw on deletes taking >1s (ENG-3667).
+    const vanishedDeadline = Date.now() + TRANSIENT_STATUS_MAX_WAIT_MS;
     for (let i = 0; i < ATTEMPTS; ++i) {
       const finalAttempt = i === ATTEMPTS - 1;
       try {
@@ -395,16 +401,26 @@ export class SandboxInstance {
             throw new Error("Sandbox name is required");
           }
 
+          // The controlplane tags the creation-lock 409 with
+          // reason=CREATION_IN_PROGRESS when the conflict comes from a
+          // concurrent create still in flight (ENG-3776). The field is absent
+          // on older controlplanes and on real row conflicts, so it only
+          // sharpens the give-up error; the polling behavior is the same.
+          const creationInProgress = (e as { reason?: unknown }).reason === "CREATION_IN_PROGRESS";
+
           // Get the existing sandbox to check its status
           let sandboxInstance: SandboxInstance;
           try {
             sandboxInstance = await this.get(name);
           } catch (getError) {
             if (isSandboxNotFound(getError)) {
-              // The record vanished between the create conflict and this status check
-              // (its deletion just finished); give the control plane a beat and retry.
-              lastStatus = "vanished";
-              if (!finalAttempt) {
+              // The record vanished between the create conflict and this status check.
+              lastStatus = creationInProgress ? "creation in progress" : "vanished";
+              if (Date.now() < vanishedDeadline) {
+                // Inside the transient window: poll without consuming attempts.
+                await new Promise((resolve) => setTimeout(resolve, TRANSIENT_STATUS_POLL_MS));
+                --i;
+              } else if (!finalAttempt) {
                 await new Promise((resolve) => setTimeout(resolve, TRANSIENT_STATUS_POLL_MS));
               }
               continue;

--- a/tests/integration/regressions/ENG-3667-concurrent-createIfNotExists.test.ts
+++ b/tests/integration/regressions/ENG-3667-concurrent-createIfNotExists.test.ts
@@ -1,0 +1,143 @@
+// ENG-3667: real-API reproducer for transient createIfNotExists failures.
+//
+// Production symptom (~237 failures/day): N concurrent createIfNotExists()
+// calls for the SAME name race; one wins the creation lock, the others get a
+// 409 on create then a 404 on the status get (row not persisted yet). The SDK
+// labels this "vanished" and gives up after 3 attempts / ~1s of waiting,
+// throwing "Unable to create sandbox after 3 attempts. Last conflicting
+// status: vanished." even though the sandbox appears moments later.
+//
+// These tests assert the CORRECT behaviour (every racer converges on the one
+// sandbox; data-plane calls right after create never surface a raw
+// WORKLOAD_UNAVAILABLE 404). While the bug exists they fail whenever the race
+// window is hit, which is the reproduction; after a fix they become the
+// regression tests.
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, describe, expect, it } from "vitest"
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from "../sandbox/helpers.js"
+
+// Defaults keep the test under the 1-minute budget; crank via env to stress.
+const ROUNDS = parseInt(process.env.ENG3667_ROUNDS || "5", 10)
+const CONCURRENCY = parseInt(process.env.ENG3667_CONCURRENCY || "10", 10)
+
+const errMessage = (reason: unknown) =>
+  reason instanceof Error ? reason.message : JSON.stringify(reason)
+
+describe("ENG-3667: transient createIfNotExists failures (real API)", () => {
+  const created: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(
+      created.map(async (name) => {
+        try {
+          await SandboxInstance.delete(name)
+        } catch {
+          // best-effort cleanup
+        }
+      })
+    )
+  })
+
+  it("concurrent createIfNotExists on one name all converge (no 'vanished')", async () => {
+    const failures: string[] = []
+
+    for (let round = 0; round < ROUNDS; round++) {
+      const name = uniqueName("eng3667")
+      created.push(name)
+
+      const results = await Promise.allSettled(
+        Array.from({ length: CONCURRENCY }, () =>
+          SandboxInstance.createIfNotExists({
+            name,
+            image: defaultImage,
+            memory: 2048,
+            labels: defaultLabels,
+            region: defaultRegion,
+          })
+        )
+      )
+
+      results.forEach((r, i) => {
+        if (r.status === "rejected") {
+          failures.push(`round ${round + 1} call#${i}: ${errMessage(r.reason)}`)
+        } else {
+          expect(r.value.metadata.name).toBe(name)
+        }
+      })
+    }
+
+    // Any rejection here (typically "... Last conflicting status: vanished.")
+    // is the production transient failure this test reproduces.
+    expect(failures, failures.join("\n")).toEqual([])
+  }, 120_000)
+
+  it("createIfNotExists racing an in-flight delete of the same name succeeds", async () => {
+    // The 'vanished' comment in sandbox.ts:404 names this exact window: create
+    // conflicts (409) with a record whose deletion then finishes before the
+    // status get (404). Deleting and immediately recreating the same name is
+    // the most direct way to sit in that window.
+    const failures: string[] = []
+
+    for (let round = 0; round < ROUNDS; round++) {
+      const name = uniqueName("eng3667-del")
+      created.push(name)
+      await SandboxInstance.create({
+        name,
+        image: defaultImage,
+        memory: 2048,
+        labels: defaultLabels,
+        region: defaultRegion,
+      })
+
+      // Fire the delete and the recreates together: some racers hit the 409
+      // (delete in flight) then the 404 (record gone) -- the vanished path.
+      const [, ...recreates] = await Promise.allSettled([
+        SandboxInstance.delete(name),
+        ...Array.from({ length: CONCURRENCY }, () =>
+          SandboxInstance.createIfNotExists({
+            name,
+            image: defaultImage,
+            memory: 2048,
+            labels: defaultLabels,
+            region: defaultRegion,
+          })
+        ),
+      ])
+
+      recreates.forEach((r, i) => {
+        if (r.status === "rejected") {
+          failures.push(`round ${round + 1} call#${i}: ${errMessage(r.reason)}`)
+        }
+      })
+    }
+
+    expect(failures, failures.join("\n")).toEqual([])
+  }, 180_000)
+
+  it("process calls immediately after create never surface WORKLOAD_UNAVAILABLE", async () => {
+    const name = uniqueName("eng3667-wu")
+    created.push(name)
+    const sandbox = await SandboxInstance.create({
+      name,
+      image: defaultImage,
+      memory: 2048,
+      labels: defaultLabels,
+      region: defaultRegion,
+    })
+
+    // Hammer the data plane right after create returns: the gateway can still
+    // answer 404 WORKLOAD_UNAVAILABLE (record exists, no healthy pod yet), and
+    // the SDK never retries it because isTransientResetError short-circuits on
+    // any HTTP status.
+    const results = await Promise.allSettled(
+      Array.from({ length: 20 }, (_, i) =>
+        sandbox.process.exec({ command: `echo ${i}` })
+      )
+    )
+
+    const failures = results
+      .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+      .map((r) => errMessage(r.reason))
+    expect(failures, failures.join("\n")).toEqual([])
+  }, 60_000)
+})

--- a/tests/integration/sandbox/ENG-3667-concurrent-createIfNotExists.test.ts
+++ b/tests/integration/sandbox/ENG-3667-concurrent-createIfNotExists.test.ts
@@ -16,8 +16,9 @@ import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from "vitest"
 import { defaultImage, defaultLabels, defaultRegion, uniqueName } from "./helpers.js"
 
-// Defaults keep the test under the 1-minute budget; crank via env to stress.
-const ROUNDS = parseInt(process.env.ENG3667_ROUNDS || "5", 10)
+// Defaults keep each test under the 1-minute budget (observed ~4s/round in
+// CI); crank via env to stress.
+const ROUNDS = parseInt(process.env.ENG3667_ROUNDS || "3", 10)
 const CONCURRENCY = parseInt(process.env.ENG3667_CONCURRENCY || "10", 10)
 
 const errMessage = (reason: unknown) =>
@@ -69,7 +70,7 @@ describe("ENG-3667: transient createIfNotExists failures (real API)", () => {
     // Any rejection here (typically "... Last conflicting status: vanished.")
     // is the production transient failure this test reproduces.
     expect(failures, failures.join("\n")).toEqual([])
-  }, 120_000)
+  }, 60_000)
 
   it("createIfNotExists racing an in-flight delete of the same name succeeds", async () => {
     // The 'vanished' comment in sandbox.ts:404 names this exact window: create
@@ -112,7 +113,7 @@ describe("ENG-3667: transient createIfNotExists failures (real API)", () => {
     }
 
     expect(failures, failures.join("\n")).toEqual([])
-  }, 180_000)
+  }, 60_000)
 
   it("process calls immediately after create never surface WORKLOAD_UNAVAILABLE", async () => {
     const name = uniqueName("eng3667-wu")

--- a/tests/integration/sandbox/ENG-3667-concurrent-createIfNotExists.test.ts
+++ b/tests/integration/sandbox/ENG-3667-concurrent-createIfNotExists.test.ts
@@ -14,7 +14,7 @@
 // regression tests.
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from "vitest"
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from "../sandbox/helpers.js"
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from "./helpers.js"
 
 // Defaults keep the test under the 1-minute budget; crank via env to stress.
 const ROUNDS = parseInt(process.env.ENG3667_ROUNDS || "5", 10)

--- a/tests/unit/sandbox-create-if-not-exists.test.ts
+++ b/tests/unit/sandbox-create-if-not-exists.test.ts
@@ -125,6 +125,97 @@ describe("SandboxInstance.createIfNotExists retry handling", () => {
     expect(create).toHaveBeenCalledTimes(2);
   });
 
+  it("waits out a persistent 'vanished' window instead of giving up after ~1s (ENG-3667)", async () => {
+    vi.useFakeTimers();
+    try {
+      // An in-flight delete rejects creates (409) for 5s while the record is
+      // already unreadable (get 404s). Pre-fix this threw 'vanished' after ~1s.
+      const replacement = sandbox("vanished-slow", "DEPLOYED");
+      const deleteFinishesAtMs = 5_000;
+      const start = Date.now();
+      const create = vi.spyOn(SandboxInstance, "create").mockImplementation(() => {
+        if (Date.now() - start < deleteFinishesAtMs) return Promise.reject(conflict());
+        return Promise.resolve(replacement);
+      });
+      vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+        Object.assign(new Error("Sandbox not found"), { code: 404 }),
+      );
+
+      const promise = SandboxInstance.createIfNotExists({ name: "vanished-slow" });
+      const assertion = expect(promise).resolves.toBe(replacement);
+      await vi.advanceTimersByTimeAsync(deleteFinishesAtMs + 1_000);
+      await assertion;
+      // It kept retrying through the window rather than stopping at 3 calls.
+      expect(create.mock.calls.length).toBeGreaterThan(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up on a 'vanished' record after the bounded window plus the attempt budget", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(SandboxInstance, "create").mockRejectedValue(conflict());
+      vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+        Object.assign(new Error("Sandbox not found"), { code: 404 }),
+      );
+
+      const promise = SandboxInstance.createIfNotExists({ name: "never-back" });
+      const assertion = expect(promise).rejects.toThrow(
+        "Unable to create sandbox after 3 attempts. Last conflicting status: vanished.",
+      );
+      // 30s transient window + the remaining attempts' 500ms waits
+      await vi.advanceTimersByTimeAsync(32_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("converges when the 409 carries reason=CREATION_IN_PROGRESS (ENG-3776)", async () => {
+    const winner = sandbox("locked", "DEPLOYED");
+    const create = vi.spyOn(SandboxInstance, "create");
+    create.mockRejectedValueOnce(
+      Object.assign(new Error("being created"), {
+        code: "SANDBOX_ALREADY_EXISTS",
+        status_code: 409,
+        reason: "CREATION_IN_PROGRESS",
+      }),
+    );
+    // Row persisted while the lock is still held: get returns the winner.
+    vi.spyOn(SandboxInstance, "get").mockResolvedValueOnce(winner);
+
+    await expect(
+      SandboxInstance.createIfNotExists({ name: "locked" }),
+    ).resolves.toBe(winner);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports 'creation in progress' instead of 'vanished' when the lock 409 never resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(SandboxInstance, "create").mockRejectedValue(
+        Object.assign(new Error("being created"), {
+          code: "SANDBOX_ALREADY_EXISTS",
+          status_code: 409,
+          reason: "CREATION_IN_PROGRESS",
+        }),
+      );
+      vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+        Object.assign(new Error("Sandbox not found"), { code: 404 }),
+      );
+
+      const promise = SandboxInstance.createIfNotExists({ name: "locked-forever" });
+      const assertion = expect(promise).rejects.toThrow(
+        "Unable to create sandbox after 3 attempts. Last conflicting status: creation in progress.",
+      );
+      await vi.advanceTimersByTimeAsync(32_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("propagates non-404 errors from the status check", async () => {
     vi.spyOn(SandboxInstance, "create").mockRejectedValueOnce(conflict());
     vi.spyOn(SandboxInstance, "get").mockRejectedValue(


### PR DESCRIPTION
Fixes ENG-3667

## Problem

Concurrent `createIfNotExists()` calls on the same name fail with `Unable to create sandbox after 3 attempts. Last conflicting status: vanished.` (~237 failures/day). The losers of the creation race get a 409 on create while get still 404s (row not persisted yet), and the SDK gave up after ~1s even though the sandbox appears moments later.

## Changes

- `createIfNotExists` now gives the "vanished" window (409 + 404) the same 30s time budget as the "dying" path, polling without burning attempts. Same root causes, same patience.
- Reads the optional `reason: CREATION_IN_PROGRESS` field the controlplane now sets on creation-lock 409s ([ENG-3776](https://linear.app/blaxel/issue/ENG-3776), deployed in dev). It only sharpens the give-up error message; behavior is identical when the field is absent (older controlplanes, real row conflicts).
- New real-API regression suite `tests/integration/regressions/ENG-3667-concurrent-createIfNotExists.test.ts`: concurrent creates on one name, creates racing an in-flight delete, and data-plane calls right after create.

## Verification

- 20/20 unit tests pass (`tests/unit/sandbox-create-if-not-exists.test.ts`, including 2 new ones for the reason field).
- 3/3 integration tests pass against dev in ~10s.
- Manually confirmed on dev: creation-lock 409s carry `reason: CREATION_IN_PROGRESS` (7/7), row-conflict 409s don't, and 10 concurrent `createIfNotExists` all converge.
- The 5 failures in `tests/unit/sandbox-list-h2-dedup.test.ts` are pre-existing on main (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Follow-up commits move the integration test to the correct directory and reduce default rounds (5→3) with explicit 60s per-test timeouts to stay within CI budget, addressing the Devin review feedback. Core logic unchanged from previously approved commit.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 60d7b3d70d160f88849a4e38d8b9944622f66d1c.</sup>
<!-- /MENDRAL_SUMMARY -->