### PR TITLE
fix(h2): dedupe concurrent idle validation (ENG-3017)

### DIFF
--- a/@blaxel/core/src/common/h2pool.ts
+++ b/@blaxel/core/src/common/h2pool.ts
@@ -2,6 +2,7 @@ import type http2 from "http2";
 
 type EstablishFn = (hostname: string) => Promise<http2.ClientHttp2Session>;
 type NowFn = () => number;
+type PingResult = "alive" | "failed" | "unsent";
 
 type H2PoolEntry = {
   session: http2.ClientHttp2Session;
@@ -28,6 +29,10 @@ const DEFAULT_PING_TIMEOUT_MS = 500;
 export class H2Pool {
   private sessions = new Map<string, H2PoolEntry>();
   private inflight = new Map<string, Promise<http2.ClientHttp2Session | null>>();
+  private validations = new Map<string, {
+    session: http2.ClientHttp2Session;
+    result: Promise<PingResult>;
+  }>();
   private _establish: EstablishFn | null = null;
   private readonly maxIdleMs: number;
   private readonly pingTimeoutMs: number;
@@ -106,29 +111,46 @@ export class H2Pool {
     }
   }
 
-  private ping(session: http2.ClientHttp2Session): Promise<boolean> {
-    if (this.isClosed(session)) return Promise.resolve(false);
+  private ping(session: http2.ClientHttp2Session): Promise<PingResult> {
+    if (this.isClosed(session)) return Promise.resolve("failed");
 
-    return new Promise<boolean>((resolve) => {
+    return new Promise<PingResult>((resolve) => {
       let settled = false;
-      const finish = (ok: boolean) => {
+      const finish = (result: PingResult) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        resolve(ok);
+        resolve(result);
       };
 
-      const timer = setTimeout(() => finish(false), this.pingTimeoutMs);
+      const timer = setTimeout(() => finish("failed"), this.pingTimeoutMs);
 
       try {
         const sent = session.ping((err?: Error | null) => {
-          finish(!err && !this.isClosed(session));
+          finish(!err && !this.isClosed(session) ? "alive" : "failed");
         });
-        if (!sent) finish(false);
+        // `false` means Node did not send the ping, not that the session failed.
+        if (!sent) finish("unsent");
       } catch {
-        finish(false);
+        finish("failed");
       }
     });
+  }
+
+  private validateSession(
+    domain: string,
+    session: http2.ClientHttp2Session,
+  ): Promise<PingResult> {
+    const existing = this.validations.get(domain);
+    if (existing?.session === session) return existing.result;
+
+    const result = this.ping(session).finally(() => {
+      if (this.validations.get(domain)?.result === result) {
+        this.validations.delete(domain);
+      }
+    });
+    this.validations.set(domain, { session, result });
+    return result;
   }
 
   private async validateEntry(
@@ -145,9 +167,10 @@ export class H2Pool {
       this.markUsed(domain, session);
       return session;
     }
-    if (await this.ping(session)) {
-      // ENG-2676 generation/identity pin: `await this.ping` yields, and during
-      // that await an eviction listener (goaway/error/close ->
+    const pingResult = await this.validateSession(domain, session);
+    if (pingResult !== "failed" && !this.isClosed(session)) {
+      // ENG-2676 generation/identity pin: validation yields, and during that
+      // await an eviction listener (goaway/error/close ->
       // attachEvictionListeners, see above) may have deleted or replaced this
       // entry. `entry` is the exact object held in the map, so if it is no
       // longer the cached generation, refuse the now-stale session instead of
@@ -250,6 +273,7 @@ export class H2Pool {
     }
     this.sessions.clear();
     this.inflight.clear();
+    this.validations.clear();
   }
 }
 

--- a/@blaxel/core/src/common/h2pool.ts
+++ b/@blaxel/core/src/common/h2pool.ts
@@ -2,7 +2,6 @@ import type http2 from "http2";
 
 type EstablishFn = (hostname: string) => Promise<http2.ClientHttp2Session>;
 type NowFn = () => number;
-type PingResult = "alive" | "failed" | "unsent";
 
 type H2PoolEntry = {
   session: http2.ClientHttp2Session;
@@ -31,7 +30,7 @@ export class H2Pool {
   private inflight = new Map<string, Promise<http2.ClientHttp2Session | null>>();
   private validations = new Map<string, {
     session: http2.ClientHttp2Session;
-    promise: Promise<PingResult>;
+    promise: Promise<boolean>;
   }>();
   private _establish: EstablishFn | null = null;
   private readonly maxIdleMs: number;
@@ -111,28 +110,28 @@ export class H2Pool {
     }
   }
 
-  private ping(session: http2.ClientHttp2Session): Promise<PingResult> {
-    if (this.isClosed(session)) return Promise.resolve("failed");
+  private ping(session: http2.ClientHttp2Session): Promise<boolean> {
+    if (this.isClosed(session)) return Promise.resolve(false);
 
-    return new Promise<PingResult>((resolve) => {
+    return new Promise<boolean>((resolve) => {
       let settled = false;
-      const finish = (result: PingResult) => {
+      const finish = (shouldRetain: boolean) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        resolve(result);
+        resolve(shouldRetain);
       };
 
-      const timer = setTimeout(() => finish("failed"), this.pingTimeoutMs);
+      const timer = setTimeout(() => finish(false), this.pingTimeoutMs);
 
       try {
         const sent = session.ping((err?: Error | null) => {
-          finish(!err && !this.isClosed(session) ? "alive" : "failed");
+          finish(!err && !this.isClosed(session));
         });
         // `false` means Node did not send the ping, not that the session failed.
-        if (!sent) finish("unsent");
+        if (!sent) finish(true);
       } catch {
-        finish("failed");
+        finish(false);
       }
     });
   }
@@ -140,7 +139,7 @@ export class H2Pool {
   private validateSession(
     domain: string,
     session: http2.ClientHttp2Session,
-  ): Promise<PingResult> {
+  ): Promise<boolean> {
     const existing = this.validations.get(domain);
     if (existing?.session === session) return existing.promise;
 
@@ -167,8 +166,8 @@ export class H2Pool {
       this.markUsed(domain, session);
       return session;
     }
-    const pingResult = await this.validateSession(domain, session);
-    if (pingResult !== "failed" && !this.isClosed(session)) {
+    const shouldRetain = await this.validateSession(domain, session);
+    if (shouldRetain && !this.isClosed(session)) {
       // ENG-2676 generation/identity pin: validation yields, and during that
       // await an eviction listener (goaway/error/close ->
       // attachEvictionListeners, see above) may have deleted or replaced this

--- a/@blaxel/core/src/common/h2pool.ts
+++ b/@blaxel/core/src/common/h2pool.ts
@@ -31,7 +31,7 @@ export class H2Pool {
   private inflight = new Map<string, Promise<http2.ClientHttp2Session | null>>();
   private validations = new Map<string, {
     session: http2.ClientHttp2Session;
-    result: Promise<PingResult>;
+    promise: Promise<PingResult>;
   }>();
   private _establish: EstablishFn | null = null;
   private readonly maxIdleMs: number;
@@ -142,15 +142,15 @@ export class H2Pool {
     session: http2.ClientHttp2Session,
   ): Promise<PingResult> {
     const existing = this.validations.get(domain);
-    if (existing?.session === session) return existing.result;
+    if (existing?.session === session) return existing.promise;
 
-    const result = this.ping(session).finally(() => {
-      if (this.validations.get(domain)?.result === result) {
+    const promise = this.ping(session).finally(() => {
+      if (this.validations.get(domain)?.promise === promise) {
         this.validations.delete(domain);
       }
     });
-    this.validations.set(domain, { session, result });
-    return result;
+    this.validations.set(domain, { session, promise });
+    return promise;
   }
 
   private async validateEntry(

--- a/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
+++ b/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from "events";
+import type http2 from "http2";
+import { afterEach, describe, expect, it } from "vitest";
+import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
+
+const DOMAIN = "edge.concurrent-ping.example.com";
+
+type EstablishHook = {
+  _establish: () => Promise<http2.ClientHttp2Session>;
+};
+
+class PingSession extends EventEmitter {
+  closed = false;
+  destroyed = false;
+  pingCalls = 0;
+  closeCalls = 0;
+  private pingCallbacks: Array<(err?: Error | null) => void> = [];
+
+  constructor(private readonly sendPing = true) {
+    super();
+  }
+
+  ping(callback: (err?: Error | null) => void): boolean {
+    this.pingCalls += 1;
+    if (!this.sendPing) return false;
+    this.pingCallbacks.push(callback);
+    return true;
+  }
+
+  acknowledgePings(): void {
+    for (const callback of this.pingCallbacks.splice(0)) callback(null);
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.closed = true;
+    this.emit("close");
+  }
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+let pool: H2Pool | undefined;
+
+afterEach(() => {
+  pool?.closeAll();
+  pool = undefined;
+});
+
+describe("ENG-3017: concurrent idle H2 validation", () => {
+  it("shares one ping across concurrent callers", async () => {
+    let now = 1_000;
+    const session = new PingSession();
+    pool = new H2Pool({ maxIdleMs: 5, pingTimeoutMs: 10_000, now: () => now });
+    (pool as unknown as EstablishHook)._establish = () =>
+      Promise.resolve(session as unknown as http2.ClientHttp2Session);
+
+    await pool.get(DOMAIN);
+    now += 10;
+
+    const requests = Array.from({ length: 100 }, () => pool!.get(DOMAIN));
+    await tick();
+    session.acknowledgePings();
+    const sessions = await Promise.all(requests);
+
+    expect(session.pingCalls).toBe(1);
+    expect(session.closeCalls).toBe(0);
+    expect(sessions.every((value) => value === (session as unknown))).toBe(true);
+  });
+
+  it("does not evict a healthy session when Node does not send the ping", async () => {
+    let now = 1_000;
+    const session = new PingSession(false);
+    pool = new H2Pool({ maxIdleMs: 5, now: () => now });
+    (pool as unknown as EstablishHook)._establish = () =>
+      Promise.resolve(session as unknown as http2.ClientHttp2Session);
+
+    await pool.get(DOMAIN);
+    now += 10;
+
+    const result = await pool.get(DOMAIN);
+
+    expect(result).toBe(session);
+    expect(session.closeCalls).toBe(0);
+  });
+});

--- a/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
+++ b/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
@@ -1,13 +1,25 @@
 import { EventEmitter } from "events";
 import type http2 from "http2";
-import { afterEach, describe, expect, it } from "vitest";
-import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  H2Pool as H2PoolInstance,
+  H2PoolOptions,
+} from "../../../@blaxel/core/dist/cjs/types/common/h2pool.js";
+
+const { establishH2Mock } = vi.hoisted(() => ({
+  establishH2Mock: vi.fn<() => Promise<http2.ClientHttp2Session>>(),
+}));
+
+vi.mock("../../../@blaxel/core/dist/esm/common/h2warm.js", () => ({
+  establishH2: establishH2Mock,
+}));
+
+// @ts-expect-error The internal ESM build does not emit co-located declarations.
+import { H2Pool as CompiledH2Pool } from "../../../@blaxel/core/dist/esm/common/h2pool.js";
+
+const H2Pool = CompiledH2Pool as new (options?: H2PoolOptions) => H2PoolInstance;
 
 const DOMAIN = "edge.concurrent-ping.example.com";
-
-type EstablishHook = {
-  _establish: () => Promise<http2.ClientHttp2Session>;
-};
 
 class PingSession extends EventEmitter {
   closed = false;
@@ -42,11 +54,12 @@ function tick(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-let pool: H2Pool | undefined;
+let pool: H2PoolInstance | undefined;
 
 afterEach(() => {
   pool?.closeAll();
   pool = undefined;
+  establishH2Mock.mockReset();
 });
 
 describe("ENG-3017: concurrent idle H2 validation", () => {
@@ -54,8 +67,7 @@ describe("ENG-3017: concurrent idle H2 validation", () => {
     let now = 1_000;
     const session = new PingSession();
     pool = new H2Pool({ maxIdleMs: 5, pingTimeoutMs: 10_000, now: () => now });
-    (pool as unknown as EstablishHook)._establish = () =>
-      Promise.resolve(session as unknown as http2.ClientHttp2Session);
+    establishH2Mock.mockResolvedValue(session as unknown as http2.ClientHttp2Session);
 
     await pool.get(DOMAIN);
     now += 10;
@@ -74,8 +86,7 @@ describe("ENG-3017: concurrent idle H2 validation", () => {
     let now = 1_000;
     const session = new PingSession(false);
     pool = new H2Pool({ maxIdleMs: 5, now: () => now });
-    (pool as unknown as EstablishHook)._establish = () =>
-      Promise.resolve(session as unknown as http2.ClientHttp2Session);
+    establishH2Mock.mockResolvedValue(session as unknown as http2.ClientHttp2Session);
 
     await pool.get(DOMAIN);
     now += 10;

--- a/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
+++ b/tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts
@@ -1,23 +1,15 @@
 import { EventEmitter } from "events";
 import type http2 from "http2";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type {
-  H2Pool as H2PoolInstance,
-  H2PoolOptions,
-} from "../../../@blaxel/core/dist/cjs/types/common/h2pool.js";
+import { H2Pool } from "../../../@blaxel/core/src/common/h2pool.js";
 
 const { establishH2Mock } = vi.hoisted(() => ({
   establishH2Mock: vi.fn<() => Promise<http2.ClientHttp2Session>>(),
 }));
 
-vi.mock("../../../@blaxel/core/dist/esm/common/h2warm.js", () => ({
+vi.mock("../../../@blaxel/core/src/common/h2warm.js", () => ({
   establishH2: establishH2Mock,
 }));
-
-// @ts-expect-error The internal ESM build does not emit co-located declarations.
-import { H2Pool as CompiledH2Pool } from "../../../@blaxel/core/dist/esm/common/h2pool.js";
-
-const H2Pool = CompiledH2Pool as new (options?: H2PoolOptions) => H2PoolInstance;
 
 const DOMAIN = "edge.concurrent-ping.example.com";
 
@@ -54,7 +46,7 @@ function tick(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-let pool: H2PoolInstance | undefined;
+let pool: H2Pool | undefined;
 
 afterEach(() => {
   pool?.closeAll();


### PR DESCRIPTION
## Summary
- Share one idle-session validation promise across concurrent `H2Pool.get()` callers for the same domain and session.
- Reduce validation to the decision the pool needs: retain the current session or evict it.
- Retain a session when Node does not send the ping because an unsent ping is not evidence of failure.

Linear: [ENG-3017](https://linear.app/blaxel/issue/ENG-3017/h2-pool-evicts-healthy-edge-sessions-under-concurrent-idle)

## User impact
Concurrent create bursts no longer close a healthy shared edge connection after Node refuses ping 11+. Callers avoid unnecessary TLS reconnects and HTTP/1.1 fallback.

## Chosen behavior
Idle validation returns one private boolean decision:

- `true`: retain and reuse the current session.
- `false`: evict the current session and establish a new one.

Concurrent callers await the same validation promise, so a burst performs one ping instead of one ping per caller. This does not change the public SDK API.

## Failure handling
Ping callback errors, ping timeouts, thrown errors, and closed or destroyed sessions resolve to `false` and evict. When `session.ping()` returns `false`, Node did not send the ping; validation resolves to `true` because there is no evidence that the session failed. Existing `goaway`, `error`, and `close` listeners still evict, and the generation check still prevents a stale session from being returned after validation yields.

## Verification
- `@blaxel/core` build passed.
- Targeted lint for `h2pool.ts` passed.
- H2 fault-injection and regression suite: 76 passed.
- ENG-3017 targeted regression: 2 passed.
- Standards review: no findings.
- Spec review: no findings.
- Package-wide core lint remains blocked by five pre-existing errors in unrelated files.

## Review Guide

### Why This PR Exists

Concurrent requests can reuse one idle HTTP/2 session. Before this change, each request started a separate ping. Node allows only 10 outstanding pings, so later `session.ping()` calls returned `false` because Node did not send them. The pool treated this result as a failed health check and evicted a healthy session.

### Behavior

- Concurrent callers for the same domain and session share one validation promise and one ping.
- Validation returns a private boolean retain-or-evict decision. The public API does not change.
- A `false` result from `session.ping()` retains the session because this result means that Node did not send the ping.
- A successful ping retains the session only if it is still open and is still the cached generation.
- A callback error, timeout, thrown error, closed session, or destroyed session causes eviction.
- `goaway`, `error`, and `close` events still remove the matching cached session.
- Failed validation closes the old session and lets `get()` establish or join a fresh session.

### Execution Flow
```mermaid
flowchart TD
    A[H2Pool.get receives an idle entry] --> B[validateSession checks active validation]
    B -->|Same domain and session| C[Await shared validation promise]
    B -->|No matching validation| D[Start one ping]
    D --> C
    C --> E{Retain result and session still cached and open?}
    E -->|Yes| F[Mark used and return session]
    E -->|No| G[Evict old entry]
    G --> H[Join or establish a fresh session]
```

### Invariants And Failure Paths

- Validation sharing requires both the same domain and the same session identity.
- Promise cleanup uses promise identity. An older validation cannot delete a newer validation entry.
- The generation identity check remains after asynchronous validation. A lifecycle event or replacement during the ping prevents return of the stale session.
- `session.ping() === false` is not a health failure. The later closed-state and generation checks still apply.
- A ping callback error, timeout, or synchronous throw returns `false` and evicts the session.
- A closed or destroyed session is not pinged or returned.
- `closeAll()` clears cached sessions, connection attempts, and validation tracking.
- Existing request callers continue through the normal H2 send or fetch fallback path.

### Reading Order

1. `@blaxel/core/src/common/h2pool.ts:113-153` - Review ping result handling and validation deduplication.
2. `@blaxel/core/src/common/h2pool.ts:155-184` - Verify retain, generation identity, and eviction decisions.
3. `tests/integration/regressions/h2pool-concurrent-ping-evict.test.ts:57-91` - Review the one-ping concurrency case and unsent-ping retention case.
4. `tests/integration/regressions/h2pool-get-validate-race.test.ts:75-121` - Confirm that lifecycle eviction during validation still rejects the stale generation.
5. `@blaxel/core/src/common/h2fetch.ts:238-311` - Trace pool output to request send, session eviction, fresh-session retry, or fetch fallback.

### Validation

- ENG-3017 targeted regression: 2 passed.
- H2 fault-injection and regression suite, including ENG-2676 and ENG-2678: 76 passed.
- `@blaxel/core` build passed.
- Targeted lint for `h2pool.ts` passed.
- Standards and spec reviews found no issues.
