### PR TITLE
Inital H2 test suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,8 +131,11 @@ jobs:
             version: "1.3.11"   # the exact fix: H2 back on
           - runtime: bun
             version: "latest"   # newest: H2 on
+          # The SDK's deno.json uses nodeModulesDir: "manual", which only exists
+          # in Deno 2.x (1.x expects a boolean and cannot parse it), so the
+          # supported range is 2.x. Pin the 2.0 floor and track latest 2.x.
           - runtime: deno
-            version: "v1.x"
+            version: "v2.0.0"
           - runtime: deno
             version: "v2.x"
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,6 +106,80 @@ jobs:
       - name: Run H2 fault-injection + regression tests
         run: npx vitest run --config tests/integration/fault-injection/vitest.faultharness.config.ts
 
+      # Exhaustive Bun/Deno version-gate matrix + parse edge cases. Pure unit
+      # tests over @blaxel/core source; no network, no build.
+      - name: Run H2 runtime version-gate unit tests
+        working-directory: '@blaxel/core'
+        run: npx vitest run --config vitest.config.ts src/common/h2-runtime.test.ts src/common/settings.test.ts
+
+  h2-runtime-version-matrix:
+    name: H2 gate on ${{ matrix.runtime }} ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      # The Bun H2 freeze is a per-VERSION bug: broken < 1.3.11, fixed >= 1.3.11.
+      # This matrix runs the runtime H2 checks (which assert settings.disableH2
+      # flips at exactly the right version, and that a >65535-byte body round-
+      # trips without the freeze) across real Bun and Deno versions. Deno never
+      # trips the gate; it is here to prove a non-Bun runtime keeps H2 on.
+      matrix:
+        include:
+          - runtime: bun
+            version: "1.3.10"   # broken: pooled H2 must be force-disabled
+          - runtime: bun
+            version: "1.3.11"   # the exact fix: H2 back on
+          - runtime: bun
+            version: "latest"   # newest: H2 on
+          - runtime: deno
+            version: "v1.x"
+          - runtime: deno
+            version: "v2.x"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Bun is always needed to install + build the SDK. On Bun rows it is
+      # pinned to the version under test (which also RUNS the test); on Deno
+      # rows we just need any Bun to build, so use latest.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.runtime == 'bun' && matrix.version || 'latest' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup Deno
+        if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.version }}
+
+      - name: Install and build SDK packages
+        run: |
+          bun install
+          bun run build
+
+      - name: Add Bun runtime-environment to workspace and install
+        if: matrix.runtime == 'bun'
+        run: |
+          jq '.workspaces += ["tests/runtime-environments/bun"]' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          bun install
+
+      - name: Run Bun H2 gate test
+        if: matrix.runtime == 'bun'
+        working-directory: tests/runtime-environments/bun
+        run: timeout 120s bun run test
+
+      - name: Run Deno H2 gate test
+        if: matrix.runtime == 'deno'
+        working-directory: tests/runtime-environments/deno
+        run: timeout 120s deno task test
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/@blaxel/core/src/common/h2-runtime.test.ts
+++ b/@blaxel/core/src/common/h2-runtime.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { env } from "./env.js";
+import {
+  BUN_H2_FIXED_VERSION,
+  H2_DEFAULT_CONNECTION_WINDOW_BYTES,
+  detectBunVersion,
+  isBrokenBunH2Runtime,
+  isBrokenBunVersion,
+  parseSemver,
+} from "./h2-runtime.js";
+
+// The Bun H2 flow-control bug (never sends connection-level WINDOW_UPDATE, so a
+// pooled session freezes after 65535 cumulative body bytes) was fixed in
+// 1.3.11. Everything below < 1.3.11 must be classified "broken"; >= 1.3.11 must
+// be "fixed". A non-Bun runtime (no version) is never broken. This is the
+// single most important gate in the SDK's H2 story, so we pin it exhaustively.
+
+describe("parseSemver", () => {
+  it("parses a plain major.minor.patch triple", () => {
+    expect(parseSemver("1.3.11")).toEqual([1, 3, 11]);
+    expect(parseSemver("0.0.0")).toEqual([0, 0, 0]);
+    expect(parseSemver("22.14.0")).toEqual([22, 14, 0]);
+  });
+
+  it("tolerates missing minor/patch", () => {
+    expect(parseSemver("2")).toEqual([2, 0, 0]);
+    expect(parseSemver("1.4")).toEqual([1, 4, 0]);
+  });
+
+  it("strips pre-release and build metadata before comparing", () => {
+    expect(parseSemver("1.3.11-canary.1")).toEqual([1, 3, 11]);
+    expect(parseSemver("1.3.10-debug")).toEqual([1, 3, 10]);
+    expect(parseSemver("1.4.0+build.7")).toEqual([1, 4, 0]);
+    expect(parseSemver("2.0.0-alpha+exp.sha.5114f85")).toEqual([2, 0, 0]);
+  });
+
+  it("returns null for absent or non-numeric input", () => {
+    expect(parseSemver(undefined)).toBeNull();
+    expect(parseSemver(null)).toBeNull();
+    expect(parseSemver("")).toBeNull();
+    expect(parseSemver("latest")).toBeNull();
+    expect(parseSemver("v1.2.3")).toBeNull();
+    expect(parseSemver("1.x.0")).toBeNull();
+  });
+});
+
+describe("isBrokenBunVersion", () => {
+  it("treats a missing version as not-Bun (never broken)", () => {
+    expect(isBrokenBunVersion(undefined)).toBe(false);
+    expect(isBrokenBunVersion(null)).toBe(false);
+    expect(isBrokenBunVersion("")).toBe(false);
+  });
+
+  // The full boundary matrix. Left column = Bun version string, right = whether
+  // the pooled H2 transport is broken on it.
+  const matrix: Array<[string, boolean]> = [
+    // Ancient / pre-1.0 — all broken.
+    ["0.1.0", true],
+    ["0.8.1", true],
+    ["0.9.9", true],
+    // 1.0.x – 1.2.x — broken.
+    ["1.0.0", true],
+    ["1.1.34", true],
+    ["1.2.0", true],
+    ["1.2.21", true],
+    // 1.3.0 – 1.3.10 — the affected line, still broken.
+    ["1.3.0", true],
+    ["1.3.1", true],
+    ["1.3.9", true],
+    ["1.3.10", true],
+    // 1.3.11 — the exact fix boundary. Fixed.
+    ["1.3.11", false],
+    // Everything after — fixed.
+    ["1.3.12", false],
+    ["1.3.100", false],
+    ["1.4.0", false],
+    ["1.10.0", false],
+    ["2.0.0", false],
+    ["10.0.0", false],
+  ];
+
+  it.each(matrix)("Bun %s -> broken=%s", (version, expected) => {
+    expect(isBrokenBunVersion(version)).toBe(expected);
+  });
+
+  // Pre-release / canary builds must compare by their release numbers so a
+  // "1.3.11-canary" is treated as fixed and a "1.3.10-debug" as broken. This is
+  // the exact parse subtlety the earlier duplicated gate got wrong.
+  const prereleaseMatrix: Array<[string, boolean]> = [
+    ["1.3.10-canary.20250101", true],
+    ["1.3.11-canary.20250101", false],
+    ["1.3.11-debug", false],
+    ["1.4.0-canary", false],
+    ["1.2.99-alpha", true],
+  ];
+
+  it.each(prereleaseMatrix)(
+    "Bun %s (pre-release) -> broken=%s",
+    (version, expected) => {
+      expect(isBrokenBunVersion(version)).toBe(expected);
+    },
+  );
+
+  it("classifies an unparseable Bun version as broken (safe default)", () => {
+    // A non-empty but unrecognizable version means we cannot prove it is safe,
+    // so we err toward disabling H2.
+    expect(isBrokenBunVersion("weird-build")).toBe(true);
+    expect(isBrokenBunVersion("nightly")).toBe(true);
+  });
+
+  it("agrees with the documented fix boundary constant", () => {
+    const [maj, min, patch] = parseSemver(BUN_H2_FIXED_VERSION)!;
+    // One patch below the fix is broken; the fix itself is not.
+    expect(isBrokenBunVersion(`${maj}.${min}.${patch - 1}`)).toBe(true);
+    expect(isBrokenBunVersion(`${maj}.${min}.${patch}`)).toBe(false);
+  });
+});
+
+describe("detectBunVersion / isBrokenBunH2Runtime (current runtime)", () => {
+  it("reports the running Bun version, or undefined off Bun", () => {
+    const detected = detectBunVersion();
+    const actual = globalThis.process?.versions?.bun;
+    expect(detected).toBe(actual);
+  });
+
+  it("runtime predicate matches the version predicate for this runtime", () => {
+    expect(isBrokenBunH2Runtime()).toBe(isBrokenBunVersion(detectBunVersion()));
+  });
+});
+
+describe("H2_DEFAULT_CONNECTION_WINDOW_BYTES", () => {
+  it("is 2^16 - 1 (the window a broken Bun never grows)", () => {
+    expect(H2_DEFAULT_CONNECTION_WINDOW_BYTES).toBe(65535);
+    expect(H2_DEFAULT_CONNECTION_WINDOW_BYTES).toBe(2 ** 16 - 1);
+  });
+});
+
+// End-to-end: the settings.disableH2 getter must honor the runtime gate. We
+// simulate different Bun versions by injecting process.versions.bun, since the
+// getter reads it live on every access.
+describe("settings.disableH2 honors the Bun version gate", () => {
+  const originalBun = globalThis.process?.versions?.bun;
+
+  afterEach(async () => {
+    if (globalThis.process?.versions) {
+      if (originalBun === undefined) {
+        delete (globalThis.process.versions as Record<string, unknown>).bun;
+      } else {
+        (globalThis.process.versions as Record<string, string>).bun = originalBun;
+      }
+    }
+    delete (env as Record<string, unknown>).BL_DISABLE_H2;
+    const { settings } = await import("./settings.js");
+    delete settings.config.disableH2;
+  });
+
+  function setBunVersion(version: string | undefined) {
+    if (!globalThis.process?.versions) return false;
+    if (version === undefined) {
+      delete (globalThis.process.versions as Record<string, unknown>).bun;
+    } else {
+      (globalThis.process.versions as Record<string, string>).bun = version;
+    }
+    return true;
+  }
+
+  it("forces H2 OFF on a broken Bun regardless of config/env", async () => {
+    if (!setBunVersion("1.3.10")) return;
+    delete (env as Record<string, unknown>).BL_DISABLE_H2;
+    const { settings } = await import("./settings.js");
+    // Even explicitly asking for H2 on cannot override the safety gate.
+    settings.config.disableH2 = false;
+    expect(settings.disableH2).toBe(true);
+  });
+
+  it("leaves H2 ON (default) on a fixed Bun", async () => {
+    if (!setBunVersion("1.3.11")) return;
+    delete (env as Record<string, unknown>).BL_DISABLE_H2;
+    const { settings } = await import("./settings.js");
+    delete settings.config.disableH2;
+    expect(settings.disableH2).toBe(false);
+  });
+
+  it("still respects an explicit opt-out on a fixed Bun", async () => {
+    if (!setBunVersion("1.4.0")) return;
+    const { settings } = await import("./settings.js");
+    settings.config.disableH2 = true;
+    expect(settings.disableH2).toBe(true);
+  });
+});

