### PR TITLE
Disable mk 3 tests

### DIFF
--- a/tests/integration/sandbox/drive-acl.test.ts
+++ b/tests/integration/sandbox/drive-acl.test.ts
@@ -6,7 +6,7 @@ import { defaultImage, defaultLabels, sleep, uniqueName, waitForSandboxDeletion,
 const defaultRegion = process.env.BL_DRIVE_REGION || (process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1')
 const MOUNT_SETTLE_MS = 3_000
 
-describe.runIf(isUsingMk3_1())('Drive ACL Permissions', () => {
+describe.skipIf(isUsingMk3_1())('Drive ACL Permissions', () => {
   const createdSandboxes: string[] = []
   const createdDrives: string[] = []
 
@@ -33,7 +33,7 @@ describe.runIf(isUsingMk3_1())('Drive ACL Permissions', () => {
     )
   })
 
-  describe.runIf(isUsingMk3_1())('Drive creation with permissions', () => {
+  describe.skipIf(isUsingMk3_1())('Drive creation with permissions', () => {
     it('creates a drive with permissions', async () => {
       const name = uniqueName("acl-create")
       const permissions: DrivePermission[] = [
@@ -121,7 +121,7 @@ describe.runIf(isUsingMk3_1())('Drive ACL Permissions', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Drive permission updates', () => {
+  describe.skipIf(isUsingMk3_1())('Drive permission updates', () => {
     it('updates permissions on an existing drive', async () => {
       const name = uniqueName("acl-upd")
 
@@ -168,7 +168,7 @@ describe.runIf(isUsingMk3_1())('Drive ACL Permissions', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Label-based access control', () => {
+  describe.skipIf(isUsingMk3_1())('Label-based access control', () => {
     it('allows matching sandbox to mount and write', async () => {
       const driveName = uniqueName("acl-allow")
       const sandboxName = uniqueName("acl-allow-sbx")

--- a/tests/integration/sandbox/drive-acl.test.ts
+++ b/tests/integration/sandbox/drive-acl.test.ts
@@ -1,12 +1,12 @@
 import { DriveInstance, SandboxInstance } from "@blaxel/core"
 import type { DrivePermission } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, sleep, uniqueName, waitForSandboxDeletion } from './helpers.js'
+import { defaultImage, defaultLabels, sleep, uniqueName, waitForSandboxDeletion, isUsingMk3_1 } from './helpers.js'
 
 const defaultRegion = process.env.BL_DRIVE_REGION || (process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1')
 const MOUNT_SETTLE_MS = 3_000
 
-describe('Drive ACL Permissions', () => {
+describe.runIf(isUsingMk3_1())('Drive ACL Permissions', () => {
   const createdSandboxes: string[] = []
   const createdDrives: string[] = []
 
@@ -33,7 +33,7 @@ describe('Drive ACL Permissions', () => {
     )
   })
 
-  describe('Drive creation with permissions', () => {
+  describe.runIf(isUsingMk3_1())('Drive creation with permissions', () => {
     it('creates a drive with permissions', async () => {
       const name = uniqueName("acl-create")
       const permissions: DrivePermission[] = [
@@ -121,7 +121,7 @@ describe('Drive ACL Permissions', () => {
     })
   })
 
-  describe('Drive permission updates', () => {
+  describe.runIf(isUsingMk3_1())('Drive permission updates', () => {
     it('updates permissions on an existing drive', async () => {
       const name = uniqueName("acl-upd")
 
@@ -168,7 +168,7 @@ describe('Drive ACL Permissions', () => {
     })
   })
 
-  describe('Label-based access control', () => {
+  describe.runIf(isUsingMk3_1())('Label-based access control', () => {
     it('allows matching sandbox to mount and write', async () => {
       const driveName = uniqueName("acl-allow")
       const sandboxName = uniqueName("acl-allow-sbx")

--- a/tests/integration/sandbox/drives.test.ts
+++ b/tests/integration/sandbox/drives.test.ts
@@ -4,7 +4,7 @@ import { defaultImage, defaultLabels, uniqueName, waitForSandboxDeletion, isUsin
 
 const defaultRegion = process.env.BL_DRIVE_REGION || (process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1') // Only region for drives right now
 
-describe.runIf(isUsingMk3_1())('Drive Operations', () => {
+describe.skipIf(isUsingMk3_1())('Drive Operations', () => {
   const createdSandboxes: string[] = []
   const createdDrives: string[] = []
 
@@ -33,7 +33,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     )
   })
 
-  describe.runIf(isUsingMk3_1())('DriveInstance CRUD', () => {
+  describe.skipIf(isUsingMk3_1())('DriveInstance CRUD', () => {
     it('creates a drive', async () => {
       const name = uniqueName("drive")
       const drive = await DriveInstance.create({
@@ -188,7 +188,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Sandbox Drive Mounting', () => {
+  describe.skipIf(isUsingMk3_1())('Sandbox Drive Mounting', () => {
     it('mounts a drive to a sandbox', async () => {
       const driveName = uniqueName("mount-drive")
       const sandboxName = uniqueName("mount-sandbox")
@@ -399,7 +399,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Drive persistence across sandboxes', () => {
+  describe.skipIf(isUsingMk3_1())('Drive persistence across sandboxes', () => {
     it('data persists when drive is mounted to different sandboxes', async () => {
       const driveName = uniqueName("persist-drive")
       const fileContent = "persistent data " + Date.now()
@@ -464,7 +464,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Multiple drives', () => {
+  describe.skipIf(isUsingMk3_1())('Multiple drives', () => {
     it('mounts multiple drives to a sandbox', async () => {
       const drive1Name = uniqueName("multi-drive1")
       const drive2Name = uniqueName("multi-drive2")
@@ -536,7 +536,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Drive mount path handling', () => {
+  describe.skipIf(isUsingMk3_1())('Drive mount path handling', () => {
     it('handles mount path without leading slash', async () => {
       const driveName = uniqueName("path-drive")
       const sandboxName = uniqueName("path-sandbox")
@@ -575,7 +575,7 @@ describe.runIf(isUsingMk3_1())('Drive Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('Drive file operations', () => {
+  describe.skipIf(isUsingMk3_1())('Drive file operations', () => {
     it('creates directory structure in drive', async () => {
       const driveName = uniqueName("fs-drive")
       const sandboxName = uniqueName("fs-sandbox")

--- a/tests/integration/sandbox/drives.test.ts
+++ b/tests/integration/sandbox/drives.test.ts
@@ -1,10 +1,10 @@
 import { DriveInstance, SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, uniqueName, waitForSandboxDeletion } from './helpers.js'
+import { defaultImage, defaultLabels, uniqueName, waitForSandboxDeletion, isUsingMk3_1 } from './helpers.js'
 
 const defaultRegion = process.env.BL_DRIVE_REGION || (process.env.BL_ENV !== 'dev' ? 'us-was-1' : 'eu-dub-1') // Only region for drives right now
 
-describe('Drive Operations', () => {
+describe.runIf(isUsingMk3_1())('Drive Operations', () => {
   const createdSandboxes: string[] = []
   const createdDrives: string[] = []
 
@@ -33,7 +33,7 @@ describe('Drive Operations', () => {
     )
   })
 
-  describe('DriveInstance CRUD', () => {
+  describe.runIf(isUsingMk3_1())('DriveInstance CRUD', () => {
     it('creates a drive', async () => {
       const name = uniqueName("drive")
       const drive = await DriveInstance.create({
@@ -188,7 +188,7 @@ describe('Drive Operations', () => {
     })
   })
 
-  describe('Sandbox Drive Mounting', () => {
+  describe.runIf(isUsingMk3_1())('Sandbox Drive Mounting', () => {
     it('mounts a drive to a sandbox', async () => {
       const driveName = uniqueName("mount-drive")
       const sandboxName = uniqueName("mount-sandbox")
@@ -399,7 +399,7 @@ describe('Drive Operations', () => {
     })
   })
 
-  describe('Drive persistence across sandboxes', () => {
+  describe.runIf(isUsingMk3_1())('Drive persistence across sandboxes', () => {
     it('data persists when drive is mounted to different sandboxes', async () => {
       const driveName = uniqueName("persist-drive")
       const fileContent = "persistent data " + Date.now()
@@ -464,7 +464,7 @@ describe('Drive Operations', () => {
     })
   })
 
-  describe('Multiple drives', () => {
+  describe.runIf(isUsingMk3_1())('Multiple drives', () => {
     it('mounts multiple drives to a sandbox', async () => {
       const drive1Name = uniqueName("multi-drive1")
       const drive2Name = uniqueName("multi-drive2")
@@ -536,7 +536,7 @@ describe('Drive Operations', () => {
     })
   })
 
-  describe('Drive mount path handling', () => {
+  describe.runIf(isUsingMk3_1())('Drive mount path handling', () => {
     it('handles mount path without leading slash', async () => {
       const driveName = uniqueName("path-drive")
       const sandboxName = uniqueName("path-sandbox")
@@ -575,7 +575,7 @@ describe('Drive Operations', () => {
     })
   })
 
-  describe('Drive file operations', () => {
+  describe.runIf(isUsingMk3_1())('Drive file operations', () => {
     it('creates directory structure in drive', async () => {
       const driveName = uniqueName("fs-drive")
       const sandboxName = uniqueName("fs-sandbox")

--- a/tests/integration/sandbox/helpers.ts
+++ b/tests/integration/sandbox/helpers.ts
@@ -36,6 +36,16 @@ export function isSlowTestEnabled(flag: string): boolean {
 }
 
 /**
+ * Whether the current test runtime should run mk-3.1-only feature tests.
+ *
+ * BL_RUNTIME=mk-3 means the older runtime is in use, where mk-3.1-only
+ * features such as drives, firewall, and volumes are not expected to work.
+ */
+export function isUsingMk3_1(): boolean {
+  return process.env.BL_RUNTIME?.trim().toLowerCase() !== "mk-3"
+}
+
+/**
  * Waits for a sandbox to be deployed by polling until status is DEPLOYED
  * @param sandboxName The name of the sandbox to wait for
  * @param maxAttempts Maximum number of attempts to wait (default: 30 seconds)

--- a/tests/integration/sandbox/large-envs.test.ts
+++ b/tests/integration/sandbox/large-envs.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance, VolumeInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, isUsingMk3_1, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion } from './helpers.js'
 
 describe('Sandbox Large Environment Variables', () => {
   const createdSandboxes: string[] = []
@@ -113,7 +113,7 @@ describe('Sandbox Large Environment Variables', () => {
     console.log(`All ${charTargets.length} targets passed: ${passedTargets.join(', ')}`)
   })
 
-  it('creates a sandbox with large environment variables (4000 chars) and a volume, then verifies persistence', async () => {
+  it.skipIf(isUsingMk3_1())('creates a sandbox with large environment variables (4000 chars) and a volume, then verifies persistence', async () => {
     const sandboxName1 = uniqueName("envs-volume-1")
     const sandboxName2 = uniqueName("envs-volume-2")
     const volumeName = uniqueName("volume-envs")

--- a/tests/integration/sandbox/process.test.ts
+++ b/tests/integration/sandbox/process.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import { SandboxInstance } from "@blaxel/core"
 import { uniqueName, defaultImage, defaultLabels, defaultRegion, sleep } from './helpers.js'
 
-const SKIP_KEEP_ALIVE = true
+const SKIP_KEEP_ALIVE = false
 
 describe('Sandbox Process Operations', () => {
   let sandbox: SandboxInstance
@@ -535,6 +535,26 @@ describe('Sandbox Process Operations', () => {
       expect(result.status).toBe("completed")
       // Process should complete normally without keepAlive
       expect(result.logs).toContain("no keepalive")
+    })
+
+    it('keeps running server-side without any sandbox calls in between', async () => {
+      await sandbox.process.exec({
+        name: "keepalive-no-poll",
+        command: "sleep 120 && echo 'keepalive done'",
+        keepAlive: true,
+        waitForCompletion: false
+      })
+
+      // Do NOT call the sandbox at all during this window: keepAlive must
+      // keep the process alive server-side without relying on client polling.
+      await sleep(125000)
+
+      const process = await sandbox.process.get("keepalive-no-poll")
+      expect(process.status).toBe("completed")
+      expect(process.exitCode).toBe(0)
+
+      const logs = await sandbox.process.logs("keepalive-no-poll", "stdout")
+      expect(logs).toContain("keepalive done")
     })
   })
 })

--- a/tests/integration/sandbox/proxy/claude.test.ts
+++ b/tests/integration/sandbox/proxy/claude.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, proxyCleanup } from './helpers.js'
 
-describe('proxy e2e with Claude Code agent', () => {
+describe.runIf(isUsingMk3_1())('proxy e2e with Claude Code agent', () => {
   if (!process.env.ANTHROPIC_API_KEY) {
     it.skip('requires ANTHROPIC_API_KEY', () => {})
     return

--- a/tests/integration/sandbox/proxy/claude.test.ts
+++ b/tests/integration/sandbox/proxy/claude.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, proxyCleanup } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('proxy e2e with Claude Code agent', () => {
+describe.skipIf(isUsingMk3_1())('proxy e2e with Claude Code agent', () => {
   if (!process.env.ANTHROPIC_API_KEY) {
     it.skip('requires ANTHROPIC_API_KEY', () => {})
     return

--- a/tests/integration/sandbox/proxy/cli-tools.test.ts
+++ b/tests/integration/sandbox/proxy/cli-tools.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
+describe.skipIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -41,7 +41,7 @@ describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
     if (certInstall.exitCode !== 0) throw new Error(`CA cert install failed: ${certInstall.logs?.slice(0, 500)}`)
   }, 180_000)
 
-  describe.runIf(isUsingMk3_1())('curl', () => {
+  describe.skipIf(isUsingMk3_1())('curl', () => {
     it('routes GET requests through the proxy with header injection', async () => {
       const result = await cliSandbox.process.exec({ command: `curl -s ${echoUrl}/headers`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -99,7 +99,7 @@ describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('git', () => {
+  describe.skipIf(isUsingMk3_1())('git', () => {
     it('clones a public repository through the proxy', async () => {
       const result = await cliSandbox.process.exec({ command: 'export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1', waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -121,7 +121,7 @@ describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
     }, 30_000)
   })
 
-  describe.runIf(isUsingMk3_1())('pip (Python package manager)', () => {
+  describe.skipIf(isUsingMk3_1())('pip (Python package manager)', () => {
     it('pip install works through the proxy', async () => {
       const result = await cliSandbox.process.exec({ command: 'pip3 install --break-system-packages --quiet six 2>&1 && python3 -c "import six; print(six.__version__)"', waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -129,7 +129,7 @@ describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
     }, 120_000)
   })
 
-  describe.runIf(isUsingMk3_1())('npm / npx (Node package manager)', () => {
+  describe.skipIf(isUsingMk3_1())('npm / npx (Node package manager)', () => {
     it('npm install works through the proxy', async () => {
       await cliSandbox.fs.write("/tmp/npm-test/package.json", JSON.stringify({ name: "proxy-npm-test", version: "1.0.0", dependencies: { "is-odd": "^3.0.1" } }))
       const result = await cliSandbox.process.exec({ command: 'cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1', waitForCompletion: true })

--- a/tests/integration/sandbox/proxy/cli-tools.test.ts
+++ b/tests/integration/sandbox/proxy/cli-tools.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
-describe('proxy e2e with common CLI tools', () => {
+describe.runIf(isUsingMk3_1())('proxy e2e with common CLI tools', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -41,7 +41,7 @@ describe('proxy e2e with common CLI tools', () => {
     if (certInstall.exitCode !== 0) throw new Error(`CA cert install failed: ${certInstall.logs?.slice(0, 500)}`)
   }, 180_000)
 
-  describe('curl', () => {
+  describe.runIf(isUsingMk3_1())('curl', () => {
     it('routes GET requests through the proxy with header injection', async () => {
       const result = await cliSandbox.process.exec({ command: `curl -s ${echoUrl}/headers`, waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -99,7 +99,7 @@ describe('proxy e2e with common CLI tools', () => {
     }, 60_000)
   })
 
-  describe('git', () => {
+  describe.runIf(isUsingMk3_1())('git', () => {
     it('clones a public repository through the proxy', async () => {
       const result = await cliSandbox.process.exec({ command: 'export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1', waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -121,7 +121,7 @@ describe('proxy e2e with common CLI tools', () => {
     }, 30_000)
   })
 
-  describe('pip (Python package manager)', () => {
+  describe.runIf(isUsingMk3_1())('pip (Python package manager)', () => {
     it('pip install works through the proxy', async () => {
       const result = await cliSandbox.process.exec({ command: 'pip3 install --break-system-packages --quiet six 2>&1 && python3 -c "import six; print(six.__version__)"', waitForCompletion: true })
       expect(result.exitCode).toBe(0)
@@ -129,7 +129,7 @@ describe('proxy e2e with common CLI tools', () => {
     }, 120_000)
   })
 
-  describe('npm / npx (Node package manager)', () => {
+  describe.runIf(isUsingMk3_1())('npm / npx (Node package manager)', () => {
     it('npm install works through the proxy', async () => {
       await cliSandbox.fs.write("/tmp/npm-test/package.json", JSON.stringify({ name: "proxy-npm-test", version: "1.0.0", dependencies: { "is-odd": "^3.0.1" } }))
       const result = await cliSandbox.process.exec({ command: 'cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1', waitForCompletion: true })

--- a/tests/integration/sandbox/proxy/comparison.test.ts
+++ b/tests/integration/sandbox/proxy/comparison.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('proxy vs no-proxy comparison', () => {
+describe.skipIf(isUsingMk3_1())('proxy vs no-proxy comparison', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/comparison.test.ts
+++ b/tests/integration/sandbox/proxy/comparison.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
-describe('proxy vs no-proxy comparison', () => {
+describe.runIf(isUsingMk3_1())('proxy vs no-proxy comparison', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/connect-tunnel.test.ts
+++ b/tests/integration/sandbox/proxy/connect-tunnel.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { execProxyCommandWithRetry, parseJsonOutput, proxyCleanup } from './helpers.js'
 
 type PythonProxyOutput = {
@@ -18,10 +18,10 @@ type PythonProxyOutput = {
  *    forces the Go GCS client to use HTTP/2 over the CONNECT tunnel. Only runs when
  *    `BL_TEST_GCS_BUCKET` + `GCSFUSE_SA_KEY_JSON` are provided.
  */
-describe('proxy CONNECT tunnel support', () => {
+describe.runIf(isUsingMk3_1())('proxy CONNECT tunnel support', () => {
   const unsetHttpProxyEnv = 'env -u HTTP_PROXY -u http_proxy'
 
-  describe('Python urllib3 through CONNECT', () => {
+  describe.runIf(isUsingMk3_1())('Python urllib3 through CONNECT', () => {
     const createdSandboxes: string[] = []
     afterAll(proxyCleanup(createdSandboxes))
 
@@ -90,7 +90,7 @@ except urllib3.exceptions.HTTPError as e:
     }, 90_000)
   })
 
-  describe('pip install through CONNECT', () => {
+  describe.runIf(isUsingMk3_1())('pip install through CONNECT', () => {
     const createdSandboxes: string[] = []
     afterAll(proxyCleanup(createdSandboxes))
 
@@ -144,7 +144,7 @@ except urllib3.exceptions.HTTPError as e:
     }, 240_000)
   })
 
-  describe('gcsfuse with native HTTP/2 (no --client-protocol=http1)', () => {
+  describe.runIf(isUsingMk3_1())('gcsfuse with native HTTP/2 (no --client-protocol=http1)', () => {
     const bucket = process.env.BL_TEST_GCS_BUCKET
     const saKeyJson = process.env.GCSFUSE_SA_KEY_JSON
 

--- a/tests/integration/sandbox/proxy/connect-tunnel.test.ts
+++ b/tests/integration/sandbox/proxy/connect-tunnel.test.ts
@@ -18,10 +18,10 @@ type PythonProxyOutput = {
  *    forces the Go GCS client to use HTTP/2 over the CONNECT tunnel. Only runs when
  *    `BL_TEST_GCS_BUCKET` + `GCSFUSE_SA_KEY_JSON` are provided.
  */
-describe.runIf(isUsingMk3_1())('proxy CONNECT tunnel support', () => {
+describe.skipIf(isUsingMk3_1())('proxy CONNECT tunnel support', () => {
   const unsetHttpProxyEnv = 'env -u HTTP_PROXY -u http_proxy'
 
-  describe.runIf(isUsingMk3_1())('Python urllib3 through CONNECT', () => {
+  describe.skipIf(isUsingMk3_1())('Python urllib3 through CONNECT', () => {
     const createdSandboxes: string[] = []
     afterAll(proxyCleanup(createdSandboxes))
 
@@ -90,7 +90,7 @@ except urllib3.exceptions.HTTPError as e:
     }, 90_000)
   })
 
-  describe.runIf(isUsingMk3_1())('pip install through CONNECT', () => {
+  describe.skipIf(isUsingMk3_1())('pip install through CONNECT', () => {
     const createdSandboxes: string[] = []
     afterAll(proxyCleanup(createdSandboxes))
 
@@ -144,7 +144,7 @@ except urllib3.exceptions.HTTPError as e:
     }, 240_000)
   })
 
-  describe.runIf(isUsingMk3_1())('gcsfuse with native HTTP/2 (no --client-protocol=http1)', () => {
+  describe.skipIf(isUsingMk3_1())('gcsfuse with native HTTP/2 (no --client-protocol=http1)', () => {
     const bucket = process.env.BL_TEST_GCS_BUCKET
     const saKeyJson = process.env.GCSFUSE_SA_KEY_JSON
 

--- a/tests/integration/sandbox/proxy/create.test.ts
+++ b/tests/integration/sandbox/proxy/create.test.ts
@@ -3,7 +3,7 @@ import { afterAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { proxyCleanup } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('create with proxy', () => {
+describe.skipIf(isUsingMk3_1())('create with proxy', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/create.test.ts
+++ b/tests/integration/sandbox/proxy/create.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { proxyCleanup } from './helpers.js'
 
-describe('create with proxy', () => {
+describe.runIf(isUsingMk3_1())('create with proxy', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/e2e.test.ts
+++ b/tests/integration/sandbox/proxy/e2e.test.ts
@@ -8,7 +8,7 @@ type HttpBinResponse = {
   json: Record<string, unknown>
 }
 
-describe.runIf(isUsingMk3_1())('proxy end-to-end functionality', () => {
+describe.skipIf(isUsingMk3_1())('proxy end-to-end functionality', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/e2e.test.ts
+++ b/tests/integration/sandbox/proxy/e2e.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
@@ -8,7 +8,7 @@ type HttpBinResponse = {
   json: Record<string, unknown>
 }
 
-describe('proxy end-to-end functionality', () => {
+describe.runIf(isUsingMk3_1())('proxy end-to-end functionality', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/firewall.test.ts
+++ b/tests/integration/sandbox/proxy/firewall.test.ts
@@ -1,13 +1,13 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
 }
 
-describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
+describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -25,7 +25,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
 
   let fwSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
-  describe('allowedDomains (allowlist)', () => {
+  describe.runIf(isUsingMk3_1())('allowedDomains (allowlist)', () => {
     beforeAll(async () => {
       fwSandbox = await createReadyProxySandbox(
         async () => {
@@ -53,7 +53,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 60_000)
   })
 
-  describe('no proxy bypass (firewall ruleset: proxy)', () => {
+  describe.runIf(isUsingMk3_1())('no proxy bypass (firewall ruleset: proxy)', () => {
     let bypassSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -99,7 +99,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 60_000)
   })
 
-  describe('forbiddenDomains (denylist)', () => {
+  describe.runIf(isUsingMk3_1())('forbiddenDomains (denylist)', () => {
     let denySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -129,7 +129,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 60_000)
   })
 
-  describe('allowedDomains + forbiddenDomains combined', () => {
+  describe.runIf(isUsingMk3_1())('allowedDomains + forbiddenDomains combined', () => {
     let comboSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -154,7 +154,7 @@ describe('firewall e2e (allowedDomains / forbiddenDomains)', () => {
     }, 60_000)
   })
 
-  describe('allowedDomains with proxy routing', () => {
+  describe.runIf(isUsingMk3_1())('allowedDomains with proxy routing', () => {
     let proxyFwSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {

--- a/tests/integration/sandbox/proxy/firewall.test.ts
+++ b/tests/integration/sandbox/proxy/firewall.test.ts
@@ -7,7 +7,7 @@ type HttpBinResponse = {
   headers: Record<string, string>
 }
 
-describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)', () => {
+describe.skipIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -25,7 +25,7 @@ describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)
 
   let fwSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
-  describe.runIf(isUsingMk3_1())('allowedDomains (allowlist)', () => {
+  describe.skipIf(isUsingMk3_1())('allowedDomains (allowlist)', () => {
     beforeAll(async () => {
       fwSandbox = await createReadyProxySandbox(
         async () => {
@@ -53,7 +53,7 @@ describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('no proxy bypass (firewall ruleset: proxy)', () => {
+  describe.skipIf(isUsingMk3_1())('no proxy bypass (firewall ruleset: proxy)', () => {
     let bypassSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -99,7 +99,7 @@ describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('forbiddenDomains (denylist)', () => {
+  describe.skipIf(isUsingMk3_1())('forbiddenDomains (denylist)', () => {
     let denySandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -129,7 +129,7 @@ describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('allowedDomains + forbiddenDomains combined', () => {
+  describe.skipIf(isUsingMk3_1())('allowedDomains + forbiddenDomains combined', () => {
     let comboSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {
@@ -154,7 +154,7 @@ describe.runIf(isUsingMk3_1())('firewall e2e (allowedDomains / forbiddenDomains)
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('allowedDomains with proxy routing', () => {
+  describe.skipIf(isUsingMk3_1())('allowedDomains with proxy routing', () => {
     let proxyFwSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
 
     beforeAll(async () => {

--- a/tests/integration/sandbox/proxy/get-delete.test.ts
+++ b/tests/integration/sandbox/proxy/get-delete.test.ts
@@ -3,7 +3,7 @@ import { afterAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion, isUsingMk3_1 } from '../helpers.js'
 import { proxyCleanup } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('get proxy config', () => {
+describe.skipIf(isUsingMk3_1())('get proxy config', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -47,7 +47,7 @@ describe.runIf(isUsingMk3_1())('get proxy config', () => {
   })
 })
 
-describe.runIf(isUsingMk3_1())('delete sandbox with proxy', () => {
+describe.skipIf(isUsingMk3_1())('delete sandbox with proxy', () => {
   it('deletes a sandbox that has proxy configuration', async () => {
     const name = uniqueName("proxy-del")
     await SandboxInstance.create({

--- a/tests/integration/sandbox/proxy/get-delete.test.ts
+++ b/tests/integration/sandbox/proxy/get-delete.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, waitForSandboxDeletion, isUsingMk3_1 } from '../helpers.js'
 import { proxyCleanup } from './helpers.js'
 
-describe('get proxy config', () => {
+describe.runIf(isUsingMk3_1())('get proxy config', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 
@@ -47,7 +47,7 @@ describe('get proxy config', () => {
   })
 })
 
-describe('delete sandbox with proxy', () => {
+describe.runIf(isUsingMk3_1())('delete sandbox with proxy', () => {
   it('deletes a sandbox that has proxy configuration', async () => {
     const name = uniqueName("proxy-del")
     await SandboxInstance.create({

--- a/tests/integration/sandbox/proxy/http2.test.ts
+++ b/tests/integration/sandbox/proxy/http2.test.ts
@@ -1,6 +1,6 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
@@ -129,7 +129,7 @@ if (!proxyUrl) {
 }
 `.trim()
 
-describe('proxy end-to-end functionality over HTTP/2', () => {
+describe.runIf(isUsingMk3_1())('proxy end-to-end functionality over HTTP/2', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/http2.test.ts
+++ b/tests/integration/sandbox/proxy/http2.test.ts
@@ -129,7 +129,7 @@ if (!proxyUrl) {
 }
 `.trim()
 
-describe.runIf(isUsingMk3_1())('proxy end-to-end functionality over HTTP/2', () => {
+describe.skipIf(isUsingMk3_1())('proxy end-to-end functionality over HTTP/2', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/python.test.ts
+++ b/tests/integration/sandbox/proxy/python.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('proxy e2e with Python requests (py-app image)', () => {
+describe.skipIf(isUsingMk3_1())('proxy e2e with Python requests (py-app image)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/python.test.ts
+++ b/tests/integration/sandbox/proxy/python.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup } from './helpers.js'
 
-describe('proxy e2e with Python requests (py-app image)', () => {
+describe.runIf(isUsingMk3_1())('proxy e2e with Python requests (py-app image)', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/secrets.test.ts
+++ b/tests/integration/sandbox/proxy/secrets.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
-describe('secrets replacement validation', () => {
+describe.runIf(isUsingMk3_1())('secrets replacement validation', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/secrets.test.ts
+++ b/tests/integration/sandbox/proxy/secrets.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyCleanup, proxyHelperScript } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('secrets replacement validation', () => {
+describe.skipIf(isUsingMk3_1())('secrets replacement validation', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/wildcard.test.ts
+++ b/tests/integration/sandbox/proxy/wildcard.test.ts
@@ -7,7 +7,7 @@ type HttpBinResponse = {
   headers: Record<string, string>
 }
 
-describe.runIf(isUsingMk3_1())('proxy with wildcard (*) destination', () => {
+describe.skipIf(isUsingMk3_1())('proxy with wildcard (*) destination', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/proxy/wildcard.test.ts
+++ b/tests/integration/sandbox/proxy/wildcard.test.ts
@@ -1,13 +1,13 @@
 import { SandboxInstance } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName, isUsingMk3_1 } from '../helpers.js'
 import { createEchoServerSandbox, createReadyProxySandbox, execProxyCommandWithRetry, lowercaseKeys, parseJsonObjectOutput, proxyCleanup } from './helpers.js'
 
 type HttpBinResponse = {
   headers: Record<string, string>
 }
 
-describe('proxy with wildcard (*) destination', () => {
+describe.runIf(isUsingMk3_1())('proxy with wildcard (*) destination', () => {
   const createdSandboxes: string[] = []
   afterAll(proxyCleanup(createdSandboxes))
 

--- a/tests/integration/sandbox/update.test.ts
+++ b/tests/integration/sandbox/update.test.ts
@@ -1,9 +1,9 @@
 import { SandboxInstance, Sandbox as SandboxModel } from "@blaxel/core"
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeployed } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeployed, isUsingMk3_1 } from './helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyHelperScript } from './proxy/helpers.js'
 
-describe('Sandbox Update Operations', () => {
+describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
   const createdSandboxes: string[] = []
 
   // A controlled httpbin-compatible upstream (reached via a preview URL) shared by
@@ -43,7 +43,7 @@ describe('Sandbox Update Operations', () => {
     return instance
   }
 
-  describe('update network config in-place', () => {
+  describe.runIf(isUsingMk3_1())('update network config in-place', () => {
     const MARKER_PATH = '/tmp/update-test-marker.txt'
     const MARKER_CONTENT = 'sandbox-identity-check'
     let name: string
@@ -95,7 +95,7 @@ describe('Sandbox Update Operations', () => {
     })
   })
 
-  describe('add and remove proxy config in-place', () => {
+  describe.runIf(isUsingMk3_1())('add and remove proxy config in-place', () => {
     const MARKER_PATH = '/tmp/proxy-update-marker.txt'
     const MARKER_CONTENT = 'proxy-identity-check'
     let name: string
@@ -156,7 +156,7 @@ describe('Sandbox Update Operations', () => {
     })
   })
 
-  describe('swap network config (forbiddenDomains → allowedDomains)', () => {
+  describe.runIf(isUsingMk3_1())('swap network config (forbiddenDomains → allowedDomains)', () => {
     const MARKER_PATH = '/tmp/swap-update-marker.txt'
     const MARKER_CONTENT = 'swap-identity-check'
     let name: string
@@ -195,7 +195,7 @@ describe('Sandbox Update Operations', () => {
     })
   })
 
-  describe('update network config with proxy + firewall combined', () => {
+  describe.runIf(isUsingMk3_1())('update network config with proxy + firewall combined', () => {
     let name: string
 
     it('creates a sandbox with allowedDomains only', async () => {
@@ -261,7 +261,7 @@ describe('Sandbox Update Operations', () => {
     })
   })
 
-  describe('multiple sequential updates preserve sandbox identity', () => {
+  describe.runIf(isUsingMk3_1())('multiple sequential updates preserve sandbox identity', () => {
     const MARKER_PATH = '/tmp/seq-update-marker.txt'
     let name: string
 
@@ -304,7 +304,7 @@ describe('Sandbox Update Operations', () => {
     }, 120_000)
   })
 
-  describe('forbiddenDomains update verified with live network calls', () => {
+  describe.runIf(isUsingMk3_1())('forbiddenDomains update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
@@ -356,7 +356,7 @@ describe('Sandbox Update Operations', () => {
     }, 60_000)
   })
 
-  describe('allowedDomains update verified with live network calls', () => {
+  describe.runIf(isUsingMk3_1())('allowedDomains update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
@@ -421,7 +421,7 @@ describe('Sandbox Update Operations', () => {
     }, 60_000)
   })
 
-  describe('proxy header injection update verified with live network calls', () => {
+  describe.runIf(isUsingMk3_1())('proxy header injection update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 

--- a/tests/integration/sandbox/update.test.ts
+++ b/tests/integration/sandbox/update.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeployed, isUsingMk3_1 } from './helpers.js'
 import { createEchoServerSandbox, lowercaseKeys, parseJsonOutput, proxyHelperScript } from './proxy/helpers.js'
 
-describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
+describe.skipIf(isUsingMk3_1())('Sandbox Update Operations', () => {
   const createdSandboxes: string[] = []
 
   // A controlled httpbin-compatible upstream (reached via a preview URL) shared by
@@ -43,7 +43,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     return instance
   }
 
-  describe.runIf(isUsingMk3_1())('update network config in-place', () => {
+  describe.skipIf(isUsingMk3_1())('update network config in-place', () => {
     const MARKER_PATH = '/tmp/update-test-marker.txt'
     const MARKER_CONTENT = 'sandbox-identity-check'
     let name: string
@@ -95,7 +95,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('add and remove proxy config in-place', () => {
+  describe.skipIf(isUsingMk3_1())('add and remove proxy config in-place', () => {
     const MARKER_PATH = '/tmp/proxy-update-marker.txt'
     const MARKER_CONTENT = 'proxy-identity-check'
     let name: string
@@ -156,7 +156,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('swap network config (forbiddenDomains → allowedDomains)', () => {
+  describe.skipIf(isUsingMk3_1())('swap network config (forbiddenDomains → allowedDomains)', () => {
     const MARKER_PATH = '/tmp/swap-update-marker.txt'
     const MARKER_CONTENT = 'swap-identity-check'
     let name: string
@@ -195,7 +195,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('update network config with proxy + firewall combined', () => {
+  describe.skipIf(isUsingMk3_1())('update network config with proxy + firewall combined', () => {
     let name: string
 
     it('creates a sandbox with allowedDomains only', async () => {
@@ -261,7 +261,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('multiple sequential updates preserve sandbox identity', () => {
+  describe.skipIf(isUsingMk3_1())('multiple sequential updates preserve sandbox identity', () => {
     const MARKER_PATH = '/tmp/seq-update-marker.txt'
     let name: string
 
@@ -304,7 +304,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     }, 120_000)
   })
 
-  describe.runIf(isUsingMk3_1())('forbiddenDomains update verified with live network calls', () => {
+  describe.skipIf(isUsingMk3_1())('forbiddenDomains update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
@@ -356,7 +356,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('allowedDomains update verified with live network calls', () => {
+  describe.skipIf(isUsingMk3_1())('allowedDomains update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 
@@ -421,7 +421,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Update Operations', () => {
     }, 60_000)
   })
 
-  describe.runIf(isUsingMk3_1())('proxy header injection update verified with live network calls', () => {
+  describe.skipIf(isUsingMk3_1())('proxy header injection update verified with live network calls', () => {
     let name: string
     let sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>
 

--- a/tests/integration/sandbox/volumes.test.ts
+++ b/tests/integration/sandbox/volumes.test.ts
@@ -1,8 +1,8 @@
 import { SandboxInstance, VolumeInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
-import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion } from './helpers.js'
+import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion, isUsingMk3_1 } from './helpers.js'
 
-describe('Sandbox Volume Operations', () => {
+describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
   const createdSandboxes: string[] = []
   const createdVolumes: string[] = []
 
@@ -31,7 +31,7 @@ describe('Sandbox Volume Operations', () => {
     )
   })
 
-  describe('VolumeInstance CRUD', () => {
+  describe.runIf(isUsingMk3_1())('VolumeInstance CRUD', () => {
     it('creates a volume', async () => {
       const name = uniqueName("volume")
       const volume = await VolumeInstance.create({
@@ -192,7 +192,7 @@ describe('Sandbox Volume Operations', () => {
     })
   })
 
-  describe('mounting volumes to sandboxes', () => {
+  describe.runIf(isUsingMk3_1())('mounting volumes to sandboxes', () => {
     it('mounts a volume to a sandbox', async () => {
       const volumeName = uniqueName("mount-vol")
       const sandboxName = uniqueName("mount-sandbox")
@@ -291,7 +291,7 @@ describe('Sandbox Volume Operations', () => {
     // })
   })
 
-  describe('volume resize', () => {
+  describe.runIf(isUsingMk3_1())('volume resize', () => {
     it('resizes volume and preserves data', { timeout: 600000 }, async () => {
       const volumeName = uniqueName("resize-vol")
       const sandbox1Name = uniqueName("resize-sandbox-1")
@@ -441,7 +441,7 @@ describe('Sandbox Volume Operations', () => {
     })
   })
 
-  describe('volume persistence', () => {
+  describe.runIf(isUsingMk3_1())('volume persistence', () => {
     it('data persists across sandbox recreations', async () => {
       const volumeName = uniqueName("persist-vol")
       const fileContent = "persistent data " + Date.now()

--- a/tests/integration/sandbox/volumes.test.ts
+++ b/tests/integration/sandbox/volumes.test.ts
@@ -2,7 +2,7 @@ import { SandboxInstance, VolumeInstance } from "@blaxel/core"
 import { afterAll, describe, expect, it } from 'vitest'
 import { defaultImage, defaultLabels, defaultRegion, sleep, uniqueName, waitForSandboxDeletion, waitForVolumeDeletion, isUsingMk3_1 } from './helpers.js'
 
-describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
+describe.skipIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
   const createdSandboxes: string[] = []
   const createdVolumes: string[] = []
 
@@ -31,7 +31,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
     )
   })
 
-  describe.runIf(isUsingMk3_1())('VolumeInstance CRUD', () => {
+  describe.skipIf(isUsingMk3_1())('VolumeInstance CRUD', () => {
     it('creates a volume', async () => {
       const name = uniqueName("volume")
       const volume = await VolumeInstance.create({
@@ -192,7 +192,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('mounting volumes to sandboxes', () => {
+  describe.skipIf(isUsingMk3_1())('mounting volumes to sandboxes', () => {
     it('mounts a volume to a sandbox', async () => {
       const volumeName = uniqueName("mount-vol")
       const sandboxName = uniqueName("mount-sandbox")
@@ -291,7 +291,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
     // })
   })
 
-  describe.runIf(isUsingMk3_1())('volume resize', () => {
+  describe.skipIf(isUsingMk3_1())('volume resize', () => {
     it('resizes volume and preserves data', { timeout: 600000 }, async () => {
       const volumeName = uniqueName("resize-vol")
       const sandbox1Name = uniqueName("resize-sandbox-1")
@@ -441,7 +441,7 @@ describe.runIf(isUsingMk3_1())('Sandbox Volume Operations', () => {
     })
   })
 
-  describe.runIf(isUsingMk3_1())('volume persistence', () => {
+  describe.skipIf(isUsingMk3_1())('volume persistence', () => {
     it('data persists across sandbox recreations', async () => {
       const volumeName = uniqueName("persist-vol")
       const fileContent = "persistent data " + Date.now()

--- a/tests/manual/delete.ts
+++ b/tests/manual/delete.ts
@@ -1,0 +1,110 @@
+/**
+ * Delete all sandboxes in the current workspace.
+ *
+ * Fetches every sandbox (paginated) and deletes them concurrently in
+ * bounded batches, so it stays efficient even with thousands of sandboxes
+ * without overwhelming the API.
+ *
+ * Requires BL_WORKSPACE + BL_API_KEY (or `bl login`).
+ *
+ * Run:
+ *   npx tsx tests/manual/delete.ts
+ *   npx tsx tests/manual/delete.ts --dry-run
+ *   npx tsx tests/manual/delete.ts --label env=staging
+ *   npx tsx tests/manual/delete.ts --concurrency 20
+ */
+
+import { SandboxInstance } from "@blaxel/core"
+
+const args = process.argv.slice(2)
+const DRY_RUN = args.includes("--dry-run")
+const CONCURRENCY = Number(readFlag("--concurrency") ?? "10")
+const LABEL_FILTER = parseLabelFilter(readFlag("--label"))
+
+function readFlag(name: string): string | undefined {
+  const index = args.indexOf(name)
+  if (index === -1) return undefined
+  return args[index + 1]
+}
+
+function parseLabelFilter(raw?: string): [string, string] | null {
+  if (!raw) return null
+  const [key, value] = raw.split("=")
+  if (!key || value === undefined) {
+    throw new Error(`Invalid --label value "${raw}", expected key=value`)
+  }
+  return [key, value]
+}
+
+function matchesLabelFilter(sandbox: SandboxInstance): boolean {
+  if (!LABEL_FILTER) return true
+  const [key, value] = LABEL_FILTER
+  return sandbox.metadata?.labels?.[key] === value
+}
+
+async function collectSandboxNames(): Promise<string[]> {
+  const names: string[] = []
+  let page = await SandboxInstance.list({ limit: 200 })
+  let pageIndex = 0
+  while (true) {
+    pageIndex++
+    console.log(`  page ${pageIndex}: got ${page.data.length} sandbox(es), hasMore=${page.hasMore}`)
+    for (const sandbox of page.data) {
+      if (matchesLabelFilter(sandbox)) {
+        names.push(sandbox.metadata!.name!)
+      }
+    }
+    const next = await page.nextPage()
+    if (pageIndex >= 10) break
+    if (!next) break
+    page = next
+  }
+  return names
+}
+
+async function deleteAll(names: string[]): Promise<void> {
+  let done = 0
+  let failed = 0
+
+  for (let i = 0; i < names.length; i += CONCURRENCY) {
+    const batch = names.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(
+      batch.map((name) => SandboxInstance.delete(name)),
+    )
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j]
+      const name = batch[j]
+      if (result.status === "fulfilled") {
+        done++
+        console.log(`[${done + failed}/${names.length}] Deleted ${name}`)
+      } else {
+        failed++
+        console.error(`[${done + failed}/${names.length}] Failed to delete ${name}: ${result.reason}`)
+      }
+    }
+  }
+
+  console.log(`\nDone. Deleted ${done}/${names.length} sandboxes${failed ? `, ${failed} failed` : ""}.`)
+}
+
+async function main() {
+  console.log("Fetching sandboxes...")
+  const names = await collectSandboxNames()
+
+  if (names.length === 0) {
+    console.log("No sandboxes found.")
+    return
+  }
+
+  console.log(`Found ${names.length} sandbox(es)${LABEL_FILTER ? ` matching label ${LABEL_FILTER[0]}=${LABEL_FILTER[1]}` : ""}.`)
+
+  if (DRY_RUN) {
+    for (const name of names) console.log(`  - ${name}`)
+    console.log("\nDry run, nothing deleted.")
+    return
+  }
+
+  await deleteAll(names)
+}
+
+await main()


### PR DESCRIPTION
Fixes ENG-3909

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Conditionally skips integration tests for mk-3.1-only features (drives, volumes, proxy, firewall, update) when running on the older mk-3 runtime. Also enables keep-alive tests, adds a new server-side keep-alive test, and introduces a manual sandbox deletion script.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e7d074d97712bdaf02e87850615a73471906d008.</sup>
<!-- /MENDRAL_SUMMARY -->