### PR TITLE
test: exclude flaky proxy tests by default and extend SKIP_CLEANUP

### DIFF
--- a/tests/integration/sandbox/globalTeardown.ts
+++ b/tests/integration/sandbox/globalTeardown.ts
@@ -7,6 +7,10 @@ import { SandboxInstance, VolumeInstance } from "@blaxel/core"
 export default function globalSetup() {
   // Return the teardown function
   return async () => {
+    if (process.env.SKIP_CLEANUP === "1") {
+      console.log("\nSKIP_CLEANUP=1: skipping global cleanup, test resources are left alive for debugging")
+      return
+    }
     console.log("\n🧹 Cleaning up test resources...")
 
     // Clean up sandboxes with test labels

--- a/tests/integration/sandbox/interpreter.test.ts
+++ b/tests/integration/sandbox/interpreter.test.ts
@@ -15,6 +15,10 @@ describe('CodeInterpreter Operations', () => {
   }, 180000) // 3 minute timeout for interpreter creation
 
   afterAll(async () => {
+    if (process.env.SKIP_CLEANUP === '1') {
+      console.log('SKIP_CLEANUP=1: skipping teardown. Interpreter left alive:', interpreter?.metadata.name)
+      return
+    }
     if (interpreter?.metadata.name) {
       try {
         await CodeInterpreter.delete(interpreter.metadata.name)
@@ -150,6 +154,10 @@ describe('CodeInterpreter Operations', () => {
     const cineNames: string[] = []
 
     afterAll(async () => {
+      if (process.env.SKIP_CLEANUP === '1') {
+        console.log('SKIP_CLEANUP=1: skipping teardown. Interpreters left alive:', cineNames)
+        return
+      }
       await Promise.all(
         cineNames.map(async (name) => {
           try {

--- a/tests/integration/sandbox/lifecycle.test.ts
+++ b/tests/integration/sandbox/lifecycle.test.ts
@@ -6,6 +6,10 @@ describe('Sandbox Lifecycle and Expiration', () => {
   const createdSandboxes: string[] = []
 
   afterAll(async () => {
+    if (process.env.SKIP_CLEANUP === '1') {
+      console.log('SKIP_CLEANUP=1: skipping teardown. Sandboxes left alive:', createdSandboxes)
+      return
+    }
     // Clean up all sandboxes in parallel
     await Promise.all(
       createdSandboxes.map(async (name) => {

--- a/tests/integration/sandbox/volumes.test.ts
+++ b/tests/integration/sandbox/volumes.test.ts
@@ -7,6 +7,10 @@ describe('Sandbox Volume Operations', () => {
   const createdVolumes: string[] = []
 
   afterAll(async () => {
+    if (process.env.SKIP_CLEANUP === '1') {
+      console.log('SKIP_CLEANUP=1: skipping teardown. Sandboxes left alive:', createdSandboxes, 'volumes:', createdVolumes)
+      return
+    }
     // Clean up sandboxes in parallel and wait for full deletion
     await Promise.all(
       createdSandboxes.map(async (name) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       'tests/runtime-environments/**',
       '**/node_modules/**',
       'tests/**/node_modules/**',
+      // Egress proxy tests have been flaky for a while (proxy readiness, TLS,
+      // preview 401 on non-routed egress); opt back in with RUN_PROXY_TESTS=true.
+      ...(process.env.RUN_PROXY_TESTS === 'true' ? [] : ['tests/integration/sandbox/proxy/**']),
     ],
     testTimeout: 300000, // 5 minutes - API operations can be slow
     hookTimeout: 120000, // 2 minutes for setup/teardown


### PR DESCRIPTION
Fixes ENG-3939

## What

- Proxy integration tests (`tests/integration/sandbox/proxy/**`) are now **excluded from the default vitest run**. They have been flaky for weeks (egress proxy readiness, TLS handshake, preview 401 on non-routed egress) and keep turning CI red. Run them explicitly with `RUN_PROXY_TESTS=true`.
- The `SKIP_CLEANUP=1` escape hatch (already in `update.test.ts`) now also covers `lifecycle`, `volumes`, `interpreter` and the global teardown. With it set, test sandboxes are left alive so you can debug them after a failing run.

## Why now

CI on #383 surfaced a new set of failures (lifecycle updateTtl/updateLifecycle, interpreter 502 on /port/8888) that reproduce only in `us-pdx-1` and look like a backend regression from the mk3.1 conditional routing change. The proxy failures were drowning the signal, and we needed to keep the broken sandboxes around to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Excludes flaky proxy integration tests from the default vitest run (opt back in with `RUN_PROXY_TESTS=true`) and extends the `SKIP_CLEANUP=1` env var to `lifecycle`, `volumes`, `interpreter` test teardowns and the global teardown, so test resources can be left alive for debugging.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c3c09cfbb3f85fbfe7a4ceadaea82c79f782fe32.</sup>
<!-- /MENDRAL_SUMMARY -->