--- a/@blaxel/core/src/common/h2-runtime.ts
+++ b/@blaxel/core/src/common/h2-runtime.ts
@@ -1,0 +1,81 @@
+/**
+ * HTTP/2 runtime-capability detection.
+ *
+ * The SDK's pooled HTTP/2 transport relies on the runtime's HTTP/2 client
+ * managing connection-level flow control correctly. One runtime does not:
+ *
+ *   Bun < 1.3.11 never sends a connection-level WINDOW_UPDATE frame. The pooled
+ *   H2 session therefore freezes after exactly 65535 cumulative body bytes (the
+ *   default connection receive window that Bun never grows), and every request
+ *   on that session hangs until the edge resets the streams (~330s).
+ *   Fixed in Bun 1.3.11: https://bun.com/blog/bun-v1.3.11
+ *
+ * This module centralizes the version gate so the settings layer, the unit
+ * tests, and the cross-runtime environment tests all agree on ONE definition of
+ * "is this a Bun that breaks pooled H2". Keeping a single source of truth is the
+ * whole point: the bug this guards against is subtle and the parse is easy to
+ * get subtly wrong (see `stripPrerelease`).
+ */
+
+/** First Bun release with a working connection-level WINDOW_UPDATE. */
+export const BUN_H2_FIXED_VERSION = "1.3.11" as const;
+
+/**
+ * The default HTTP/2 connection-level receive window, in bytes (2^16 - 1). This
+ * is the exact number of cumulative body bytes after which a broken-Bun pooled
+ * session freezes: the window opens to 65535 and, absent a WINDOW_UPDATE, never
+ * reopens. Node grows it (see `establishH2`'s `setLocalWindowSize`); Bun < 1.3.11
+ * does not.
+ */
+export const H2_DEFAULT_CONNECTION_WINDOW_BYTES = 65535 as const;
+
+/**
+ * Parse a `major.minor.patch` version, tolerating a pre-release/build suffix
+ * (e.g. `1.3.11-canary.1`, `1.4.0+build`). Returns `null` when the input is
+ * absent or not a recognizable semver triple.
+ */
+export function parseSemver(
+  version: string | undefined | null,
+): [number, number, number] | null {
+  if (!version) return null;
+  // Strip any pre-release ("-canary.1") or build ("+abc") metadata first so a
+  // tagged build compares by its release numbers, then take the leading triple.
+  const core = version.split("-")[0].split("+")[0].trim();
+  const parts = core.split(".");
+  if (parts.length === 0) return null;
+  const nums = parts.slice(0, 3).map((p) => Number(p));
+  if (nums.some((n) => !Number.isInteger(n) || n < 0)) return null;
+  const [maj = 0, min = 0, patch = 0] = nums;
+  return [maj, min, patch];
+}
+
+/**
+ * Given a Bun version string, is this a Bun whose HTTP/2 client breaks the
+ * pooled transport (Bun < 1.3.11)? A falsy/undefined version means "not Bun",
+ * which returns `false`. An unparseable version is treated as broken (`true`):
+ * we cannot prove it is safe, and forcing H2 off is the safe default.
+ */
+export function isBrokenBunVersion(version: string | undefined | null): boolean {
+  if (!version) return false;
+  const parsed = parseSemver(version);
+  if (parsed === null) return true;
+  const [maj, min, patch] = parsed;
+  return maj < 1 || (maj === 1 && (min < 3 || (min === 3 && patch < 11)));
+}
+
+/**
+ * The running runtime's Bun version, or `undefined` when not on Bun (Node,
+ * Deno, browsers, workers). Deno also exposes `process.versions` but never sets
+ * `.bun`, so this stays `undefined` there.
+ */
+export function detectBunVersion(): string | undefined {
+  return globalThis.process?.versions?.bun;
+}
+
+/**
+ * Is the CURRENT runtime a Bun that breaks the pooled H2 transport? This is the
+ * predicate the settings layer uses to force H2 off.
+ */
+export function isBrokenBunH2Runtime(): boolean {
+  return isBrokenBunVersion(detectBunVersion());
+}

--- a/@blaxel/core/src/common/settings.test.ts
+++ b/@blaxel/core/src/common/settings.test.ts
@@ -57,3 +57,205 @@ describe('Settings.disableH2', () => {
     expect(settings.disableH2).toBe(true);
   });
 });
