### PR TITLE
chore(core): remove redundant image type assertions

### DIFF
--- a/@blaxel/core/src/image/image.ts
+++ b/@blaxel/core/src/image/image.ts
@@ -213,7 +213,7 @@ export class ImageInstance {
     let options: PipInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as PipInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -240,7 +240,7 @@ export class ImageInstance {
     let options: AptInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as AptInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -266,7 +266,7 @@ export class ImageInstance {
     let options: ApkAddOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as ApkAddOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -298,7 +298,7 @@ export class ImageInstance {
     let options: NpmInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as NpmInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -343,7 +343,7 @@ export class ImageInstance {
     let options: GemInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as GemInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -364,7 +364,7 @@ export class ImageInstance {
     let options: CargoInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as CargoInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -393,7 +393,7 @@ export class ImageInstance {
     let options: ComposerInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as ComposerInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -418,7 +418,7 @@ export class ImageInstance {
     let options: UvInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as UvInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];


### PR DESCRIPTION
## Summary

- remove eight redundant type assertions that trip the core ESLint baseline
- preserve the existing overload narrowing and generated image instructions unchanged
- unblock the focused ENG-4047 Sentry boundary change from being obscured by unrelated lint errors

## Verification

- bun install --frozen-lockfile
- bun run --filter @blaxel/core lint (0 errors; one pre-existing warning in sandbox/preview.ts)
- bun run --filter @blaxel/core test (88 passed, 3 skipped)
- bun run build
- git diff --check

This is a behavior-preserving prerequisite; the core image suite covers all affected install helpers.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes redundant `as XxxOptions` type assertions from eight package-install helper methods in `ImageInstance`. TypeScript's control-flow narrowing via the `typeof args[0] === "object"` guard already narrows `args[0]` from `string | XxxOptions` to `XxxOptions`, making the casts unnecessary.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ed107a19f287755908dedc77077ac4f280f4eb76.</sup>
<!-- /MENDRAL_SUMMARY -->