### PR TITLE
fix(core): constrain SDK Sentry boundary (ENG-4047)

### DIFF
--- a/@blaxel/core/src/common/lazyInit.ts
+++ b/@blaxel/core/src/common/lazyInit.ts
@@ -15,8 +15,8 @@ let autoloaded = false;
  *     populates `BL_ENV` if the user has a dev workspace configured).
  *   - Re-apply the control-plane and sandbox clients' `baseUrl` so they
  *     target the now-env-aware endpoint.
- *   - Initialize the lightweight Sentry client (registers
- *     `uncaughtExceptionMonitor` and patches `console.error` in Node).
+ *   - Initialize the lightweight Sentry client (registers a composable
+ *     `uncaughtExceptionMonitor` handler in Node).
  *   - Pre-warm the edge H2 connection pool for `settings.region`.
  *
  * These used to run at module load, but that meant `import "@blaxel/core"`

--- a/@blaxel/core/src/common/sentry.test.ts
+++ b/@blaxel/core/src/common/sentry.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSettings = vi.hoisted(() => ({
+  tracking: true,
+  sentryDsn: "https://public-key@sentry.example/123",
+  env: "prod",
+  version: "9.9.9",
+  commit: "abcdef0",
+  workspace: "private-workspace",
+}));
+
+vi.mock("./settings.js", () => ({ settings: mockSettings }));
+
+const appFrameUrl = "file:///Users/customer/private-project/app.ts";
+
+function makeSdkError(
+  message = "secret response body for resource customer-123"
+): Error {
+  // This helper lives under the exact @blaxel/core source root, so its real
+  // runtime frame exercises package-root attribution without test hooks.
+  return new TypeError(message);
+}
+
+function makeApplicationError(): Error {
+  const sdkFrame = makeSdkError().stack
+    ?.split("\n")
+    .find((line) => line.includes("sentry.test"));
+  if (!sdkFrame) throw new Error("Expected a real SDK test frame");
+
+  const error = new Error("application secret");
+  error.stack = [
+    "Error: application secret",
+    `    at application (${appFrameUrl}:10:20)`,
+    sdkFrame,
+  ].join("\n");
+  return error;
+}
+
+type CapturedEvent = {
+  exception: {
+    values: Array<{
+      type: string;
+      value: string;
+      stacktrace: { frames: Array<Record<string, unknown>> };
+    }>;
+  };
+  tags: Record<string, string>;
+};
+
+function eventFromFetch(fetchMock: ReturnType<typeof vi.fn>): CapturedEvent {
+  const request = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  if (typeof request?.body !== "string") throw new Error("Expected a string Sentry envelope");
+  return JSON.parse(request.body.split("\n")[2]) as CapturedEvent;
+}
+
+function emitUncaughtExceptionMonitor(error: Error): boolean {
+  const processWithStringEvents = process as unknown as {
+    emit(event: string, ...args: unknown[]): boolean;
+  };
+  return processWithStringEvents.emit(
+    "uncaughtExceptionMonitor",
+    error,
+    "uncaughtException"
+  );
+}
+
+describe("SDK Sentry boundary", () => {
+  let originalMonitorListeners: Array<(...args: any[]) => void>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockSettings.tracking = true;
+    mockSettings.sentryDsn = "https://public-key@sentry.example/123";
+    mockSettings.env = "prod";
+    originalMonitorListeners = process.listeners("uncaughtExceptionMonitor") as Array<
+      (...args: any[]) => void
+    >;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const listener of process.listeners("uncaughtExceptionMonitor")) {
+      if (!originalMonitorListeners.includes(listener)) {
+        process.removeListener("uncaughtExceptionMonitor", listener);
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("does not replace console.error or report caught errors", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const hostConsoleError = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(hostConsoleError);
+
+    const { initSentry } = await import("./sentry.js");
+    initSentry();
+    const installedConsoleError = console.error;
+
+    console.error(makeSdkError());
+
+    expect(console.error).toBe(installedConsoleError);
+    expect(hostConsoleError).toHaveBeenCalledOnce();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("composes with host handlers and reports one sanitized SDK-owned event", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const hostMonitor = vi.fn();
+    const hostRejection = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    process.on("uncaughtExceptionMonitor", hostMonitor);
+    process.on("unhandledRejection", hostRejection);
+    const rejectionListeners = process.listeners("unhandledRejection");
+
+    try {
+      const { flushSentry, initSentry } = await import("./sentry.js");
+      initSentry();
+      const error = makeSdkError();
+
+      emitUncaughtExceptionMonitor(error);
+      emitUncaughtExceptionMonitor(error);
+      await flushSentry();
+
+      expect(hostMonitor).toHaveBeenCalledTimes(2);
+      expect(process.listeners("unhandledRejection")).toEqual(rejectionListeners);
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      const event = eventFromFetch(fetchMock);
+      expect(event.exception.values[0]).toMatchObject({
+        type: "TypeError",
+        value: "Unhandled SDK exception",
+      });
+      expect(event.tags).toEqual({
+        "blaxel.version": "9.9.9",
+        "blaxel.commit": "abcdef0",
+        "blaxel.error_source": "unhandled-sdk-exception",
+      });
+      expect(event.tags).not.toHaveProperty("blaxel.workspace");
+      const frames = event.exception.values[0].stacktrace.frames;
+      expect(frames.length).toBeGreaterThan(0);
+      for (const frame of frames) {
+        expect(frame.filename).toBe("@blaxel/core/src/common/sentry.test.ts");
+      }
+
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain("secret response body");
+      expect(serialized).not.toContain("customer-123");
+      expect(serialized).not.toContain("private-workspace");
+      expect(serialized).not.toContain("/Users/customer");
+    } finally {
+      process.removeListener("uncaughtExceptionMonitor", hostMonitor);
+      process.removeListener("unhandledRejection", hostRejection);
+    }
+  });
+
+  it("does not attribute an application-owned exception with a later SDK frame", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initSentry } = await import("./sentry.js");
+    initSentry();
+    emitUncaughtExceptionMonitor(makeApplicationError());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("composes with browser handlers and ignores primitive rejections", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const listeners = new Map<string, (event: unknown) => void>();
+    const addEventListener = vi.fn((type: string, listener: (event: unknown) => void) => {
+      listeners.set(type, listener);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("process", undefined);
+    vi.stubGlobal("addEventListener", addEventListener);
+
+    const { flushSentry, initSentry } = await import("./sentry.js");
+    initSentry();
+
+    expect(addEventListener).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(addEventListener).toHaveBeenCalledWith("unhandledrejection", expect.any(Function));
+
+    listeners.get("unhandledrejection")?.({ reason: "raw rejection secret" });
+    listeners.get("error")?.({ error: makeSdkError() });
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(JSON.stringify(eventFromFetch(fetchMock))).not.toContain("raw rejection secret");
+  });
+
+  it("does not initialize when tracking is disabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    mockSettings.tracking = false;
+
+    const { initSentry, isSentryInitialized } = await import("./sentry.js");
+    initSentry();
+    emitUncaughtExceptionMonitor(makeSdkError());
+
+    expect(isSentryInitialized()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/@blaxel/core/src/common/sentry.test.ts
+++ b/@blaxel/core/src/common/sentry.test.ts
@@ -36,6 +36,23 @@ function makeApplicationError(): Error {
   return error;
 }
 
+function makeTraversalStackError(): Error {
+  const sdkFrame = makeSdkError().stack
+    ?.split("\n")
+    .find((line) => line.includes("sentry.test"));
+  if (!sdkFrame) throw new Error("Expected a real SDK test frame");
+
+  const forgedFrame = sdkFrame.replace(
+    /([\\/])src\1common\1sentry\.test\.ts/,
+    "$1src$1..$1private$1customer-secret.ts"
+  );
+  if (forgedFrame === sdkFrame) throw new Error("Expected to forge the SDK frame path");
+
+  const error = new Error("application secret");
+  error.stack = ["Error: application secret", forgedFrame].join("\n");
+  return error;
+}
+
 type CapturedEvent = {
   exception: {
     values: Array<{
@@ -161,6 +178,37 @@ describe("SDK Sentry boundary", () => {
     const { initSentry } = await import("./sentry.js");
     initSentry();
     emitUncaughtExceptionMonitor(makeApplicationError());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a forged owned path containing parent traversal", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initSentry } = await import("./sentry.js");
+    initSentry();
+    emitUncaughtExceptionMonitor(makeTraversalStackError());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("contains delivery setup failures without creating an unhandled rejection", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal(
+      "AbortController",
+      class FailingAbortController {
+        constructor() {
+          throw new Error("host AbortController failure");
+        }
+      }
+    );
+
+    const { flushSentry, initSentry } = await import("./sentry.js");
+    initSentry();
+    emitUncaughtExceptionMonitor(makeSdkError());
+    await flushSentry();
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/@blaxel/core/src/common/sentry.ts
+++ b/@blaxel/core/src/common/sentry.ts
@@ -44,6 +44,7 @@ const SAFE_ERROR_NAMES = new Set([
 
 const MAX_IN_FLIGHT_EVENTS = 20;
 const DELIVERY_TIMEOUT_MS = 500;
+const SAFE_FILENAME_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
 let sentryInitialized = false;
 let handlersRegistered = false;
@@ -128,11 +129,31 @@ function isRuntimeFrame(filename: string): boolean {
   return filename.startsWith("node:") || filename.startsWith("internal/");
 }
 
+function ownedRelativeFilename(filename: string): string | null {
+  if (!sdkPackageRoot) return null;
+
+  for (const directory of OWNED_PACKAGE_DIRECTORIES) {
+    const prefix = `${sdkPackageRoot}${directory}`;
+    if (!filename.startsWith(prefix)) continue;
+
+    const relativeFilename = filename.slice(sdkPackageRoot.length).replace(/^\/+/, "");
+    const segments = relativeFilename.split("/");
+    if (
+      segments.length > 0 &&
+      segments.every(
+        (segment) =>
+          segment !== "." && segment !== ".." && SAFE_FILENAME_SEGMENT.test(segment)
+      )
+    ) {
+      return relativeFilename;
+    }
+  }
+
+  return null;
+}
+
 function isOwnedFilename(filename: string): boolean {
-  if (!sdkPackageRoot) return false;
-  return OWNED_PACKAGE_DIRECTORIES.some((directory) =>
-    filename.startsWith(`${sdkPackageRoot}${directory}`)
-  );
+  return ownedRelativeFilename(filename) !== null;
 }
 
 /**
@@ -160,9 +181,7 @@ function sanitizeFunctionName(name: string): string {
 }
 
 function sanitizeOwnedFrame(frame: ParsedFrame): ParsedFrame {
-  const relativeFilename = sdkPackageRoot
-    ? frame.filename.slice(sdkPackageRoot.length).replace(/^\/+/, "")
-    : "unknown";
+  const relativeFilename = ownedRelativeFilename(frame.filename) ?? "unknown";
 
   return {
     function: sanitizeFunctionName(frame.function),
@@ -277,9 +296,11 @@ async function sendToSentry(event: SentryEvent): Promise<void> {
 function scheduleDelivery(event: SentryEvent): void {
   if (inFlightDeliveries.size >= MAX_IN_FLIGHT_EVENTS) return;
 
-  const delivery = sendToSentry(event);
+  // Contain rejections from setup that occurs before sendToSentry's internal
+  // fetch guard (for example, a host-provided AbortController implementation).
+  const delivery = sendToSentry(event).catch(() => undefined);
   inFlightDeliveries.add(delivery);
-  void delivery.finally(() => inFlightDeliveries.delete(delivery));
+  void delivery.then(() => inFlightDeliveries.delete(delivery));
 }
 
 function captureException(error: Error): void {

--- a/@blaxel/core/src/common/sentry.ts
+++ b/@blaxel/core/src/common/sentry.ts
@@ -1,47 +1,192 @@
 import { settings } from "./settings.js";
 
-// Lightweight Sentry client using fetch - only captures SDK errors
-let sentryInitialized = false;
-const capturedExceptions = new Set<string>();
-let handlersRegistered = false;
-
-// Parsed DSN components
-let sentryConfig: {
+type SentryConfig = {
   publicKey: string;
   host: string;
   projectId: string;
-} | null = null;
+};
 
-// SDK path patterns to identify errors originating from our SDK
-const SDK_PATTERNS = [
-  "@blaxel/",
-  "blaxel-sdk",
-  "/node_modules/@blaxel/",
-  "/@blaxel/core/",
-  "/@blaxel/telemetry/",
-];
+type ParsedFrame = {
+  filename: string;
+  function: string;
+  lineno?: number;
+  colno?: number;
+};
+
+type SentryEvent = Record<string, unknown> & { event_id: string };
+
+const PACKAGE_LAYOUT_MARKERS = [
+  "/src/common/sentry.ts",
+  "/dist/cjs/common/sentry.js",
+  "/dist/esm/common/sentry.js",
+  "/dist/cjs-browser/common/sentry.js",
+  "/dist/esm-browser/common/sentry.js",
+] as const;
+
+const OWNED_PACKAGE_DIRECTORIES = [
+  "/src/",
+  "/dist/cjs/",
+  "/dist/esm/",
+  "/dist/cjs-browser/",
+  "/dist/esm-browser/",
+] as const;
+
+const SAFE_ERROR_NAMES = new Set([
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+  "AggregateError",
+]);
+
+const MAX_IN_FLIGHT_EVENTS = 20;
+const DELIVERY_TIMEOUT_MS = 500;
+
+let sentryInitialized = false;
+let handlersRegistered = false;
+let sentryConfig: SentryConfig | null = null;
+let flushPromise: Promise<void> | null = null;
+
+const capturedExceptions = new WeakSet<Error>();
+const inFlightDeliveries = new Set<Promise<void>>();
 
 /**
- * Check if an error originated from the SDK based on its stack trace.
- * Returns true if the stack trace contains any SDK-related paths.
+ * Normalize stack filenames without resolving or exposing host filesystem data.
  */
-function isFromSDK(error: Error): boolean {
-  const stack = error.stack || "";
-  return SDK_PATTERNS.some((pattern) => stack.includes(pattern));
+function normalizeFilename(filename: string): string {
+  return filename.replace(/\\/g, "/").replace(/[?#].*$/, "");
 }
 
 /**
- * Parse a Sentry DSN into its components.
- * DSN format: https://{public_key}@{host}/{project_id}
+ * Parse V8/Node and browser stack-frame formats in call order (newest first).
  */
-function parseDsn(dsn: string): typeof sentryConfig {
+function parseStackTrace(stack: string): ParsedFrame[] {
+  const frames: ParsedFrame[] = [];
+
+  // V8 starts with an error header (which does not match a frame), while
+  // Firefox-style stacks can start directly with the first frame.
+  for (const line of stack.split("\n")) {
+    const v8WithFunction = line.match(/^\s*at\s+(.+?)\s+\((.+):(\d+):(\d+)\)\s*$/);
+    const v8WithoutFunction = line.match(/^\s*at\s+(.+):(\d+):(\d+)\s*$/);
+    const browser = line.match(/^\s*(.*?)@(.+):(\d+):(\d+)\s*$/);
+
+    const match = v8WithFunction ?? v8WithoutFunction ?? browser;
+    if (!match) continue;
+
+    if (match === v8WithFunction) {
+      frames.push({
+        function: match[1],
+        filename: normalizeFilename(match[2]),
+        lineno: Number.parseInt(match[3], 10),
+        colno: Number.parseInt(match[4], 10),
+      });
+      continue;
+    }
+
+    if (match === browser) {
+      frames.push({
+        function: match[1] || "<anonymous>",
+        filename: normalizeFilename(match[2]),
+        lineno: Number.parseInt(match[3], 10),
+        colno: Number.parseInt(match[4], 10),
+      });
+      continue;
+    }
+
+    frames.push({
+      function: "<anonymous>",
+      filename: normalizeFilename(match[1]),
+      lineno: Number.parseInt(match[2], 10),
+      colno: Number.parseInt(match[3], 10),
+    });
+  }
+
+  return frames;
+}
+
+/**
+ * Discover this exact @blaxel/core package root from this module's own frame.
+ * This avoids trusting a generic "@blaxel" substring in an arbitrary stack.
+ */
+function discoverPackageRoot(stack: string): string | null {
+  for (const frame of parseStackTrace(stack)) {
+    for (const marker of PACKAGE_LAYOUT_MARKERS) {
+      if (frame.filename.endsWith(marker)) {
+        return frame.filename.slice(0, -marker.length);
+      }
+    }
+  }
+  return null;
+}
+
+const sdkPackageRoot = discoverPackageRoot(new Error().stack ?? "");
+
+function isRuntimeFrame(filename: string): boolean {
+  return filename.startsWith("node:") || filename.startsWith("internal/");
+}
+
+function isOwnedFilename(filename: string): boolean {
+  if (!sdkPackageRoot) return false;
+  return OWNED_PACKAGE_DIRECTORIES.some((directory) =>
+    filename.startsWith(`${sdkPackageRoot}${directory}`)
+  );
+}
+
+/**
+ * Attribute an exception only when its first non-runtime frame is inside the
+ * exact installed @blaxel/core package. Application and dependency frames are
+ * never included in the event.
+ */
+function getOwnedFrames(error: Error): ParsedFrame[] {
+  const frames = parseStackTrace(error.stack ?? "");
+  const firstRelevantFrame = frames.find((frame) => !isRuntimeFrame(frame.filename));
+
+  if (!firstRelevantFrame || !isOwnedFilename(firstRelevantFrame.filename)) {
+    return [];
+  }
+
+  return frames.filter((frame) => isOwnedFilename(frame.filename));
+}
+
+function sanitizeFunctionName(name: string): string {
+  const normalized = name.trim();
+  if (!normalized || normalized.length > 120 || !/^[\w.$<> /-]+$/u.test(normalized)) {
+    return "<sdk>";
+  }
+  return normalized;
+}
+
+function sanitizeOwnedFrame(frame: ParsedFrame): ParsedFrame {
+  const relativeFilename = sdkPackageRoot
+    ? frame.filename.slice(sdkPackageRoot.length).replace(/^\/+/, "")
+    : "unknown";
+
+  return {
+    function: sanitizeFunctionName(frame.function),
+    filename: `@blaxel/core/${relativeFilename}`,
+    lineno: frame.lineno,
+    colno: frame.colno,
+  };
+}
+
+function sanitizeErrorName(name: string): string {
+  return SAFE_ERROR_NAMES.has(name) ? name : "Error";
+}
+
+/**
+ * Parse a Sentry DSN into the public transport components used by envelopes.
+ */
+function parseDsn(dsn: string): SentryConfig | null {
   try {
     const url = new URL(dsn);
     const publicKey = url.username;
     const host = url.host;
-    const projectId = url.pathname.slice(1); // Remove leading slash
+    const projectId = url.pathname.slice(1);
 
-    if (!publicKey || !host || !projectId) {
+    if (!publicKey || !host || !projectId || !["http:", "https:"].includes(url.protocol)) {
       return null;
     }
 
@@ -51,23 +196,19 @@ function parseDsn(dsn: string): typeof sentryConfig {
   }
 }
 
-/**
- * Generate a UUID v4
- */
 function generateEventId(): string {
-  return "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx".replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
+  return "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx".replace(/[xy]/g, (character) => {
+    const random = (Math.random() * 16) | 0;
+    const value = character === "x" ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
   });
 }
 
 /**
- * Convert an Error to a Sentry event payload.
+ * Build an allowlisted event. Raw messages, response bodies, workspace/resource
+ * context, and absolute host paths are deliberately excluded.
  */
-function errorToSentryEvent(error: Error): Record<string, unknown> {
-  const frames = parseStackTrace(error.stack || "");
-
+function errorToSentryEvent(error: Error, ownedFrames: ParsedFrame[]): SentryEvent {
   return {
     event_id: generateEventId(),
     timestamp: Date.now() / 1000,
@@ -76,17 +217,18 @@ function errorToSentryEvent(error: Error): Record<string, unknown> {
     environment: settings.env,
     release: `sdk-typescript@${settings.version}`,
     tags: {
-      "blaxel.workspace": settings.workspace,
       "blaxel.version": settings.version,
       "blaxel.commit": settings.commit,
+      "blaxel.error_source": "unhandled-sdk-exception",
     },
     exception: {
       values: [
         {
-          type: error.name,
-          value: error.message,
+          type: sanitizeErrorName(error.name),
+          value: "Unhandled SDK exception",
           stacktrace: {
-            frames,
+            // Sentry expects oldest-to-newest frame order.
+            frames: ownedFrames.map(sanitizeOwnedFrame).reverse(),
           },
         },
       ],
@@ -94,55 +236,25 @@ function errorToSentryEvent(error: Error): Record<string, unknown> {
   };
 }
 
-/**
- * Parse a stack trace string into Sentry-compatible frames.
- */
-function parseStackTrace(
-  stack: string
-): Array<{ filename: string; function: string; lineno?: number; colno?: number }> {
-  const lines = stack.split("\n").slice(1); // Skip first line (error message)
-  const frames: Array<{ filename: string; function: string; lineno?: number; colno?: number }> = [];
-
-  for (const line of lines) {
-    // Match patterns like "at functionName (filename:line:col)" or "at filename:line:col"
-    const match = line.match(/at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?/);
-    if (match) {
-      frames.unshift({
-        function: match[1] || "<anonymous>",
-        filename: match[2],
-        lineno: parseInt(match[3], 10),
-        colno: parseInt(match[4], 10),
-      });
-    }
-  }
-
-  return frames;
-}
-
-/**
- * Send an event to Sentry using fetch.
- */
-async function sendToSentry(event: Record<string, unknown>): Promise<void> {
+async function sendToSentry(event: SentryEvent): Promise<void> {
   if (!sentryConfig) return;
 
   const { publicKey, host, projectId } = sentryConfig;
   const envelopeUrl = `https://${host}/api/${projectId}/envelope/`;
-
-  // Create envelope header
   const envelopeHeader = JSON.stringify({
     event_id: event.event_id,
     sent_at: new Date().toISOString(),
     dsn: `https://${publicKey}@${host}/${projectId}`,
   });
-
-  // Create item header
   const itemHeader = JSON.stringify({
     type: "event",
     content_type: "application/json",
   });
-
-  // Create envelope body
   const envelope = `${envelopeHeader}\n${itemHeader}\n${JSON.stringify(event)}`;
+  const controller = typeof AbortController === "function" ? new AbortController() : null;
+  const abortTimer = controller
+    ? setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS)
+    : null;
 
   try {
     await fetch(envelopeUrl, {
@@ -152,192 +264,119 @@ async function sendToSentry(event: Record<string, unknown>): Promise<void> {
         "X-Sentry-Auth": `Sentry sentry_version=7, sentry_client=blaxel-sdk/${settings.version}, sentry_key=${publicKey}`,
       },
       body: envelope,
+      keepalive: true,
+      signal: controller?.signal,
     });
   } catch {
-    // Silently fail - error reporting should never break the SDK
+    // Error reporting must never affect the host application.
+  } finally {
+    if (abortTimer) clearTimeout(abortTimer);
   }
 }
 
-// Queue for pending events
-const pendingEvents: Array<Record<string, unknown>> = [];
-let flushPromise: Promise<void> | null = null;
+function scheduleDelivery(event: SentryEvent): void {
+  if (inFlightDeliveries.size >= MAX_IN_FLIGHT_EVENTS) return;
 
-/**
- * Register browser/edge environment error handlers.
- * Separated to isolate dynamic globalThis access.
- */
-function registerBrowserHandlers(): void {
-  const g = globalThis as Record<string, unknown>;
-  if (g && typeof g.addEventListener === "function") {
-    (g.addEventListener as (type: string, listener: (e: unknown) => void) => void)("error", (event: unknown) => {
-      const e = event as { error?: unknown };
-      if (e.error instanceof Error && isFromSDK(e.error)) {
-        captureException(e.error);
-      }
-    });
-
-    (g.addEventListener as (type: string, listener: (e: unknown) => void) => void)("unhandledrejection", (event: unknown) => {
-      const e = event as { reason?: unknown };
-      const error =
-        e.reason instanceof Error ? e.reason : new Error(String(e.reason));
-      if (isFromSDK(error)) {
-        captureException(error);
-      }
-    });
-  }
+  const delivery = sendToSentry(event);
+  inFlightDeliveries.add(delivery);
+  void delivery.finally(() => inFlightDeliveries.delete(delivery));
 }
 
-/**
- * Initialize the lightweight Sentry client for SDK error tracking.
- */
-export function initSentry() {
+function captureException(error: Error): void {
+  if (!sentryInitialized || !sentryConfig || capturedExceptions.has(error)) {
+    return;
+  }
+
   try {
-    // Check if tracking is disabled
-    if (!settings.tracking) {
-      return;
-    }
+    const ownedFrames = getOwnedFrames(error);
+    if (ownedFrames.length === 0) return;
 
-    const dsn = settings.sentryDsn;
+    capturedExceptions.add(error);
+    scheduleDelivery(errorToSentryEvent(error, ownedFrames));
+  } catch {
+    // Error reporting must never affect the host application.
+  }
+}
 
-    if (!dsn) {
-      return;
-    }
+function registerBrowserHandlers(): void {
+  const host = globalThis as typeof globalThis & {
+    addEventListener?: (type: string, listener: (event: unknown) => void) => void;
+  };
 
-    // Parse DSN
-    sentryConfig = parseDsn(dsn);
-    if (!sentryConfig) {
-      return;
-    }
+  if (typeof host.addEventListener !== "function") return;
 
-    // Only allow dev/prod environments
-    if (settings.env !== "dev" && settings.env !== "prod") {
-      return;
-    }
+  host.addEventListener.call(host, "error", (event: unknown) => {
+    const error = (event as { error?: unknown }).error;
+    if (error instanceof Error) captureException(error);
+  });
 
+  host.addEventListener.call(host, "unhandledrejection", (event: unknown) => {
+    const reason = (event as { reason?: unknown }).reason;
+    // A primitive rejection carries no attributable stack, so do not guess.
+    if (reason instanceof Error) captureException(reason);
+  });
+}
+
+/**
+ * Initialize opt-in SDK error tracking. Registration composes with host global
+ * handlers and never replaces console, process, or browser callbacks.
+ */
+export function initSentry(): void {
+  try {
+    if (!settings.tracking || !settings.sentryDsn || !sdkPackageRoot) return;
+
+    const config = parseDsn(settings.sentryDsn);
+    if (!config || (settings.env !== "dev" && settings.env !== "prod")) return;
+
+    sentryConfig = config;
     sentryInitialized = true;
 
-    // Register error handlers only once
-    if (!handlersRegistered) {
-      handlersRegistered = true;
+    if (handlersRegistered) return;
+    handlersRegistered = true;
 
-      // Node.js specific handlers
-      if (typeof process !== "undefined" && typeof process.on === "function") {
-        // Monitor uncaught exceptions to capture SDK errors without
-        // preventing Node.js default crash behavior (print + exit).
-        const uncaughtExceptionMonitorHandler = (error: Error) => {
-          if (isFromSDK(error)) {
-            captureException(error);
-          }
-        };
-
-        process.on("uncaughtExceptionMonitor", uncaughtExceptionMonitorHandler);
-
-        // Intercept console.error to capture SDK errors that are caught and logged
-        const originalConsoleError = console.error;
-        console.error = function (...args: unknown[]) {
-          originalConsoleError.apply(console, args);
-          for (const arg of args) {
-            if (arg instanceof Error && isFromSDK(arg)) {
-              captureException(arg);
-              break;
-            }
-          }
-        };
-      } else {
-        // Browser/Edge environment handlers
-        registerBrowserHandlers();
-      }
-    }
-  } catch (error) {
-    // Silently fail - Sentry initialization should never break the SDK
-    if (settings.env !== "production") {
-      console.error("[Blaxel SDK] Error initializing Sentry:", error);
-    }
-  }
-}
-
-/**
- * Capture an exception to Sentry.
- * Only errors originating from SDK code will be captured.
- *
- * @param error - The error to capture
- */
-function captureException(error: Error): void {
-  if (!sentryInitialized || !sentryConfig) {
-    return;
-  }
-
-  // Double-check that error is from SDK (defense in depth)
-  if (!isFromSDK(error)) {
-    return;
-  }
-
-  try {
-    // Create a unique identifier for this exception to avoid duplicates
-    const errorKey = `${error.name}:${error.message}:${error.stack?.slice(0, 200)}`;
-
-    if (capturedExceptions.has(errorKey)) {
+    if (
+      typeof process !== "undefined" &&
+      process.versions?.node &&
+      typeof process.on === "function"
+    ) {
+      process.on("uncaughtExceptionMonitor", (error: Error) => {
+        captureException(error);
+      });
       return;
     }
 
-    capturedExceptions.add(errorKey);
-
-    // Clean up old exception keys to prevent memory leak
-    if (capturedExceptions.size > 1000) {
-      capturedExceptions.clear();
-    }
-
-    // Convert error to Sentry event and queue it
-    const event = errorToSentryEvent(error);
-    pendingEvents.push(event);
-
-    // Send immediately (fire and forget)
-    sendToSentry(event).catch(() => {
-      // Silently fail
-    });
+    registerBrowserHandlers();
   } catch {
-    // Silently fail - error capturing should never break the SDK
+    // Initialization is intentionally silent and cannot break the SDK.
   }
 }
 
 /**
- * Flush pending Sentry events.
- * This should be called before the process exits to ensure all events are sent.
- *
- * @param timeout - Maximum time in milliseconds to wait for flush (default: 2000)
+ * Await only deliveries already in flight, bounded by the supplied timeout.
+ * Events are sent exactly once; flush never re-enqueues them.
  */
-export async function flushSentry(timeout = 2000): Promise<void> {
-  if (!sentryInitialized || pendingEvents.length === 0) {
-    return;
-  }
+export async function flushSentry(timeout = DELIVERY_TIMEOUT_MS): Promise<void> {
+  if (!sentryInitialized || inFlightDeliveries.size === 0) return;
 
-  // If already flushing, wait for it
   if (flushPromise) {
     await flushPromise;
     return;
   }
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    // Send all pending events
-    const eventsToSend = [...pendingEvents];
-    pendingEvents.length = 0;
-
-    flushPromise = Promise.race([
-      Promise.all(eventsToSend.map((event) => sendToSentry(event))).then(() => {}),
-      new Promise<void>((resolve) => setTimeout(resolve, timeout)),
-    ]);
-
+    const deliveries = Promise.allSettled([...inFlightDeliveries]).then(() => undefined);
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutHandle = setTimeout(resolve, Math.max(0, timeout));
+    });
+    flushPromise = Promise.race([deliveries, timeoutPromise]);
     await flushPromise;
-  } catch {
-    // Silently fail
   } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
     flushPromise = null;
   }
 }
 
-/**
- * Check if Sentry is initialized and available.
- */
 export function isSentryInitialized(): boolean {
   return sentryInitialized;
 }

--- a/@blaxel/core/src/image/image.ts
+++ b/@blaxel/core/src/image/image.ts
@@ -213,7 +213,7 @@ export class ImageInstance {
     let options: PipInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as PipInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -240,7 +240,7 @@ export class ImageInstance {
     let options: AptInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as AptInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -266,7 +266,7 @@ export class ImageInstance {
     let options: ApkAddOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as ApkAddOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -298,7 +298,7 @@ export class ImageInstance {
     let options: NpmInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as NpmInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -343,7 +343,7 @@ export class ImageInstance {
     let options: GemInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as GemInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -364,7 +364,7 @@ export class ImageInstance {
     let options: CargoInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as CargoInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -393,7 +393,7 @@ export class ImageInstance {
     let options: ComposerInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as ComposerInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];
@@ -418,7 +418,7 @@ export class ImageInstance {
     let options: UvInstallOptions = {};
     let packages: string[];
     if (args.length > 0 && typeof args[0] === "object") {
-      options = args[0] as UvInstallOptions;
+      options = args[0];
       packages = args.slice(1) as string[];
     } else {
       packages = args as string[];

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ import "@blaxel/telemetry";
 
 ### Error tracking
 
-The SDK includes error tracking that captures exceptions originating from the SDK itself (not your application code). It collects data including the error type, message, stack trace, SDK version, workspace name, and so on. No user or application data is collected.
+The SDK includes opt-in error tracking for unhandled exceptions whose first non-runtime frame belongs to the installed `@blaxel/core` package. Events contain an allowlisted error type, a fixed message, SDK-owned relative stack frames, the SDK version and commit, and the `dev` or `prod` environment. Raw error messages, response bodies, workspace and resource identifiers, absolute paths, and application stack frames are not collected. Caught errors, including errors logged with `console.error`, are not reported. If a browser bundler removes the package boundary from stack frames, error tracking stays disabled rather than attributing application errors to the SDK.
 
 Error tracking is off by default since v0.2.76. To explicitly disable it in older versions:
 


### PR DESCRIPTION
## Problem

The SDK Sentry shim patched the process-wide `console.error` function and treated any stack containing a broad Blaxel substring as SDK-owned. That reported caught application errors, could misattribute application-first stacks with a later SDK frame, and included raw error messages, workspace names, absolute paths, and application/dependency frames in events.

This is the source of the noisy TypeScript SDK groups tracked in ENG-4047.

## Root cause

The original implementation tried to infer ownership from substring presence anywhere in a stack. It also used console interception as a catch-all reporting surface. Neither boundary distinguishes an SDK defect from an expected/customer-handled error, and the event serializer copied the full exception context.

## Fix

- remove the global `console.error` monkeypatch
- report only last-chance unhandled exceptions
- compose with existing Node and browser handlers
- require the first non-runtime frame to belong to the exact installed `@blaxel/core` package root
- validate every owned relative path segment and fail closed on traversal or ambiguous paths
- fail closed when a bundler removes the package boundary
- serialize an allowlist: safe error type, fixed message, SDK-relative frames, version, commit, and environment
- deduplicate by `Error` identity, cap in-flight events, bound delivery/flush time, and contain failures that occur even before the transport guard
- document the precise opt-in data contract

## Verification

- `bun install --frozen-lockfile`
- `bun run --filter @blaxel/core lint`: 0 errors (1 pre-existing warning)
- `bun run --filter @blaxel/core test`: 167 passed
- `bun run build`: CJS, ESM, browser, and adapter packages
- clean behavioral probes against CJS, ESM, CJS-browser, and ESM-browser compiled artifacts:
  - application-first stack plus later SDK frame: 0 events
  - forged package-root path containing `../`: 0 events
  - same SDK-first unhandled error emitted twice: 1 event
  - host handlers preserved and invoked
  - `console.error` identity unchanged
  - no raw message, workspace/resource-like value, application path, or absolute package root in the envelope
- `git diff --check`

## Scope

The change does not alter API requests, SDK operation errors, application exception handling, or process exit behavior. It only narrows the optional SDK-owned last-chance telemetry boundary. Caught operational errors remain visible to callers and their own logging/observability.

Depends on #391, which removes unrelated pre-existing core lint errors without changing behavior.

Linear: ENG-4047