+
+// The H2 tuning knobs all share the same resolution order: an explicit
+// `settings.config` value wins, then the env var (`env` reads through to
+// process.env), then a hard-coded default. Numeric knobs also reject
+// unparseable/out-of-range env strings and fall back to the default. These are
+// the values that flow into establishH2 (window sizes) and the per-domain
+// concurrency gates, so an off-by-one here silently changes transport behavior.
+describe('Settings H2 tuning knobs (config > env > default)', () => {
+  // Snapshot every H2 env var so a test that sets one cannot leak into another.
+  const H2_ENV_VARS = [
+    'BL_DISABLE_CONTROL_PLANE_H2',
+    'BL_FORCE_CONTROL_PLANE_H2',
+    'BL_MAX_H2_INFLIGHT',
+    'BL_MAX_UPLOAD_H2_INFLIGHT',
+    'BL_H2_STREAM_WINDOW',
+    'BL_H2_CONNECTION_WINDOW',
+  ] as const;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of H2_ENV_VARS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    for (const key of H2_ENV_VARS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    const { settings } = await import('./settings.js');
+    delete settings.config.disableControlPlaneH2;
+    delete settings.config.forceControlPlaneH2;
+    delete settings.config.maxConcurrentH2Requests;
+    delete settings.config.maxConcurrentUploadH2Requests;
+    delete settings.config.h2StreamWindowSize;
+    delete settings.config.h2ConnectionWindowSize;
+  });
+
+  describe('disableControlPlaneH2', () => {
+    it('defaults to false', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.disableControlPlaneH2).toBe(false);
+    });
+
+    it.each(['1', 'true', 'yes', 'on', 'TRUE', 'On'])(
+      'treats env %s as true',
+      async (value) => {
+        process.env.BL_DISABLE_CONTROL_PLANE_H2 = value;
+        const { settings } = await import('./settings.js');
+        expect(settings.disableControlPlaneH2).toBe(true);
+      },
+    );
+
+    it.each(['0', 'false', 'no', 'off', ''])(
+      'treats env %s as false',
+      async (value) => {
+        process.env.BL_DISABLE_CONTROL_PLANE_H2 = value;
+        const { settings } = await import('./settings.js');
+        expect(settings.disableControlPlaneH2).toBe(false);
+      },
+    );
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_DISABLE_CONTROL_PLANE_H2 = '1';
+      const { settings } = await import('./settings.js');
+      settings.config.disableControlPlaneH2 = false;
+      expect(settings.disableControlPlaneH2).toBe(false);
+    });
+  });
+
+  describe('forceControlPlaneH2', () => {
+    it('defaults to false', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.forceControlPlaneH2).toBe(false);
+    });
+
+    it('reads a truthy env var', async () => {
+      process.env.BL_FORCE_CONTROL_PLANE_H2 = 'yes';
+      const { settings } = await import('./settings.js');
+      expect(settings.forceControlPlaneH2).toBe(true);
+    });
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_FORCE_CONTROL_PLANE_H2 = '1';
+      const { settings } = await import('./settings.js');
+      settings.config.forceControlPlaneH2 = false;
+      expect(settings.forceControlPlaneH2).toBe(false);
+    });
+  });
+
+  describe('maxConcurrentH2Requests', () => {
+    it('defaults to 0 (unlimited)', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentH2Requests).toBe(0);
+    });
+
+    it('parses the env var', async () => {
+      process.env.BL_MAX_H2_INFLIGHT = '8';
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentH2Requests).toBe(8);
+    });
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_MAX_H2_INFLIGHT = '8';
+      const { settings } = await import('./settings.js');
+      settings.config.maxConcurrentH2Requests = 3;
+      expect(settings.maxConcurrentH2Requests).toBe(3);
+    });
+
+    it('falls back to the default on an unparseable env var', async () => {
+      process.env.BL_MAX_H2_INFLIGHT = 'not-a-number';
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentH2Requests).toBe(0);
+    });
+  });
+
+  describe('maxConcurrentUploadH2Requests', () => {
+    it('defaults to 2 (the measured rapid-reset-safe cap)', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentUploadH2Requests).toBe(2);
+    });
+
+    it('parses the env var, including 0 to disable the cap', async () => {
+      process.env.BL_MAX_UPLOAD_H2_INFLIGHT = '0';
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentUploadH2Requests).toBe(0);
+    });
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_MAX_UPLOAD_H2_INFLIGHT = '5';
+      const { settings } = await import('./settings.js');
+      settings.config.maxConcurrentUploadH2Requests = 4;
+      expect(settings.maxConcurrentUploadH2Requests).toBe(4);
+    });
+
+    it('falls back to the default on an unparseable env var', async () => {
+      process.env.BL_MAX_UPLOAD_H2_INFLIGHT = 'xyz';
+      const { settings } = await import('./settings.js');
+      expect(settings.maxConcurrentUploadH2Requests).toBe(2);
+    });
+  });
+
+  describe('h2StreamWindowSize', () => {
+    it('defaults to 16 MiB', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.h2StreamWindowSize).toBe(16 * 1024 * 1024);
+    });
+
+    it('parses a positive env var', async () => {
+      process.env.BL_H2_STREAM_WINDOW = String(4 * 1024 * 1024);
+      const { settings } = await import('./settings.js');
+      expect(settings.h2StreamWindowSize).toBe(4 * 1024 * 1024);
+    });
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_H2_STREAM_WINDOW = '123456';
+      const { settings } = await import('./settings.js');
+      settings.config.h2StreamWindowSize = 654321;
+      expect(settings.h2StreamWindowSize).toBe(654321);
+    });
+
+    it.each(['0', '-1', 'nan'])(
+      'ignores non-positive/unparseable env value %s and uses the default',
+      async (value) => {
+        process.env.BL_H2_STREAM_WINDOW = value;
+        const { settings } = await import('./settings.js');
+        expect(settings.h2StreamWindowSize).toBe(16 * 1024 * 1024);
+      },
+    );
+  });
+
+  describe('h2ConnectionWindowSize', () => {
+    it('defaults to 32 MiB', async () => {
+      const { settings } = await import('./settings.js');
+      expect(settings.h2ConnectionWindowSize).toBe(32 * 1024 * 1024);
+    });
+
+    it('parses a positive env var', async () => {
+      process.env.BL_H2_CONNECTION_WINDOW = String(8 * 1024 * 1024);
+      const { settings } = await import('./settings.js');
+      expect(settings.h2ConnectionWindowSize).toBe(8 * 1024 * 1024);
+    });
+
+    it('config value wins over the env var', async () => {
+      process.env.BL_H2_CONNECTION_WINDOW = '111';
+      const { settings } = await import('./settings.js');
+      settings.config.h2ConnectionWindowSize = 222;
+      expect(settings.h2ConnectionWindowSize).toBe(222);
+    });
+
+    it.each(['0', '-100', 'foo'])(
+      'ignores non-positive/unparseable env value %s and uses the default',
+      async (value) => {
+        process.env.BL_H2_CONNECTION_WINDOW = value;
+        const { settings } = await import('./settings.js');
+        expect(settings.h2ConnectionWindowSize).toBe(32 * 1024 * 1024);
+      },
+    );
+  });
+});

--- a/@blaxel/core/src/common/settings.test.ts
+++ b/@blaxel/core/src/common/settings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ApiKey } from '../authentication/apikey.js';
 import { env } from './env.js';
