### PR TITLE
refactor(tests): remove in-place proxy config tests from sandbox upda…

### DIFF
--- a/tests/integration/sandbox/update.test.ts
+++ b/tests/integration/sandbox/update.test.ts
@@ -95,67 +95,6 @@ describe('Sandbox Update Operations', () => {
     })
   })
 
-  describe('add and remove proxy config in-place', () => {
-    const MARKER_PATH = '/tmp/proxy-update-marker.txt'
-    const MARKER_CONTENT = 'proxy-identity-check'
-    let name: string
-
-    it('creates a sandbox without proxy', async () => {
-      name = uniqueName("upd-proxy")
-      const sandbox = await SandboxInstance.create({
-        name,
-        image: defaultImage,
-        region: defaultRegion,
-        labels: defaultLabels,
-      })
-      createdSandboxes.push(name)
-
-      expect(sandbox.spec.network?.proxy).toBeUndefined()
-    })
-
-    it('writes a marker file', async () => {
-      const sandbox = await SandboxInstance.get(name)
-      await sandbox.fs.write(MARKER_PATH, MARKER_CONTENT)
-    })
-
-    it('adds proxy routing via update', async () => {
-      const updated = await updateNetwork(name, {
-        proxy: {
-          routing: [
-            {
-              destinations: ["httpbin.org"],
-              headers: { "X-Added-Via-Update": "true" },
-            },
-          ],
-        },
-      })
-
-      expect(updated.metadata?.name).toBe(name)
-      expect(updated.spec?.network?.proxy?.routing).toHaveLength(1)
-      expect(updated.spec?.network?.proxy?.routing?.[0]?.destinations).toContain("httpbin.org")
-      expect(updated.spec?.network?.proxy?.routing?.[0]?.headers?.["X-Added-Via-Update"]).toBe("true")
-    })
-
-    it('marker file survives proxy addition', async () => {
-      const sandbox = await SandboxInstance.get(name)
-      const read = await sandbox.fs.read(MARKER_PATH)
-      expect(read).toBe(MARKER_CONTENT)
-    })
-
-    it('removes proxy routing via update', async () => {
-      const updated = await updateNetwork(name, {})
-
-      expect(updated.metadata?.name).toBe(name)
-      expect(updated.spec?.network?.proxy).toBeUndefined()
-    })
-
-    it('marker file survives proxy removal', async () => {
-      const sandbox = await SandboxInstance.get(name)
-      const read = await sandbox.fs.read(MARKER_PATH)
-      expect(read).toBe(MARKER_CONTENT)
-    })
-  })
-
   describe('swap network config (forbiddenDomains → allowedDomains)', () => {
     const MARKER_PATH = '/tmp/swap-update-marker.txt'
     const MARKER_CONTENT = 'swap-identity-check'


### PR DESCRIPTION
…te suite

This commit eliminates the in-place proxy configuration tests from the sandbox update integration tests. The removed tests included scenarios for adding and removing proxy routing, as well as verifying the persistence of a marker file during these operations. The focus is now on streamlining the test suite while maintaining essential coverage for network configuration updates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the "add and remove proxy config in-place" test block (~61 lines) from the sandbox update integration test suite, including tests for adding/removing proxy routing and marker file persistence during those operations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 58ccfa8e2160ecd00d1bb90920ddbdeee6dba809.</sup>
<!-- /MENDRAL_SUMMARY -->