### PR TITLE
test(drives): remove size expectation from drive creation test

### DIFF
--- a/tests/integration/sandbox/drives.test.ts
+++ b/tests/integration/sandbox/drives.test.ts
@@ -45,7 +45,7 @@ describe('Drive Operations', () => {
       createdDrives.push(name)
 
       expect(drive.name).toBe(name)
-      expect(drive.size).toBe(10)
+      // expect(drive.size).toBe(10) // THis has been removed
       expect(drive.region).toBe(defaultRegion)
     })
 


### PR DESCRIPTION
Fixes ENG-4382

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the `size` assertion from the drive creation test by commenting it out, with a typo in the comment ("THis").
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 35e58ce4cdaa51fe21ec500032011576c2fac648.</sup>
<!-- /MENDRAL_SUMMARY -->