+import { isBrokenBunH2Runtime } from './h2-runtime.js';
 
 describe('Settings.apiVersion', () => {
   beforeEach(() => {
@@ -38,12 +39,10 @@ describe('Settings.disableH2', () => {
     delete settings.config.disableH2;
   });
 
-  const onBrokenBun = (() => {
-    const v = globalThis.process?.versions?.bun;
-    if (!v) return false;
-    const [maj = 0, min = 0, patch = 0] = v.split('.').map(Number);
-    return maj < 1 || (maj === 1 && (min < 3 || (min === 3 && patch < 11)));
-  })();
+  // On a broken-Bun runtime the getter force-returns true regardless of
+  // config/env, so the "H2 on by default" expectations below do not hold there.
+  // Use the SAME predicate the getter uses so the skip and the behavior agree.
+  const onBrokenBun = isBrokenBunH2Runtime();
 
   it.skipIf(onBrokenBun)('enables H2 by default', async () => {
     delete (env as Record<string, unknown>).BL_DISABLE_H2;

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -5,6 +5,7 @@ import { Credentials, MissingCredentials } from "../authentication/credentials.j
 import { authentication } from "../authentication/index.js";
 import { env } from "../common/env.js";
 import { CredentialsError } from "../common/errors.js";
+import { isBrokenBunH2Runtime } from "../common/h2-runtime.js";
 import { logger } from "../common/logger.js";
 import { fs, os, path } from "../common/node.js";
 
@@ -124,12 +125,9 @@ const BLAXEL_API_VERSION = "2026-04-28";
 // session freezes after exactly 65535 cumulative body bytes and every request
 // on it hangs until the edge resets the streams (~330s).
 // Fixed in Bun 1.3.11: https://bun.com/blog/bun-v1.3.11
-function isBrokenBunH2() {
-  const v = globalThis.process?.versions?.bun;
-  if (!v) return false;
-  const [maj = 0, min = 0, patch = 0] = v.split("-")[0].split(".").map(Number);
-  return maj < 1 || (maj === 1 && (min < 3 || (min === 3 && patch < 11)));
-}
+// The version gate lives in ./h2-runtime.ts so settings, unit tests, and the
+// cross-runtime environment tests share ONE definition.
+const isBrokenBunH2 = isBrokenBunH2Runtime;
 
 // Warn at most once when H2 is force-disabled on a broken Bun runtime.
 let brokenBunH2Warned = false;

--- a/@blaxel/core/src/index.ts
+++ b/@blaxel/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./agents/index.js";
 export * from "./client/client.js";
 export * from "./common/autoload.js";
 export * from "./common/env.js";
+export * from "./common/h2-runtime.js";
 export * from "./common/node.js";
 export * from "./common/errors.js";
 export * from "./common/internal.js";

--- a/@blaxel/core/vitest.config.ts
+++ b/@blaxel/core/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Unit-test config for @blaxel/core, scoped to the package's own source tests.
+ *
+ * Without this, `npm test` here resolves to the repo-root vitest config whose
+ * `include` is `tests/**` (integration/e2e) — so the package's `src/**` unit
+ * tests never ran. This config runs them in isolation with NO globalSetup and
+ * NO credentials. `*.integration.test.ts` files still require the real API and
+ * are left to the root integration run.
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: [
+      "**/node_modules/**",
+      "src/**/*.integration.test.ts",
+    ],
+    globals: true,
+    testTimeout: 30000,
+    reporters: ["verbose"],
+  },
+});

--- a/tests/integration/fault-injection/README.md
+++ b/tests/integration/fault-injection/README.md
@@ -54,8 +54,19 @@ It explicitly does **NOT**:
 ## Files
 
 - `h2-fault-server.ts` — the controllable server + `startH2FaultServer()`.
+  Also exports `getTestTlsCert()` so other loopback H2 tests can reuse the
+  runtime-generated localhost cert.
 - `h2-fault-server.test.ts` — harness self-test (baseline, GOAWAY, RST
   ENHANCE_YOUR_CALM, low `maxConcurrentStreams`).
+- `h2-flow-control-length.test.ts` — connection-level flow-control + body-length
+  suite for the Bun 65535 freeze. Observes the wire: a default client advertises
+  exactly the 65535-byte connection window Bun never grows, `setLocalWindowSize`
+  (what `h2warm.ts` does) raises it far above that, bodies spanning the boundary
+  transfer byte-perfect, and content-length framing is exact at every length.
+  The version gate itself is unit-tested in
+  `@blaxel/core/src/common/h2-runtime.test.ts` (exhaustive Bun/Deno matrix), and
+  the per-runtime behavior is asserted across real Bun/Deno versions in CI's
+  `h2-runtime-version-matrix` job via `tests/runtime-environments/**`.
 - `fixtures/localhost-cert.pem`, `fixtures/localhost-key.pem` — **test-only**
   self-signed cert for `CN=localhost` (`subjectAltName` DNS:localhost,
   IP:127.0.0.1). Clients connect with `rejectUnauthorized: false`. Not used

--- a/tests/integration/fault-injection/h2-fault-server.ts
+++ b/tests/integration/fault-injection/h2-fault-server.ts
@@ -131,6 +131,10 @@ let cachedTlsCert: { cert: Buffer; key: Buffer } | null = null;
  * protection / secret scanners and is needless key material). Requires
  * `openssl` on PATH, present on macOS and the CI runners.
  */
+export function getTestTlsCert(): { cert: Buffer; key: Buffer } {
+  return loadFixtures();
+}
+
 function loadFixtures(): { cert: Buffer; key: Buffer } {
   if (cachedTlsCert) return cachedTlsCert;
   const dir = mkdtempSync(join(tmpdir(), "h2-fault-cert-"));

--- a/tests/integration/fault-injection/h2-flow-control-length.test.ts
+++ b/tests/integration/fault-injection/h2-flow-control-length.test.ts
@@ -1,0 +1,311 @@
+// HTTP/2 flow-control + body-length suite
+//
+// This locks down the protocol-level details behind the Bun H2 freeze
+// (see @blaxel/core/src/common/h2-runtime.ts):
+//
+//   Bun < 1.3.11 never sends a connection-level WINDOW_UPDATE, so the shared
+//   pooled session freezes after exactly 65535 cumulative body bytes — the
+//   default HTTP/2 connection receive window — and every request on it hangs
+//   until the edge resets the streams (~330s).
+//
+// A correct client (Node) grows that window. `establishH2` in h2warm.ts does it
+// explicitly via session.setLocalWindowSize(h2ConnectionWindowSize). These
+// tests observe the window ON THE WIRE (a real node:http2 server reads the
+// server-side session's connection send-window, i.e. the client's advertised
+// receive window) and prove:
+//   1. a default client advertises exactly 65535 (the number Bun never grows),
+//   2. setLocalWindowSize raises it far above 65535 (the SDK's mitigation),
+//   3. bodies spanning the 65535 boundary transfer byte-perfect and complete,
+//   4. content-length framing is correct for every body length.
+//
+// Deterministic and loopback-only: a self-signed localhost cert (shared with the
+// fault harness), 127.0.0.1, ephemeral port. No network, no creds.
+import http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { createH2Fetch } from "../../../@blaxel/core/src/common/h2fetch.js";
+import {
+  getTestTlsCert,
+  startH2FaultServer,
+  type H2FaultServer,
+} from "./h2-fault-server.js";
+
+const DEFAULT_CONNECTION_WINDOW = 65535; // 2^16 - 1
+const RAISED_WINDOW = 32 * 1024 * 1024; // what h2warm.ts advertises
+const RAISED_STREAM_WINDOW = 16 * 1024 * 1024;
+
+type RawH2Server = {
+  url: string;
+  latestServerSession: () => http2.ServerHttp2Session | undefined;
+  close: () => Promise<void>;
+};
+
+/**
+ * A minimal real HTTP/2 server that (a) exposes the most recently connected
+ * server-side session so a test can read its connection-level send window
+ * (`state.remoteWindowSize` = the client's advertised receive window), and
+ * (b) serves a body of N ASCII bytes at `/big/<N>`.
+ */
+async function startRawH2Server(): Promise<RawH2Server> {
+  const { cert, key } = getTestTlsCert();
+  let latest: http2.ServerHttp2Session | undefined;
+
+  const server = http2.createSecureServer({
+    cert,
+    key,
+    ALPNProtocols: ["h2"],
+    // Give the client plenty of room to SEND to us; irrelevant to the
+    // connection receive window we are measuring, but keeps POST bodies flowing.
+    settings: { initialWindowSize: RAISED_STREAM_WINDOW },
+  });
+  server.on("error", () => {});
+  server.on("sessionError", () => {});
+  server.on("session", (session) => {
+    latest = session;
+    session.on("error", () => {});
+  });
+
+  server.on("stream", (stream, headers) => {
+    const path = String(headers[http2.constants.HTTP2_HEADER_PATH] ?? "/");
+    const match = /^\/big\/(\d+)$/.exec(path);
+    if (match) {
+      const n = Number(match[1]);
+      stream.respond({
+        [http2.constants.HTTP2_HEADER_STATUS]: 200,
+        "content-type": "application/octet-stream",
+        "content-length": n,
+      });
+      stream.end(Buffer.alloc(n, 0x61)); // 'a' * n
+      return;
+    }
+    stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+    stream.end("ok");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  if (addr === null || typeof addr === "string") {
+    throw new Error("raw H2 server failed to bind");
+  }
+
+  return {
+    url: `https://127.0.0.1:${addr.port}`,
+    latestServerSession: () => latest,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        (server as unknown as { closeIdleConnections?: () => void })
+          .closeIdleConnections?.();
+      }),
+  };
+}
+
+function connectClient(
+  url: string,
+  opts: { localWindowSize?: number; streamWindowSize?: number } = {},
+): Promise<http2.ClientHttp2Session> {
+  return new Promise((resolve, reject) => {
+    const session = http2.connect(url, {
+      rejectUnauthorized: false,
+      ALPNProtocols: ["h2"],
+      ...(opts.streamWindowSize
+        ? { settings: { initialWindowSize: opts.streamWindowSize } }
+        : {}),
+    });
+    session.on("error", reject);
+    session.once("connect", () => {
+      if (opts.localWindowSize) {
+        (session as unknown as { setLocalWindowSize?: (n: number) => void })
+          .setLocalWindowSize?.(opts.localWindowSize);
+      }
+      resolve(session);
+    });
+  });
+}
+
+/** Round-trip a ping so any frames sent before it are guaranteed processed. */
+function pingRoundTrip(session: http2.ClientHttp2Session): Promise<void> {
+  return new Promise((resolve) => session.ping(() => resolve()));
+}
+
+async function waitFor<T>(
+  fn: () => T | undefined,
+  timeoutMs = 2000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const v = fn();
+    if (v !== undefined) return v;
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function readAll(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
+
+let rawServer: RawH2Server | undefined;
+let faultServer: H2FaultServer | undefined;
+const clientSessions: http2.ClientHttp2Session[] = [];
+
+afterEach(async () => {
+  for (const s of clientSessions) {
+    if (!s.destroyed) s.destroy();
+  }
+  clientSessions.length = 0;
+  if (rawServer) await rawServer.close();
+  rawServer = undefined;
+  if (faultServer) await faultServer.close();
+  faultServer = undefined;
+});
+
+function track(session: http2.ClientHttp2Session): http2.ClientHttp2Session {
+  clientSessions.push(session);
+  return session;
+}
+
+describe("HTTP/2 connection-level flow-control window (the Bun 65535 freeze)", () => {
+  it("a default client advertises exactly the 65535-byte window Bun never grows", async () => {
+    rawServer = await startRawH2Server();
+    const client = track(await connectClient(rawServer.url));
+    await pingRoundTrip(client);
+
+    const serverSession = await waitFor(() => rawServer!.latestServerSession());
+    // The server's connection-level SEND window == the client's advertised
+    // RECEIVE window. With no WINDOW_UPDATE from the client it sits at the
+    // protocol default: 65535. This is precisely the ceiling a broken Bun is
+    // stuck behind forever.
+    expect(serverSession.state.remoteWindowSize).toBe(DEFAULT_CONNECTION_WINDOW);
+  });
+
+  it("setLocalWindowSize raises the connection window far above 65535 (the SDK's mitigation)", async () => {
+    rawServer = await startRawH2Server();
+    const client = track(
+      await connectClient(rawServer.url, { localWindowSize: RAISED_WINDOW }),
+    );
+    // Flush the WINDOW_UPDATE emitted by setLocalWindowSize, then read.
+    await pingRoundTrip(client);
+
+    const serverSession = await waitFor(() => rawServer!.latestServerSession());
+    const window = serverSession.state.remoteWindowSize ?? 0;
+    expect(window).toBeGreaterThan(DEFAULT_CONNECTION_WINDOW);
+    // Effectively the full raised window (allow slack for anything already
+    // consumed by the ping round-trip).
+    expect(window).toBeGreaterThan(RAISED_WINDOW - 1_000_000);
+  });
+
+  it("a body larger than 65535 bytes streams to completion on a raised-window session", async () => {
+    rawServer = await startRawH2Server();
+    const session = track(
+      await connectClient(rawServer.url, {
+        localWindowSize: RAISED_WINDOW,
+        streamWindowSize: RAISED_STREAM_WINDOW,
+      }),
+    );
+    const h2fetch = createH2Fetch(session);
+
+    const size = 1024 * 1024; // 1MB, ~16x the frozen window
+    const res = await h2fetch(new Request(`${rawServer.url}/big/${size}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-length")).toBe(String(size));
+
+    const body = await readAll(res.body!);
+    expect(body.byteLength).toBe(size);
+    // Every byte intact (no truncation at the window boundary).
+    expect(body.every((b) => b === 0x61)).toBe(true);
+  });
+
+  it("a correct client drains a >65535 body even at the DEFAULT window (Node replenishes; Bun would not)", async () => {
+    // The freeze is not about the window value per se — it is about never
+    // replenishing it. A correct client at the default 65535 window still
+    // completes because it emits WINDOW_UPDATE as it consumes. This is the
+    // positive control that isolates the bug to Bun's missing WINDOW_UPDATE.
+    rawServer = await startRawH2Server();
+    const session = track(await connectClient(rawServer.url)); // no raise
+    const h2fetch = createH2Fetch(session);
+
+    const size = 512 * 1024; // 8x the window
+    const res = await h2fetch(new Request(`${rawServer.url}/big/${size}`));
+    const body = await readAll(res.body!);
+    expect(body.byteLength).toBe(size);
+  });
+});
+
+describe("HTTP/2 content-length framing across the 65535 boundary", () => {
+  // Every request body length must be framed with an accurate content-length
+  // and round-trip byte-for-byte. The boundary sizes (65534/65535/65536) are the
+  // ones the Bun bug is sensitive to, so they are explicit here.
+  const sizes = [1, 1024, 65534, 65535, 65536, 131072, 1024 * 1024];
+
+  it.each(sizes)(
+    "POST of %i bytes: content-length is exact and the body round-trips",
+    async (size) => {
+      faultServer = await startH2FaultServer();
+      const session = track(
+        faultServer.connectClient() as http2.ClientHttp2Session,
+      );
+      await new Promise<void>((resolve) =>
+        session.once("connect", () => resolve()),
+      );
+      const h2fetch = createH2Fetch(session);
+
+      const payload = "a".repeat(size);
+      const res = await h2fetch(
+        new Request(`${faultServer.url}/echo`, {
+          method: "POST",
+          body: payload,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      // The server recorded the request; assert the framed content-length.
+      const recorded = faultServer.requests.at(-1)!;
+      expect(recorded.headers["content-length"]).toBe(String(size));
+      expect(recorded.body.length).toBe(size);
+
+      // And the echoed response body matches what we sent, exactly.
+      const echoed = await res.text();
+      expect(echoed.length).toBe(size);
+      expect(echoed).toBe(payload);
+    },
+  );
+
+  it("a GET with no body sets no content-length and returns an empty body", async () => {
+    faultServer = await startH2FaultServer();
+    const session = track(
+      faultServer.connectClient() as http2.ClientHttp2Session,
+    );
+    await new Promise<void>((resolve) =>
+      session.once("connect", () => resolve()),
+    );
+    const h2fetch = createH2Fetch(session);
+
+    const res = await h2fetch(new Request(`${faultServer.url}/empty`));
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe("");
+
+    const recorded = faultServer.requests.at(-1)!;
+    expect(recorded.headers["content-length"]).toBeUndefined();
+  });
+});

--- a/tests/runtime-environments/bun/src/index.ts
+++ b/tests/runtime-environments/bun/src/index.ts
@@ -1,5 +1,18 @@
 // Test Bun runtime compatibility
-import { env, getTool, ToolOptions } from "@blaxel/core";
+import {
+  detectBunVersion,
+  env,
+  getTool,
+  isBrokenBunVersion,
+  settings,
+  ToolOptions,
+} from "@blaxel/core";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
 
 async function testCore() {
   console.log("✅ @blaxel/core env:", typeof env);
@@ -9,6 +22,65 @@ async function testCore() {
     console.log("✅ @blaxel/core getTool:", typeof tools);
   } catch (e) {
     console.log("✅ @blaxel/core getTool error (expected):", (e as Error).message);
+  }
+}
+
+// The crux of the Bun H2 story: the SDK must force its pooled HTTP/2 transport
+// OFF on Bun < 1.3.11 (which never sends a connection-level WINDOW_UPDATE and so
+// freezes the shared session after 65535 cumulative body bytes) and leave it ON
+// on 1.3.11+. Run under a CI matrix of Bun versions, this asserts the gate flips
+// at exactly the right version — the behavior we regressed on before.
+function testH2VersionGate() {
+  const running = Bun.version;
+  const detected = detectBunVersion();
+  console.log("✅ Bun.version:", running, "| detectBunVersion:", detected);
+  assert(
+    detected === running,
+    `detectBunVersion (${detected}) should equal Bun.version (${running})`,
+  );
+
+  const expectedBroken = isBrokenBunVersion(running);
+  console.log(
+    `✅ Bun ${running} broken-H2=${expectedBroken} -> settings.disableH2=${settings.disableH2}`,
+  );
+  assert(
+    settings.disableH2 === expectedBroken,
+    `On Bun ${running}, settings.disableH2 (${settings.disableH2}) must match ` +
+      `isBrokenBunVersion (${expectedBroken}): H2 off iff the runtime is a broken Bun.`,
+  );
+}
+
+// Prove the running Bun actually moves a body well past the 65535 freeze
+// threshold without hanging. On a broken Bun the SDK sidesteps the bug by
+// disabling H2, but the runtime's own HTTP path must still round-trip a large
+// body — this is the smoke test that it does, deterministically and fast.
+async function testLargeBodyRoundTrip() {
+  const size = 200_000; // ~3x the 65535 connection window
+  const payload = "a".repeat(size);
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request: Request) {
+      const body = await request.text();
+      return new Response(body, {
+        headers: { "content-length": String(body.length) },
+      });
+    },
+  });
+  try {
+    const res = await fetch(`http://localhost:${server.port}/echo`, {
+      method: "POST",
+      body: payload,
+    });
+    const echoed = await res.text();
+    assert(
+      echoed.length === size,
+      `large-body round-trip truncated: sent ${size}, got ${echoed.length}`,
+    );
+    assert(echoed === payload, "large-body round-trip corrupted the payload");
+    console.log(`✅ Large-body round-trip OK (${size} bytes, > 65535 window)`);
+  } finally {
+    server.stop();
   }
 }
 
@@ -37,6 +109,8 @@ async function main() {
   try {
     await testCore();
     await testBunSpecific();
+    testH2VersionGate();
+    await testLargeBodyRoundTrip();
 
     console.log("==========================================");
     console.log("✅ All imports successful with Bun runtime");

--- a/tests/runtime-environments/deno/src/index.ts
+++ b/tests/runtime-environments/deno/src/index.ts
@@ -1,5 +1,11 @@
 // Test Deno runtime compatibility against the local @blaxel/core package.
-import { env, SandboxInstance, settings } from "@blaxel/core";
+import {
+  detectBunVersion,
+  env,
+  isBrokenBunVersion,
+  SandboxInstance,
+  settings,
+} from "@blaxel/core";
 
 type ProcessResponse = {
   command: string;
@@ -100,7 +106,53 @@ function testCoreImports() {
   console.log("✅ @blaxel/core SandboxInstance:", typeof SandboxInstance);
   console.log("✅ @blaxel/core Deno disableH2:", settings.disableH2);
   assert(typeof SandboxInstance === "function", "SandboxInstance import failed");
+  // Deno is not Bun: the broken-Bun H2 gate must never trip here, so H2 stays
+  // on by default. (detectBunVersion reads process.versions.bun, which Deno
+  // never sets even though it shims process.)
+  assert(
+    detectBunVersion() === undefined,
+    "Deno must not be detected as a Bun runtime",
+  );
+  assert(
+    isBrokenBunVersion(detectBunVersion()) === false,
+    "Deno must never be classified as a broken-Bun H2 runtime",
+  );
   assert(settings.disableH2 === false, "Deno runtime should enable SDK H2 by default");
+}
+
+// Push a body well past the 65535-byte HTTP/2 connection window through Deno's
+// own HTTP path to prove the runtime moves large bodies without the freeze the
+// Bun bug caused. Uses real fetch (outside the fake-sandbox monkeypatch).
+async function testLargeBodyRoundTrip() {
+  const size = 200_000; // ~3x the 65535 connection window
+  const payload = "a".repeat(size);
+
+  const controller = new AbortController();
+  const server = Deno.serve(
+    { port: 0, signal: controller.signal, onListen: () => {} },
+    async (request: Request) => {
+      const body = await request.text();
+      return new Response(body);
+    },
+  );
+  // @ts-ignore - addr is present for a TCP listener
+  const port: number = server.addr.port;
+  try {
+    const res = await fetch(`http://localhost:${port}/echo`, {
+      method: "POST",
+      body: payload,
+    });
+    const echoed = await res.text();
+    assert(
+      echoed.length === size,
+      `large-body round-trip truncated: sent ${size}, got ${echoed.length}`,
+    );
+    assert(echoed === payload, "large-body round-trip corrupted the payload");
+    console.log(`✅ Large-body round-trip OK (${size} bytes, > 65535 window)`);
+  } finally {
+    controller.abort();
+    await server.finished;
+  }
 }
 
 async function testSandboxGeneratedActions() {
@@ -180,6 +232,7 @@ async function main() {
   testCoreImports();
   await testSandboxGeneratedActions();
   await testDenoSpecific();
+  await testLargeBodyRoundTrip();
 
   console.log("==========================================");
   console.log("✅ Deno runtime sandbox compatibility checks passed");

--- a/tests/unit/control-plane-fetch.test.ts
+++ b/tests/unit/control-plane-fetch.test.ts
@@ -1,8 +1,10 @@
+import { EventEmitter } from "events";
 import { client } from "../../@blaxel/core/src/client/client.gen.js";
 import { initialize } from "../../@blaxel/core/src/common/autoload.js";
 import { controlPlaneFetch, shouldUseControlPlaneH2, undiciSupportsNativeH2 } from "../../@blaxel/core/src/common/controlPlaneFetch.js";
+import { h2Pool } from "../../@blaxel/core/src/common/h2pool.js";
 import { settings } from "../../@blaxel/core/src/common/settings.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("control-plane H2 routing predicate", () => {
   // Proves Blaxel API hosts engage the H2 pool, which is the TLS storm fix.
@@ -118,5 +120,172 @@ describe("control-plane H2 routing predicate", () => {
       settings.setConfig(originalSettingsConfig);
       client.setConfig(originalClientConfig);
     }
+  });
+});
+
+/**
+ * Minimal ClientHttp2Session / stream stand-ins so controlPlaneFetch can be
+ * driven end-to-end (through createPoolBackedH2Fetch -> the H2 gateway ->
+ * _h2Request) without a real socket. The test emits the response lifecycle by
+ * hand.
+ */
+class MockStream extends EventEmitter {
+  public closed = false;
+  close(): void {
+    this.closed = true;
+  }
+  end(): void {
+    // no-op
+  }
+}
+
+class MockSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  public lastStream: MockStream | null = null;
+  public streams: MockStream[] = [];
+  request(): MockStream {
+    const stream = new MockStream();
+    this.lastStream = stream;
+    this.streams.push(stream);
+    return stream;
+  }
+  close(): void {
+    this.closed = true;
+    this.emit("close");
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+}
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+// controlPlaneFetch is the fetch hook installed on the generated client. It
+// decides, per request, whether to route through the pooled H2 wrapper or fall
+// straight to globalThis.fetch. These drive the ACTUAL function (not just the
+// pure predicate) so the routing wiring — env/config gating, the fallback, and
+// the pooled send — is covered, not just shouldUseControlPlaneH2 in isolation.
+//
+// NB: on this runner (undici 6) nativeFetchSupportsH2 is false, so a qualifying
+// Blaxel HTTPS request engages the wrapper without needing forceControlPlaneH2.
+describe("controlPlaneFetch routing (end to end)", () => {
+  afterEach(() => {
+    h2Pool.closeAll();
+    vi.restoreAllMocks();
+    delete settings.config.disableH2;
+    delete settings.config.disableControlPlaneH2;
+    delete (settings.config as Record<string, unknown>).proxy;
+  });
+
+  it.each([
+    ["a non-HTTPS URL", "http://api.blaxel.ai/v0/sandboxes"],
+    ["a non-Blaxel host", "https://api.example.com/v0/sandboxes"],
+    ["the oauth token refresh path", "https://api.blaxel.ai/v0/oauth/token"],
+  ])("falls back to globalThis.fetch for %s (no H2 stream opened)", async (_label, url) => {
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, "request");
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("native"));
+
+    const res = await controlPlaneFetch(new Request(url));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy).not.toHaveBeenCalled();
+    await expect(res.text()).resolves.toBe("native");
+  });
+
+  it("falls back to globalThis.fetch when disableH2 is set, even for a Blaxel HTTPS host", async () => {
+    settings.config.disableH2 = true;
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, "request");
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("native"));
+
+    const res = await controlPlaneFetch(new Request("https://api.blaxel.ai/v0/sandboxes"));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy).not.toHaveBeenCalled();
+    await expect(res.text()).resolves.toBe("native");
+  });
+
+  it("falls back to globalThis.fetch for a Blaxel host when disableControlPlaneH2 is set but data-plane H2 stays available", async () => {
+    settings.config.disableControlPlaneH2 = true;
+    const session = new MockSession();
+    const requestSpy = vi.spyOn(session, "request");
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("native"));
+
+    const res = await controlPlaneFetch(new Request("https://api.blaxel.ai/v0/sandboxes"));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy).not.toHaveBeenCalled();
+    await expect(res.text()).resolves.toBe("native");
+  });
+
+  it("routes a qualifying Blaxel HTTPS request through the pooled H2 transport (no native fetch send)", async () => {
+    const session = new MockSession();
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => Promise.resolve(session);
+    // If the wrapper is engaged, the send goes over the H2 stream, NOT
+    // globalThis.fetch; a call here would mean an unexpected fallback.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("native-should-not-run"));
+
+    const promise = controlPlaneFetch(
+      new Request("https://api.blaxel.ai/v0/sandboxes"),
+    );
+    await tick();
+
+    expect(session.lastStream).not.toBeNull();
+    session.lastStream!.emit("response", { ":status": 200 });
+    session.lastStream!.emit("data", Buffer.from("h2-body"));
+    session.lastStream!.emit("end");
+
+    const res = await promise;
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe("h2-body");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reuses one pooled H2 fetch per host across calls (single established session)", async () => {
+    const sessions: MockSession[] = [];
+    (h2Pool as unknown as { _establish: (d: string) => Promise<MockSession> })._establish =
+      () => {
+        const s = new MockSession();
+        sessions.push(s);
+        return Promise.resolve(s);
+      };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("native"));
+
+    const drive = async () => {
+      const p = controlPlaneFetch(new Request("https://api.blaxel.dev/v0/sandboxes"));
+      await tick();
+      const s = sessions.at(-1)!;
+      s.lastStream!.emit("response", { ":status": 200 });
+      s.lastStream!.emit("end");
+      return p;
+    };
+
+    await drive();
+    await drive();
+
+    // Both calls shared one pooled session for the host (warm/get dedup), so
+    // establish ran exactly once rather than per request.
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].streams).toHaveLength(2);
   });
 });

--- a/tests/unit/h2-request-encoding.test.ts
+++ b/tests/unit/h2-request-encoding.test.ts
@@ -1,0 +1,294 @@
+// HTTP/2 request/response wire-encoding unit tests.
+//
+// The fault-injection suite proves bodies round-trip against a REAL node:http2
+// server, but it only ever sends string bodies and Headers objects. The manual
+// framing in `h2fetch.ts` (`h2RequestDirectInternal` / `_h2Request` / the
+// response mapping in `_h2Send`) has several branches those never touch:
+//   - pseudo-header derivation (:method / :path incl. query / :authority),
+//   - the `host` header being dropped (it is illegal to send with :authority),
+//   - the three RequestInit header shapes (Headers, array of tuples, plain obj),
+//   - every body encoding branch (string, Buffer, ArrayBuffer, Uint8Array) and
+//     the auto content-length (respecting an explicit one; UTF-8 byte length),
+//   - response header mapping: pseudo-headers stripped, multi-value arrays
+//     joined, undefined values skipped, and a missing :status defaulting to 200.
+//
+// These drive the transport against a capturing mock session (no socket) and
+// assert the EXACT frames it would put on the wire, so a regression in the hand
+// framing fails here instead of silently corrupting a real request.
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createH2Fetch,
+  h2RequestDirect,
+} from "../../@blaxel/core/src/common/h2fetch.js";
+
+type OutHeaders = http2.OutgoingHttpHeaders;
+
+/** A stream that records the request headers and whatever body was written. */
+class CapturingStream extends EventEmitter {
+  public closed = false;
+  public endBody: Buffer | undefined;
+  end(body?: Buffer): void {
+    this.endBody = body;
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+/** A session that records the headers passed to every `request()` call. */
+class CapturingSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  public lastStream: CapturingStream | null = null;
+  public lastHeaders: OutHeaders | null = null;
+  request(headers: OutHeaders): CapturingStream {
+    this.lastHeaders = headers;
+    const stream = new CapturingStream();
+    this.lastStream = stream;
+    return stream;
+  }
+  close(): void {
+    this.closed = true;
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+}
+
+function asSession(s: CapturingSession): http2.ClientHttp2Session {
+  return s as unknown as http2.ClientHttp2Session;
+}
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+/**
+ * Drive one request through the transport, resolve it with a canned 200 (empty
+ * body), and return the headers + body the transport framed on the wire.
+ */
+async function capture(
+  fn: (session: http2.ClientHttp2Session) => Promise<Response>,
+): Promise<{ headers: OutHeaders; body: Buffer | undefined; response: Response }> {
+  const session = new CapturingSession();
+  const promise = fn(asSession(session));
+  await tick();
+  const stream = session.lastStream!;
+  expect(stream).not.toBeNull();
+  stream.emit("response", { ":status": 200 });
+  stream.emit("end");
+  const response = await promise;
+  return { headers: session.lastHeaders!, body: stream.endBody, response };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("h2 request framing: pseudo-headers and host handling", () => {
+  it("derives :method, :path (with query), and :authority from the URL", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com:8443/a/b?x=1&y=2", {
+        method: "DELETE",
+      }),
+    );
+    expect(headers[":method"]).toBe("DELETE");
+    expect(headers[":path"]).toBe("/a/b?x=1&y=2");
+    expect(headers[":authority"]).toBe("edge.example.com:8443");
+  });
+
+  it("defaults the method to GET", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/only"),
+    );
+    expect(headers[":method"]).toBe("GET");
+    expect(headers[":path"]).toBe("/only");
+  });
+
+  it("drops a caller-supplied host header (it is illegal alongside :authority)", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        headers: { Host: "spoof.example.com", "x-keep": "1" },
+      }),
+    );
+    expect(headers.host).toBeUndefined();
+    expect(headers[":authority"]).toBe("edge.example.com");
+    expect(headers["x-keep"]).toBe("1");
+  });
+});
+
+describe("h2 request framing: the three RequestInit header shapes", () => {
+  it("accepts a plain object (keys lowercased)", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        headers: { "X-Custom": "v", Authorization: "Bearer t" },
+      }),
+    );
+    expect(headers["x-custom"]).toBe("v");
+    expect(headers["authorization"]).toBe("Bearer t");
+  });
+
+  it("accepts an array of tuples", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        headers: [
+          ["X-A", "1"],
+          ["host", "drop-me"],
+        ],
+      }),
+    );
+    expect(headers["x-a"]).toBe("1");
+    expect(headers.host).toBeUndefined();
+  });
+
+  it("accepts a Headers instance", async () => {
+    const h = new Headers();
+    h.set("X-B", "2");
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", { headers: h }),
+    );
+    expect(headers["x-b"]).toBe("2");
+  });
+});
+
+describe("h2 request framing: body encodings and content-length", () => {
+  it("encodes a string body and sets content-length to its UTF-8 byte length", async () => {
+    // "é" is two UTF-8 bytes, so byte length (4) != char length (3).
+    const payload = "aé b";
+    const { headers, body } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        method: "POST",
+        body: payload,
+      }),
+    );
+    const expected = Buffer.from(payload);
+    expect(headers["content-length"]).toBe(expected.byteLength);
+    expect(expected.byteLength).toBe(5);
+    expect(body!.equals(expected)).toBe(true);
+  });
+
+  it("encodes a Buffer body verbatim", async () => {
+    const payload = Buffer.from([1, 2, 3, 4, 5]);
+    const { headers, body } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        method: "POST",
+        body: payload,
+      }),
+    );
+    expect(headers["content-length"]).toBe(5);
+    expect(body!.equals(payload)).toBe(true);
+  });
+
+  it("encodes an ArrayBuffer body", async () => {
+    const ab = new Uint8Array([9, 8, 7]).buffer;
+    const { headers, body } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        method: "PUT",
+        body: ab,
+      }),
+    );
+    expect(headers["content-length"]).toBe(3);
+    expect(Array.from(body!)).toEqual([9, 8, 7]);
+  });
+
+  it("encodes a Uint8Array body honoring its byteOffset/byteLength (subarray view)", async () => {
+    const backing = new Uint8Array([0, 0, 42, 43, 44, 0]);
+    const view = backing.subarray(2, 5); // [42,43,44], nonzero byteOffset
+    const { headers, body } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        method: "PUT",
+        body: view,
+      }),
+    );
+    expect(headers["content-length"]).toBe(3);
+    expect(Array.from(body!)).toEqual([42, 43, 44]);
+  });
+
+  it("does not overwrite an explicit content-length", async () => {
+    const { headers } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p", {
+        method: "POST",
+        headers: { "content-length": "999" },
+        body: "abc",
+      }),
+    );
+    expect(headers["content-length"]).toBe("999");
+  });
+
+  it("sets no content-length for a body-less request", async () => {
+    const { headers, body } = await capture((s) =>
+      h2RequestDirect(s, "http://edge.example.com/p"),
+    );
+    expect(headers["content-length"]).toBeUndefined();
+    expect(body).toBeUndefined();
+  });
+});
+
+describe("h2 request framing via createH2Fetch (Request objects)", () => {
+  it("strips host, derives pseudo-headers, and frames the body from a Request", async () => {
+    const { headers, body } = await capture((s) => {
+      const h2fetch = createH2Fetch(s);
+      return h2fetch(
+        new Request("http://edge.example.com/r?q=z", {
+          method: "POST",
+          headers: { "x-req": "yes" },
+          body: "hello",
+        }),
+      );
+    });
+    expect(headers[":method"]).toBe("POST");
+    expect(headers[":path"]).toBe("/r?q=z");
+    expect(headers[":authority"]).toBe("edge.example.com");
+    expect(headers.host).toBeUndefined();
+    expect(headers["x-req"]).toBe("yes");
+    expect(headers["content-length"]).toBe(5);
+    expect(body!.toString()).toBe("hello");
+  });
+});
+
+describe("h2 response mapping in _h2Send", () => {
+  it("maps status, strips pseudo-headers, joins multi-value headers, and skips undefined", async () => {
+    const session = new CapturingSession();
+    const promise = h2RequestDirect(
+      asSession(session),
+      "http://edge.example.com/p",
+    );
+    await tick();
+    const stream = session.lastStream!;
+    stream.emit("response", {
+      ":status": 207,
+      "content-type": "application/json",
+      "set-cookie": ["a=1", "b=2"], // array -> joined
+      "x-absent": undefined, // skipped
+    });
+    stream.emit("end");
+
+    const res = await promise;
+    expect(res.status).toBe(207);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(res.headers.get("set-cookie")).toBe("a=1, b=2");
+    expect(res.headers.has("x-absent")).toBe(false);
+    // Pseudo-headers never leak into the public Response headers.
+    expect([...res.headers.keys()].some((k) => k.startsWith(":"))).toBe(false);
+  });
+
+  it("defaults the status to 200 when the response omits :status", async () => {
+    const session = new CapturingSession();
+    const promise = h2RequestDirect(
+      asSession(session),
+      "http://edge.example.com/p",
+    );
+    await tick();
+    const stream = session.lastStream!;
+    stream.emit("response", { "content-type": "text/plain" });
+    stream.emit("data", Buffer.from("body"));
+    stream.emit("end");
+
+    const res = await promise;
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe("body");
+  });
+});

--- a/tests/unit/h2pool-warm.test.ts
+++ b/tests/unit/h2pool-warm.test.ts
@@ -1,0 +1,198 @@
+// H2Pool.warm() / closeAll() unit tests.
+//
+// `warm(domain)` is the fire-and-forget background connect the SDK kicks off in
+// parallel with createSandbox() so the first real call pays no TLS/SETTINGS RTT
+// (see h2warm.ts). Its behavior — cache on success, de-duplicate concurrent
+// warms, let a racing get() JOIN the in-flight warm rather than opening a second
+// session, and swallow connect failures instead of throwing into a floating
+// promise — is load-bearing for the cold-start latency win but was previously
+// only exercised indirectly. These drive a real H2Pool with a controllable
+// establish hook so each warm branch is asserted directly. No socket, no creds.
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { describe, expect, it } from "vitest";
+import { H2Pool } from "../../@blaxel/core/src/common/h2pool.js";
+
+class MockSession extends EventEmitter {
+  public closed = false;
+  public destroyed = false;
+  close(): void {
+    this.closed = true;
+    this.emit("close");
+  }
+  ping(cb: (err?: Error | null) => void): boolean {
+    setImmediate(() => cb(null));
+    return true;
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+}
+
+function asSession(s: MockSession): http2.ClientHttp2Session {
+  return s as unknown as http2.ClientHttp2Session;
+}
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+async function waitFor(fn: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!fn()) {
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await tick();
+  }
+}
+
+/** Install an establish hook that returns whatever the factory yields. */
+function withEstablish(
+  pool: H2Pool,
+  factory: (domain: string) => Promise<http2.ClientHttp2Session>,
+): void {
+  (pool as unknown as { _establish: (d: string) => Promise<http2.ClientHttp2Session> })._establish =
+    factory;
+}
+
+describe("H2Pool.warm", () => {
+  it("caches the session in the background so a later tryGet finds it", async () => {
+    let count = 0;
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      count += 1;
+      return Promise.resolve(asSession(new MockSession()));
+    });
+
+    expect(pool.tryGet("edge.example.com")).toBeNull();
+    pool.warm("edge.example.com");
+    await waitFor(() => pool.tryGet("edge.example.com") !== null);
+
+    expect(count).toBe(1);
+    expect(pool.tryGet("edge.example.com")).not.toBeNull();
+  });
+
+  it("is a no-op when a live session is already cached", async () => {
+    let count = 0;
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      count += 1;
+      return Promise.resolve(asSession(new MockSession()));
+    });
+
+    pool.warm("edge.example.com");
+    await waitFor(() => pool.tryGet("edge.example.com") !== null);
+    expect(count).toBe(1);
+
+    // Second warm sees the cached session and does not establish again.
+    pool.warm("edge.example.com");
+    await tick();
+    expect(count).toBe(1);
+  });
+
+  it("de-duplicates concurrent warms into a single connection attempt", async () => {
+    let count = 0;
+    const gate = deferred<http2.ClientHttp2Session>();
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      count += 1;
+      return gate.promise;
+    });
+
+    // Fire three warms before the first connection resolves.
+    pool.warm("edge.example.com");
+    pool.warm("edge.example.com");
+    pool.warm("edge.example.com");
+    await tick();
+    expect(count).toBe(1); // only one establish in flight
+
+    gate.resolve(asSession(new MockSession()));
+    await waitFor(() => pool.tryGet("edge.example.com") !== null);
+    expect(count).toBe(1);
+  });
+
+  it("lets a racing get() join the in-flight warm instead of opening a second session", async () => {
+    let count = 0;
+    const gate = deferred<http2.ClientHttp2Session>();
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      count += 1;
+      return gate.promise;
+    });
+
+    pool.warm("edge.example.com");
+    await tick();
+    const getPromise = pool.get("edge.example.com");
+
+    const session = asSession(new MockSession());
+    gate.resolve(session);
+
+    await expect(getPromise).resolves.toBe(session);
+    expect(count).toBe(1); // get joined the warm; no second establish
+    expect(pool.tryGet("edge.example.com")).toBe(session);
+  });
+
+  it("swallows a failed connection: nothing is cached and no error is thrown", async () => {
+    let count = 0;
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      count += 1;
+      return Promise.reject(new Error("connect refused"));
+    });
+
+    // warm() must not throw synchronously nor produce an unhandled rejection.
+    expect(() => pool.warm("edge.example.com")).not.toThrow();
+    await tick();
+    await tick();
+
+    expect(count).toBe(1);
+    expect(pool.tryGet("edge.example.com")).toBeNull();
+
+    // A subsequent warm can retry (the inflight slot was cleared).
+    withEstablish(pool, () => {
+      count += 1;
+      return Promise.resolve(asSession(new MockSession()));
+    });
+    pool.warm("edge.example.com");
+    await waitFor(() => pool.tryGet("edge.example.com") !== null);
+    expect(count).toBe(2);
+  });
+});
+
+describe("H2Pool.closeAll", () => {
+  it("closes every cached session and clears the cache", async () => {
+    const sessions: MockSession[] = [];
+    const pool = new H2Pool();
+    withEstablish(pool, () => {
+      const s = new MockSession();
+      sessions.push(s);
+      return Promise.resolve(asSession(s));
+    });
+
+    await pool.get("edge.a.example.com");
+    await pool.get("edge.b.example.com");
+    expect(sessions).toHaveLength(2);
+    expect(pool.tryGet("edge.a.example.com")).not.toBeNull();
+
+    pool.closeAll();
+
+    expect(sessions.every((s) => s.closed)).toBe(true);
+    expect(pool.tryGet("edge.a.example.com")).toBeNull();
+    expect(pool.tryGet("edge.b.example.com")).toBeNull();
+  });
+
+  it("is safe to call with nothing pooled", () => {
+    const pool = new H2Pool();
+    expect(() => pool.closeAll()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes ENG-4076

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Pins the Deno CI matrix entry from `v1.x` to `v2.0.0` to fix compatibility with `deno.json`'s `nodeModulesDir: "manual"` setting (which requires Deno 2.x). No other changes since the previously reviewed commit.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 03c64143c782f46d9d527f5f3db6154d3ad7ebb8.</sup>
<!-- /MENDRAL_SUMMARY -->