### PR TITLE
feat: add Eve sandbox backend

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - name: Set version
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,6 +112,44 @@ jobs:
         working-directory: '@blaxel/core'
         run: npx vitest run --config vitest.config.ts src/common/h2-runtime.test.ts src/common/settings.test.ts
 
+  eve-sandbox-contract-tests:
+    name: eve sandbox contract tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build dependencies and eve adapter
+        run: |
+          bun run --filter @blaxel/core build
+          bun run --filter @blaxel/eve-sandbox build
+
+      - name: Lint eve adapter
+        run: |
+          bun run --filter @blaxel/eve-sandbox lint
+          bunx eslint tests/unit/eve-sandbox-network-policy.test.ts tests/unit/eve-sandbox-session.test.ts tests/unit/eve-sandbox-lifecycle.test.ts tests/integration/sandbox/eve-backend.test.ts
+
+      - name: Typecheck eve adapter tests
+        run: |
+          bun run --filter @blaxel/eve-sandbox typecheck:examples
+          bunx tsc --noEmit --strict --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --types node,vitest/globals tests/unit/eve-sandbox-network-policy.test.ts tests/unit/eve-sandbox-session.test.ts tests/unit/eve-sandbox-lifecycle.test.ts tests/integration/sandbox/eve-backend.test.ts
+          bunx tsc -p @blaxel/eve-sandbox/test/tsconfig.json
+
+      - name: Run eve adapter contract tests
+        run: bunx vitest run tests/unit/eve-sandbox-network-policy.test.ts tests/unit/eve-sandbox-session.test.ts tests/unit/eve-sandbox-lifecycle.test.ts
+
   h2-runtime-version-matrix:
     name: H2 gate on ${{ matrix.runtime }} ${{ matrix.version }}
     runs-on: ubuntu-latest
@@ -243,7 +281,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install and build SDK packages
         run: |
@@ -252,3 +290,6 @@ jobs:
 
       - name: Run integration tests
         run: bun run test:integration
+
+      - name: Run eve integration
+        run: bunx vitest run --config @blaxel/eve-sandbox/test/vitest.config.ts

--- a/@blaxel/eve-sandbox/LICENSE
+++ b/@blaxel/eve-sandbox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Beamlit, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/@blaxel/eve-sandbox/README.md
+++ b/@blaxel/eve-sandbox/README.md
@@ -1,0 +1,127 @@
+# @blaxel/eve-sandbox
+
+[Blaxel](https://blaxel.ai) sandbox backend for [eve](https://eve.dev).
+
+Run eve's built-in shell and file tools in secure, durable Blaxel sandboxes. Each durable eve session reconnects to the same sandbox after an application restart without relying on preview-only Blaxel APIs.
+
+## Quick start
+
+You need Node.js 24 or later and an existing [eve project](https://eve.dev/docs/installation).
+
+### 1. Install the backend
+
+```bash
+npm install @blaxel/eve-sandbox
+```
+
+The package expects the `eve` and `ai` versions already installed by your eve project.
+
+### 2. Authenticate with Blaxel
+
+For local development, sign in with the [Blaxel CLI](https://docs.blaxel.ai/cli-reference/overview):
+
+```bash
+bl login YOUR-WORKSPACE
+```
+
+In CI and production, provide `BL_WORKSPACE` and `BL_API_KEY` to the application runtime. Do not copy those credentials into the sandbox.
+
+### 3. Select Blaxel in eve
+
+```ts
+// agent/sandbox.ts
+import { blaxel } from "@blaxel/eve-sandbox";
+import { defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: blaxel({
+    image: "blaxel/ts-app:latest",
+    lifecycle: {
+      expirationPolicies: [{ type: "ttl-idle", value: "1d", action: "delete" }],
+    },
+    memory: 4096,
+  }),
+  async onSession({ use }) {
+    const sandbox = await use({
+      networkPolicy: { allow: ["github.com", "*.npmjs.org"] },
+    });
+    await sandbox.run({ command: "mkdir -p /workspace/project" });
+  },
+});
+```
+
+Start eve as usual:
+
+```bash
+npm run dev
+```
+
+The built-in `bash`, `read_file`, `write_file`, `glob`, and `grep` tools now operate inside the Blaxel sandbox. To smoke-test the setup in eve's terminal UI, ask the agent to create `/workspace/hello.txt` and read it back.
+
+A copy-ready sandbox definition is available in [`examples/agent/sandbox.ts`](./examples/agent/sandbox.ts).
+
+## What works
+
+- All five built-in eve sandbox tools
+- Blocking commands and streaming background processes
+- Text, binary, and streaming file operations
+- Durable filesystem and process state across turns and app restarts
+- Custom Blaxel images, regions, resources, volumes, environment variables, and lifecycle policies
+- Per-session setup through `onSession()`
+- Domain egress policies and secret-backed header transforms
+- Deterministic reconnection through eve's captured session metadata
+
+## Generally available capability scope
+
+The backend intentionally uses only generally available Blaxel sandbox APIs. It does not call Blaxel snapshot or fork APIs.
+
+eve's `bootstrap()` hook and files under `agent/sandbox/workspace` require a backend to clone a build-time template. This backend does not implement template prewarming. If either feature is configured, it fails with actionable guidance before serving traffic.
+
+Put reusable system dependencies and base files in a [custom Blaxel image](https://docs.blaxel.ai/Sandboxes/Templates). Put setup that must run once for each durable eve session in `onSession()`.
+
+## Lifecycle
+
+- `create()` reconnects a saved sandbox by name or creates a new sandbox from the configured image.
+- `onSession()` performs one-time setup for a new durable eve session.
+- Session names include the backend configuration identity, so a changed sandbox definition gets a new sandbox.
+- `captureState()` persists the Blaxel sandbox name in eve's durable session state.
+- `shutdown()` closes active log streams. Blaxel then moves the idle sandbox into standby while preserving memory, processes, and files.
+
+Session discovery uses Blaxel resources and does not depend on an in-process registry.
+
+## Network policy
+
+The backend supports:
+
+- `"allow-all"`
+- `"deny-all"`
+- Domain allow-lists
+- eve header transforms through Blaxel's secret-backed egress proxy
+
+The backend rejects subnet rules, request match conditions, and `forwardURL`. It does not silently weaken unsupported policies.
+
+The default is `"allow-all"`. For production or untrusted workloads, select `"deny-all"` or an explicit allow-list before the first command runs.
+
+## Options
+
+`blaxel()` accepts standard `SandboxCreateConfiguration` fields such as `image`, `memory`, `region`, `ports`, `envs`, `volumes`, `ttl`, `lifecycle`, and `labels`.
+
+| Option | Purpose | Default |
+| --- | --- | --- |
+| `backendName` | Stable eve backend identifier | `blaxel` |
+| `namePrefix` | Prefix for deterministic Blaxel resources | `eve` |
+| `networkPolicy` | Egress policy applied when a session sandbox is created | `"allow-all"` |
+| `processOutputBufferBytes` | Maximum unread stdout or stderr per process stream | 1 MiB |
+| `startupTimeoutMs` | Maximum cold-image readiness wait | 60 seconds |
+
+## Compatibility
+
+| Package | eve | AI SDK | Node.js | Default image |
+| --- | --- | --- | --- | --- |
+| `@blaxel/eve-sandbox` 0.2.x | 0.31.3 to less than 0.32 | 7.0.38 to less than 8 | 24 or later | `blaxel/ts-app:latest` |
+
+Each release must pass the adapter contract suite and a live eve agent evaluation against its declared range. A new eve minor requires a tested peer-range update.
+
+## Cleanup
+
+Blaxel sandboxes remain durable until their configured lifecycle removes them. Set `lifecycle` or `ttl` when the application requires automatic deletion of inactive sessions.

--- a/@blaxel/eve-sandbox/eslint.config.mjs
+++ b/@blaxel/eve-sandbox/eslint.config.mjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["dist", "eslint.config.mjs"] },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked.map((config) => ({
+    ...config,
+    files: ["**/*.ts"],
+    languageOptions: {
+      ...(config.languageOptions || {}),
+      parserOptions: {
+        ...(config.languageOptions?.parserOptions || {}),
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  })),
+  {
+    rules: {
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+    },
+  },
+);

--- a/@blaxel/eve-sandbox/examples/agent/sandbox.ts
+++ b/@blaxel/eve-sandbox/examples/agent/sandbox.ts
@@ -1,0 +1,21 @@
+import { blaxel } from "@blaxel/eve-sandbox";
+import { defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: blaxel({
+    image: "blaxel/ts-app:latest",
+    labels: { application: "eve" },
+    memory: 4096,
+  }),
+  async onSession({ use }) {
+    const sandbox = await use({
+      networkPolicy: {
+        allow: ["api.github.com", "github.com", "registry.npmjs.org"],
+      },
+    });
+    const result = await sandbox.run({ command: "mkdir -p /workspace/project" });
+    if (result.exitCode !== 0) {
+      throw new Error(`Blaxel session setup failed: ${result.stderr}`);
+    }
+  },
+});

--- a/@blaxel/eve-sandbox/examples/tsconfig.json
+++ b/@blaxel/eve-sandbox/examples/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/@blaxel/eve-sandbox/package.json
+++ b/@blaxel/eve-sandbox/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@blaxel/eve-sandbox",
+  "version": "0.2.59",
+  "description": "Durable Blaxel sandbox backend for eve agents",
+  "license": "MIT",
+  "author": "Blaxel, INC (https://blaxel.ai)",
+  "homepage": "https://blaxel.ai",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blaxel-ai/sdk-typescript",
+    "directory": "@blaxel/eve-sandbox"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "keywords": [
+    "agent",
+    "ai-agent",
+    "blaxel",
+    "eve",
+    "sandbox",
+    "sandbox-backend",
+    "vercel"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "examples",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint src/ examples/ test/",
+    "typecheck:examples": "tsc --noEmit -p examples/tsconfig.json",
+    "dev": "tsc --watch",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@blaxel/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "ai": "^7.0.38",
+    "eve": "^0.31.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.5",
+    "ai": "^7.0.38",
+    "eslint": "9.39.2",
+    "eve": "^0.31.3",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.64.0"
+  }
+}

--- a/@blaxel/eve-sandbox/src/index.ts
+++ b/@blaxel/eve-sandbox/src/index.ts
@@ -1,0 +1,360 @@
+import { createHash } from "node:crypto";
+
+import {
+  ResponseError,
+  SandboxInstance,
+  isGatewayError,
+  type SandboxCreateConfiguration,
+  type SandboxNetwork,
+} from "@blaxel/core";
+import {
+  type SandboxBackend,
+  type SandboxBackendCreateInput,
+  type SandboxBackendHandle,
+  type SandboxNetworkPolicy,
+  type SandboxSession,
+} from "eve/sandbox";
+
+import { toBlaxelNetworkPolicy } from "./network-policy.js";
+import { createBlaxelEveSession } from "./session.js";
+
+const DEFAULT_BACKEND_NAME = "blaxel";
+const DEFAULT_NAME_PREFIX = "eve";
+const DEFAULT_IMAGE = "blaxel/ts-app:latest";
+const DEFAULT_STARTUP_TIMEOUT_MS = 60_000;
+const MAX_SANDBOX_NAME_LENGTH = 49;
+
+export type BlaxelEveUseOptions = {
+  readonly networkPolicy?: SandboxNetworkPolicy;
+};
+
+type BlaxelEveSandboxCreateOptions = Pick<
+  SandboxCreateConfiguration,
+  | "envs"
+  | "expires"
+  | "extraArgs"
+  | "image"
+  | "labels"
+  | "lifecycle"
+  | "memory"
+  | "ports"
+  | "region"
+  | "ttl"
+  | "volumes"
+>;
+
+export type BlaxelEveBackendOptions = BlaxelEveSandboxCreateOptions & {
+  /** Stable eve backend name. Changing it invalidates persisted backend state. */
+  readonly backendName?: string;
+  /** Prefix used for deterministic Blaxel resource names. */
+  readonly namePrefix?: string;
+  /** Initial policy for new session sandboxes. */
+  readonly networkPolicy?: SandboxNetworkPolicy;
+  /** Maximum buffered stdout or stderr bytes for an unread process stream. */
+  readonly processOutputBufferBytes?: number;
+  /** Maximum time to wait for a cold sandbox image to accept commands. */
+  readonly startupTimeoutMs?: number;
+};
+
+/** Create a first-party Blaxel implementation of eve's public SandboxBackend. */
+export function blaxel(
+  options: BlaxelEveBackendOptions = {},
+): SandboxBackend<BlaxelEveUseOptions, BlaxelEveUseOptions> {
+  const {
+    backendName = DEFAULT_BACKEND_NAME,
+    namePrefix = DEFAULT_NAME_PREFIX,
+    networkPolicy,
+    processOutputBufferBytes,
+    startupTimeoutMs = DEFAULT_STARTUP_TIMEOUT_MS,
+    ...sandboxOptions
+  } = options;
+
+  validateOptions({
+    backendName,
+    namePrefix,
+    processOutputBufferBytes,
+    startupTimeoutMs,
+  });
+  const normalizedPrefix = normalizeNamePrefix(namePrefix);
+  const configurationIdentity = stableHash({
+    sandboxOptions,
+    networkPolicy: networkPolicy ?? "allow-all",
+  });
+
+  return {
+    name: backendName,
+    prewarm(input) {
+      return Promise.reject(templatePrewarmUnsupported(input.templateKey));
+    },
+    async create(input) {
+      try {
+        if (input.templateKey !== null) {
+          throw templatePrewarmUnsupported(input.templateKey);
+        }
+        const labels = resourceLabels("session", input.tags, sandboxOptions.labels);
+        const existing = await findExistingSession(input);
+        if (existing) {
+          await SandboxInstance.updateMetadata(existing.metadata.name, { labels });
+          if (networkPolicy !== undefined) await applyNetworkPolicy(existing, networkPolicy);
+          return createHandle(existing, input.sessionKey);
+        }
+
+        const sessionName = resourceName(
+          normalizedPrefix,
+          "session",
+          `${input.sessionKey}\0${configurationIdentity}`,
+        );
+        const sandbox = await SandboxInstance.createIfNotExists({
+          ...sandboxOptions,
+          image: sandboxOptions.image ?? DEFAULT_IMAGE,
+          labels,
+          name: sessionName,
+          network: initialNetwork(networkPolicy),
+        });
+        try {
+          await ensureBaseRuntime(sandbox, startupTimeoutMs);
+        } catch (error) {
+          await sandbox.delete().catch(() => undefined);
+          throw error;
+        }
+        return createHandle(sandbox, input.sessionKey);
+      } catch (error) {
+        throw new Error(
+          `Blaxel backend failed to open sandbox session "${input.sessionKey}": ${errorMessage(error)}`,
+          { cause: error },
+        );
+      }
+    },
+  };
+
+  async function findExistingSession(
+    input: SandboxBackendCreateInput,
+  ): Promise<SandboxInstance | null> {
+    const persistedName = readString(input.existingMetadata, "sandboxName");
+    const deterministicName = resourceName(
+      normalizedPrefix,
+      "session",
+      `${input.sessionKey}\0${configurationIdentity}`,
+    );
+    const names = [...new Set([persistedName, deterministicName].filter(Boolean))] as string[];
+    for (const name of names) {
+      const sandbox = await tryGetSandbox(name);
+      if (sandbox) return sandbox;
+    }
+    return null;
+  }
+
+  function createHandle(
+    sandbox: SandboxInstance,
+    sessionKey: string,
+  ): SandboxBackendHandle<BlaxelEveUseOptions> {
+    const openProcessStreams = new Set<() => void>();
+    const session = createBlaxelEveSession({
+      id: sessionKey,
+      processOutputBufferBytes,
+      sandbox,
+      registerProcessStream(close) {
+        openProcessStreams.add(close);
+        return () => openProcessStreams.delete(close);
+      },
+    });
+
+    return {
+      session,
+      async useSessionFn(useOptions?: BlaxelEveUseOptions): Promise<SandboxSession> {
+        if (useOptions?.networkPolicy !== undefined) {
+          await applyNetworkPolicy(sandbox, useOptions.networkPolicy);
+        }
+        return session;
+      },
+      captureState() {
+        return Promise.resolve({
+          backendName,
+          metadata: { sandboxName: sandbox.metadata.name },
+          sessionKey,
+        });
+      },
+      shutdown() {
+        for (const close of openProcessStreams) close();
+        openProcessStreams.clear();
+        // Blaxel automatically suspends an idle sandbox and preserves its full state.
+        return Promise.resolve();
+      },
+    };
+  }
+}
+
+export { createBlaxelEveSession } from "./session.js";
+export { toBlaxelNetworkPolicy } from "./network-policy.js";
+export default blaxel;
+
+async function applyNetworkPolicy(
+  sandbox: SandboxInstance,
+  policy: SandboxNetworkPolicy,
+): Promise<void> {
+  await SandboxInstance.updateNetwork(sandbox.metadata.name, {
+    network: toBlaxelNetworkPolicy(policy),
+  });
+}
+
+function initialNetwork(policy: SandboxNetworkPolicy | undefined): SandboxNetwork | undefined {
+  return policy === undefined ? undefined : toBlaxelNetworkPolicy(policy);
+}
+
+async function ensureBaseRuntime(
+  sandbox: SandboxInstance,
+  startupTimeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + startupTimeoutMs;
+  let retryDelayMs = 500;
+  for (;;) {
+    try {
+      const result = await sandbox.process.exec({
+        command: "mkdir -p /workspace && command -v bash >/dev/null",
+        waitForCompletion: true,
+        workingDir: "/",
+      });
+      if (result.exitCode !== 0) {
+        throw new Error("The Blaxel sandbox image must provide bash.");
+      }
+      return;
+    } catch (error) {
+      if (!isRetryableStartupError(error) || Date.now() >= deadline) throw error;
+      const remainingMs = deadline - Date.now();
+      await delay(Math.min(retryDelayMs, remainingMs));
+      retryDelayMs = Math.min(retryDelayMs * 2, 30_000);
+    }
+  }
+}
+
+async function tryGetSandbox(name: string): Promise<SandboxInstance | null> {
+  try {
+    return await SandboxInstance.get(name);
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+function resourceName(prefix: string, kind: "session", identity: string): string {
+  const hashLength = MAX_SANDBOX_NAME_LENGTH - prefix.length - kind.length - 2;
+  return `${prefix}-${kind}-${stableHash(identity).slice(0, hashLength)}`;
+}
+
+function resourceLabels(
+  kind: "session",
+  tags: Readonly<Record<string, string>> | undefined,
+  configured: Record<string, string> | undefined,
+): Record<string, string> {
+  const labels: Record<string, string> = {
+    ...(configured ?? {}),
+    "blaxel-integration": "eve",
+    "eve-resource": kind,
+  };
+  for (const [key, value] of Object.entries(tags ?? {})) {
+    labels[`eve-${normalizeLabel(key, 59)}`] = normalizeLabel(value, 63);
+  }
+  return labels;
+}
+
+function normalizeNamePrefix(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 20);
+  if (!normalized) throw new Error("namePrefix must contain a letter or number");
+  return normalized;
+}
+
+function normalizeLabel(value: string, maxLength: number): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+    .slice(0, maxLength) || "unknown";
+}
+
+function stableHash(value: unknown): string {
+  return createHash("sha256").update(stableSerialize(value)).digest("hex");
+}
+
+function stableSerialize(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item)}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function validateOptions(input: {
+  backendName: string;
+  namePrefix: string;
+  processOutputBufferBytes: number | undefined;
+  startupTimeoutMs: number;
+}): void {
+  if (!input.backendName.trim()) throw new Error("backendName cannot be empty");
+  normalizeNamePrefix(input.namePrefix);
+  if (!Number.isFinite(input.startupTimeoutMs) || input.startupTimeoutMs <= 0) {
+    throw new Error("startupTimeoutMs must be a positive finite number");
+  }
+  if (
+    input.processOutputBufferBytes !== undefined &&
+    (!Number.isInteger(input.processOutputBufferBytes) || input.processOutputBufferBytes <= 0)
+  ) {
+    throw new Error("processOutputBufferBytes must be a positive integer");
+  }
+}
+
+function isRetryableStartupError(error: unknown): boolean {
+  if (isGatewayError(error)) return true;
+  return (
+    error instanceof ResponseError &&
+    error.status === 404 &&
+    /WORKLOAD_UNAVAILABLE|currently not available/iu.test(error.message)
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; status?: unknown; statusCode?: unknown };
+  return candidate.code === 404 || candidate.code === "404" || candidate.status === 404 || candidate.statusCode === 404;
+}
+
+function templatePrewarmUnsupported(templateKey: string): Error {
+  return new Error(
+    `Blaxel eve template prewarming is not supported (template "${templateKey}"). ` +
+      "Use a custom Blaxel image for reusable dependencies and files, omit eve bootstrap() " +
+      "and agent/sandbox/workspace seed files, and perform one-time session setup in onSession().",
+  );
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const { message } = error as { message?: unknown };
+    if (typeof message === "string") return message;
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return "Unknown error object";
+    }
+  }
+  return String(error);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/@blaxel/eve-sandbox/src/index.ts
+++ b/@blaxel/eve-sandbox/src/index.ts
@@ -111,12 +111,7 @@ export function blaxel(
           name: sessionName,
           network: initialNetwork(networkPolicy),
         });
-        try {
-          await ensureBaseRuntime(sandbox, startupTimeoutMs);
-        } catch (error) {
-          await sandbox.delete().catch(() => undefined);
-          throw error;
-        }
+        await ensureBaseRuntime(sandbox, startupTimeoutMs);
         return createHandle(sandbox, input.sessionKey);
       } catch (error) {
         throw new Error(
@@ -272,7 +267,8 @@ function normalizeLabel(value: string, maxLength: number): string {
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
-    .slice(0, maxLength) || "unknown";
+    .slice(0, maxLength)
+    .replace(/[^a-z0-9]+$/g, "") || "unknown";
 }
 
 function stableHash(value: unknown): string {

--- a/@blaxel/eve-sandbox/src/network-policy.ts
+++ b/@blaxel/eve-sandbox/src/network-policy.ts
@@ -1,0 +1,84 @@
+import type { SandboxNetwork } from "@blaxel/core";
+import type { SandboxNetworkPolicy } from "eve/sandbox";
+
+type EveNetworkRule = {
+  readonly forwardURL?: string;
+  readonly match?: unknown;
+  readonly transform?: ReadonlyArray<{
+    readonly headers?: Readonly<Record<string, string>>;
+  }>;
+};
+
+type EveNetworkPolicyObject = {
+  readonly allow?:
+    | ReadonlyArray<string>
+    | Readonly<Record<string, ReadonlyArray<EveNetworkRule>>>;
+  readonly subnets?: {
+    readonly allow?: ReadonlyArray<string>;
+    readonly deny?: ReadonlyArray<string>;
+  };
+};
+
+/** Convert eve's firewall shape into Blaxel's domain proxy configuration. */
+export function toBlaxelNetworkPolicy(policy: SandboxNetworkPolicy): SandboxNetwork {
+  if (policy === "allow-all") return {};
+  if (policy === "deny-all") {
+    return { proxy: { allowedDomains: [], routing: [] } };
+  }
+
+  const input = policy as EveNetworkPolicyObject;
+  if ((input.subnets?.allow?.length ?? 0) > 0 || (input.subnets?.deny?.length ?? 0) > 0) {
+    throw new Error(
+      "The Blaxel eve backend does not support eve subnet allow or deny rules.",
+    );
+  }
+
+  const entries = normalizeAllowEntries(input.allow);
+  const allowAll = entries.some(([domain]) => domain === "*");
+  const allowedDomains = allowAll ? undefined : entries.map(([domain]) => domain);
+  const routing = entries.flatMap(([domain, rules], domainIndex) => {
+    const headers: Record<string, string> = {};
+    const secrets: Record<string, string> = {};
+
+    rules.forEach((rule, ruleIndex) => {
+      if (rule.match !== undefined) {
+        throw new Error(
+          `The Blaxel eve backend cannot apply a request match condition for ${domain}.`,
+        );
+      }
+      if (rule.forwardURL !== undefined) {
+        throw new Error(
+          `The Blaxel eve backend cannot forward requests for ${domain} to another URL.`,
+        );
+      }
+      rule.transform?.forEach((transform, transformIndex) => {
+        Object.entries(transform.headers ?? {}).forEach(([header, value], headerIndex) => {
+          const secretName = `eve-${domainIndex}-${ruleIndex}-${transformIndex}-${headerIndex}`;
+          headers[header] = `{{SECRET:${secretName}}}`;
+          secrets[secretName] = value;
+        });
+      });
+    });
+
+    if (Object.keys(headers).length === 0) return [];
+    return [{ destinations: [domain], headers, secrets }];
+  });
+
+  return {
+    proxy: {
+      ...(allowedDomains === undefined ? {} : { allowedDomains }),
+      routing,
+    },
+  };
+}
+
+function normalizeAllowEntries(
+  allow: EveNetworkPolicyObject["allow"],
+): ReadonlyArray<readonly [string, ReadonlyArray<EveNetworkRule>]> {
+  if (allow === undefined) return [];
+  if (Array.isArray(allow)) return allow.map((domain) => [domain, []] as const);
+  return Object.entries(allow).map(([domain, rules]) => [
+    domain,
+    Array.isArray(rules) ? rules : [],
+  ] as const);
+}

--- a/@blaxel/eve-sandbox/src/session.ts
+++ b/@blaxel/eve-sandbox/src/session.ts
@@ -1,0 +1,420 @@
+import { posix as path } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { SandboxInstance } from "@blaxel/core";
+import type {
+  SandboxCommandResult,
+  SandboxNetworkPolicy,
+  SandboxProcess,
+  SandboxReadFileOptions,
+  SandboxReadTextFileOptions,
+  SandboxRunOptions,
+  SandboxSession,
+  SandboxSpawnOptions,
+  SandboxWriteFileOptions,
+  SandboxWriteTextFileOptions,
+} from "eve/sandbox";
+
+import { toBlaxelNetworkPolicy } from "./network-policy.js";
+
+const WORKSPACE_ROOT = "/workspace";
+const DEFAULT_PROCESS_OUTPUT_BUFFER_BYTES = 1024 * 1024;
+
+type SandboxRemovePathOptions = {
+  readonly abortSignal?: AbortSignal;
+  readonly force?: boolean;
+  readonly path: string;
+  readonly recursive?: boolean;
+};
+
+export type CreateBlaxelEveSessionOptions = {
+  readonly id: string;
+  readonly processOutputBufferBytes?: number;
+  readonly registerProcessStream?: (close: () => void) => () => void;
+  readonly sandbox: SandboxInstance;
+};
+
+/** Build eve's public sandbox session over one Blaxel sandbox. */
+export function createBlaxelEveSession(
+  options: CreateBlaxelEveSessionOptions,
+): SandboxSession {
+  const { sandbox } = options;
+  const processOutputBufferBytes =
+    options.processOutputBufferBytes ?? DEFAULT_PROCESS_OUTPUT_BUFFER_BYTES;
+
+  const session: SandboxSession = {
+    id: options.id,
+    resolvePath,
+    async run(runOptions: SandboxRunOptions): Promise<SandboxCommandResult> {
+      const { completion, process } = await spawnInternal(runOptions);
+      const [streamedStdout, streamedStderr, result] = await Promise.all([
+        streamToString(process.stdout),
+        streamToString(process.stderr),
+        completion,
+      ]);
+      return {
+        exitCode: result.exitCode,
+        stdout: result.stdout ?? streamedStdout,
+        stderr: result.stderr ?? streamedStderr,
+      };
+    },
+    spawn,
+    async readFile(readOptions: SandboxReadFileOptions) {
+      throwIfAborted(readOptions.abortSignal);
+      try {
+        const blob = await sandbox.fs.readBinary(resolvePath(readOptions.path));
+        throwIfAborted(readOptions.abortSignal);
+        return bytesToStream(new Uint8Array(await blob.arrayBuffer()));
+      } catch (error) {
+        if (isNotFoundError(error)) return null;
+        throw error;
+      }
+    },
+    async readBinaryFile(readOptions) {
+      const stream = await session.readFile(readOptions);
+      return stream === null ? null : streamToBytes(stream);
+    },
+    async readTextFile(readOptions: SandboxReadTextFileOptions) {
+      validateReadTextFileOptions(readOptions);
+      const bytes = await session.readBinaryFile(readOptions);
+      if (bytes === null) return null;
+      return applyLineRange(
+        decodeBytes(bytes, readOptions.encoding ?? "utf-8"),
+        readOptions,
+      );
+    },
+    async writeFile(writeOptions: SandboxWriteFileOptions) {
+      throwIfAborted(writeOptions.abortSignal);
+      const target = resolvePath(writeOptions.path);
+      await ensureParentDirectory(sandbox, target);
+      const bytes = await streamToBytes(writeOptions.content);
+      throwIfAborted(writeOptions.abortSignal);
+      await sandbox.fs.writeBinary(target, bytes);
+    },
+    async writeBinaryFile(writeOptions) {
+      throwIfAborted(writeOptions.abortSignal);
+      const target = resolvePath(writeOptions.path);
+      await ensureParentDirectory(sandbox, target);
+      await sandbox.fs.writeBinary(target, toUint8Array(writeOptions.content));
+      throwIfAborted(writeOptions.abortSignal);
+    },
+    async writeTextFile(writeOptions: SandboxWriteTextFileOptions) {
+      throwIfAborted(writeOptions.abortSignal);
+      const target = resolvePath(writeOptions.path);
+      await ensureParentDirectory(sandbox, target);
+      const encoding = writeOptions.encoding ?? "utf-8";
+      if (encoding === "utf-8" || encoding === "utf8") {
+        await sandbox.fs.write(target, writeOptions.content);
+      } else {
+        await sandbox.fs.writeBinary(
+          target,
+          Buffer.from(writeOptions.content, encoding as BufferEncoding),
+        );
+      }
+      throwIfAborted(writeOptions.abortSignal);
+    },
+    async removePath(removeOptions: SandboxRemovePathOptions) {
+      throwIfAborted(removeOptions.abortSignal);
+      try {
+        await sandbox.fs.rm(resolvePath(removeOptions.path), removeOptions.recursive ?? false);
+      } catch (error) {
+        if (removeOptions.force && isNotFoundError(error)) return;
+        throw error;
+      }
+      throwIfAborted(removeOptions.abortSignal);
+    },
+    async setNetworkPolicy(policy: SandboxNetworkPolicy) {
+      await SandboxInstance.updateNetwork(sandbox.metadata.name, {
+        network: toBlaxelNetworkPolicy(policy),
+      });
+    },
+  };
+
+  return session;
+
+  async function spawn(spawnOptions: SandboxSpawnOptions): Promise<SandboxProcess> {
+    return (await spawnInternal(spawnOptions)).process;
+  }
+
+  async function spawnInternal(spawnOptions: SandboxSpawnOptions): Promise<{
+    completion: Promise<{ exitCode: number; stderr?: string; stdout?: string }>;
+    process: SandboxProcess;
+  }> {
+    throwIfAborted(spawnOptions.abortSignal);
+    const result = await sandbox.process.exec({
+      command: spawnOptions.command,
+      env: spawnOptions.env,
+      keepAlive: false,
+      name: `eve-${randomUUID()}`,
+      timeout: 0,
+      waitForCompletion: false,
+      workingDir:
+        spawnOptions.workingDirectory === undefined
+          ? WORKSPACE_ROOT
+          : resolvePath(spawnOptions.workingDirectory),
+    });
+    const pid = result.pid;
+    const stdout = createBoundedByteStream(processOutputBufferBytes);
+    const stderr = createBoundedByteStream(processOutputBufferBytes);
+    let state: "running" | "killed" | "exited" = "running";
+    let exitCode = 1;
+    let terminalError: Error | undefined;
+    let closeStream = () => {};
+
+    const stream = sandbox.process.streamLogs(pid, {
+      onStdout: (value) => {
+        const error = stdout.push(new TextEncoder().encode(value));
+        if (error) failProcess(error);
+      },
+      onStderr: (value) => {
+        const error = stderr.push(new TextEncoder().encode(value));
+        if (error) failProcess(error);
+      },
+      onError: failProcess,
+    });
+    closeStream = stream.close;
+    const unregister = options.registerProcessStream?.(stream.close) ?? (() => {});
+
+    const kill = async () => {
+      if (state !== "running") return;
+      state = "killed";
+      exitCode = 137;
+      stream.close();
+      await sandbox.process.kill(pid).catch((error: unknown) => {
+        if (!isNotFoundError(error)) throw error;
+      });
+      stdout.finish();
+      stderr.finish();
+    };
+    const abort = () => void kill().catch(failProcess);
+    spawnOptions.abortSignal?.addEventListener("abort", abort, { once: true });
+
+    const completed = (async () => {
+      try {
+        await stream.wait();
+        if (terminalError) throw terminalError;
+        if ((state as "running" | "killed" | "exited") === "killed") return { exitCode };
+        let final = await sandbox.process.get(pid);
+        while (final.status === "running") {
+          await delay(250);
+          final = await sandbox.process.get(pid);
+        }
+        exitCode = final.exitCode ?? 1;
+        state = final.status === "killed" || final.status === "stopped" ? "killed" : "exited";
+        stdout.finish();
+        stderr.finish();
+        return { exitCode, stderr: final.stderr, stdout: final.stdout };
+      } catch (error) {
+        const normalized = asError(error);
+        terminalError ??= normalized;
+        stdout.finish(normalized);
+        stderr.finish(normalized);
+        throw normalized;
+      } finally {
+        spawnOptions.abortSignal?.removeEventListener("abort", abort);
+        unregister();
+      }
+    })();
+    void completed.catch(() => undefined);
+
+    const process: SandboxProcess = {
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      wait: async () => ({ exitCode: (await completed).exitCode }),
+      kill,
+    };
+    return { completion: completed, process };
+
+    function failProcess(error: Error): void {
+      if (terminalError) return;
+      terminalError = error;
+      closeStream();
+      void sandbox.process.kill(pid).catch(() => undefined);
+      stdout.finish(error);
+      stderr.finish(error);
+    }
+  }
+}
+
+function resolvePath(input: string): string {
+  return input.startsWith("/") ? input : `${WORKSPACE_ROOT}/${input}`;
+}
+
+async function ensureParentDirectory(sandbox: SandboxInstance, filePath: string): Promise<void> {
+  const parent = path.dirname(filePath);
+  if (parent === "/" || parent === WORKSPACE_ROOT) return;
+  const result = await sandbox.process.exec({
+    command: `mkdir -p -- ${shellQuote(parent)}`,
+    waitForCompletion: true,
+    workingDir: "/",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to create parent directory ${parent}: ${result.stderr}`);
+  }
+}
+
+function createBoundedByteStream(maxBufferedBytes: number) {
+  if (!Number.isInteger(maxBufferedBytes) || maxBufferedBytes <= 0) {
+    throw new Error("processOutputBufferBytes must be a positive integer");
+  }
+  const queue: Uint8Array[] = [];
+  let bufferedBytes = 0;
+  let finished = false;
+  let terminalError: Error | undefined;
+  let pendingController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (queue.length > 0) {
+        const chunk = queue.shift()!;
+        bufferedBytes -= chunk.byteLength;
+        controller.enqueue(chunk);
+        return;
+      }
+      if (terminalError) {
+        controller.error(terminalError);
+        return;
+      }
+      if (finished) {
+        controller.close();
+        return;
+      }
+      pendingController = controller;
+    },
+    cancel() {
+      queue.length = 0;
+      bufferedBytes = 0;
+      pendingController = undefined;
+      finished = true;
+    },
+  });
+
+  return {
+    stream,
+    push(chunk: Uint8Array): Error | undefined {
+      if (finished) return terminalError;
+      if (pendingController) {
+        const controller = pendingController;
+        pendingController = undefined;
+        controller.enqueue(chunk);
+        return undefined;
+      }
+      if (bufferedBytes + chunk.byteLength > maxBufferedBytes) {
+        const error = new Error(
+          `Blaxel process output exceeded the ${maxBufferedBytes}-byte buffer; consume output while the process runs.`,
+        );
+        this.finish(error);
+        return error;
+      }
+      queue.push(chunk);
+      bufferedBytes += chunk.byteLength;
+      return undefined;
+    },
+    finish(error?: Error) {
+      if (finished) return;
+      finished = true;
+      terminalError = error;
+      if (!pendingController) return;
+      const controller = pendingController;
+      pendingController = undefined;
+      if (error) controller.error(error);
+      else controller.close();
+    },
+  };
+}
+
+function bytesToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+async function streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      size += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+async function streamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
+  return new TextDecoder().decode(await streamToBytes(stream));
+}
+
+function toUint8Array(content: Uint8Array | ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (content instanceof Uint8Array) return content;
+  if (content instanceof ArrayBuffer) return new Uint8Array(content);
+  return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+}
+
+function decodeBytes(bytes: Uint8Array, encoding: string): string {
+  if (encoding === "utf-8" || encoding === "utf8") {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  }
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString(
+    encoding as BufferEncoding,
+  );
+}
+
+function validateReadTextFileOptions(options: SandboxReadTextFileOptions): void {
+  const { startLine, endLine } = options;
+  if (startLine !== undefined && (!Number.isInteger(startLine) || startLine < 1)) {
+    throw new Error("startLine must be a positive integer (1-based).");
+  }
+  if (endLine !== undefined && (!Number.isInteger(endLine) || endLine < 1)) {
+    throw new Error("endLine must be a positive integer (1-based).");
+  }
+  if (startLine !== undefined && endLine !== undefined && startLine > endLine) {
+    throw new Error("startLine must not be greater than endLine.");
+  }
+}
+
+function applyLineRange(text: string, options: SandboxReadTextFileOptions): string {
+  if (options.startLine === undefined && options.endLine === undefined) return text;
+  const lines = text.match(/.*(?:\r\n|\r|\n)|.+$/g) ?? [];
+  const start = options.startLine ?? 1;
+  const end = Math.min(options.endLine ?? lines.length, lines.length);
+  return start > lines.length ? "" : lines.slice(start - 1, end).join("");
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; status?: unknown; statusCode?: unknown };
+  return candidate.code === 404 || candidate.code === "404" || candidate.status === 404 || candidate.statusCode === 404;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  throw new DOMException("The operation was aborted", "AbortError");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/@blaxel/eve-sandbox/test/eve-agent.test.ts
+++ b/@blaxel/eve-sandbox/test/eve-agent.test.ts
@@ -1,0 +1,80 @@
+import { execFile } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { deleteSandboxesWithPrefix } from "./helpers.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoot = fileURLToPath(new URL("./fixtures/eve-app", import.meta.url));
+const temporaryFixtureRoot = fileURLToPath(new URL("./tmp", import.meta.url));
+const namePrefix = `eve-agent-${randomUUID().replaceAll("-", "").slice(0, 8)}`;
+
+describe("eve agent on Blaxel", { timeout: 59_000 }, () => {
+  afterAll(async () => {
+    await deleteSandboxesWithPrefix(namePrefix);
+  });
+
+  it("runs all five built-in sandbox tools through a real eve turn", async () => {
+    const runRoot = await copyFixtureToTemporaryDirectory();
+    let stderr: string;
+    let stdout: string;
+    try {
+      ({ stderr, stdout } = await execFileAsync(
+        "bunx",
+        ["eve", "eval", "--skip-report", "--verbose"],
+        {
+          cwd: runRoot,
+          env: cleanChildEnvironment(namePrefix),
+          maxBuffer: 10 * 1024 * 1024,
+          timeout: 55_000,
+        },
+      ));
+    } catch (error) {
+      const failure = error as Error & { stderr?: string; stdout?: string };
+      throw new Error(
+        `eve eval failed.\nstdout:\n${failure.stdout ?? ""}\nstderr:\n${failure.stderr ?? ""}`,
+        { cause: error },
+      );
+    } finally {
+      await rm(runRoot, { force: true, recursive: true });
+    }
+
+    expect(`${stdout}\n${stderr}`).toContain("Results: 1 passed (1 total)");
+    expect(`${stdout}\n${stderr}`).toContain("Gates: 7 passed");
+  });
+});
+
+async function copyFixtureToTemporaryDirectory(): Promise<string> {
+  await mkdir(temporaryFixtureRoot, { recursive: true });
+  const runRoot = await mkdtemp(join(temporaryFixtureRoot, "eve-app-"));
+  const ignoredRoots = [
+    join(fixtureRoot, ".eve"),
+    join(fixtureRoot, "node_modules"),
+  ];
+  await cp(fixtureRoot, runRoot, {
+    recursive: true,
+    filter(source) {
+      return !ignoredRoots.some(
+        (ignoredRoot) => source === ignoredRoot || source.startsWith(`${ignoredRoot}${sep}`),
+      );
+    },
+  });
+  return runRoot;
+}
+
+function cleanChildEnvironment(testNamePrefix: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    BL_EVE_TEST_NAME_PREFIX: testNamePrefix,
+    NODE_ENV: "development",
+  };
+  delete environment.VITEST;
+  delete environment.VITEST_POOL_ID;
+  delete environment.VITEST_WORKER_ID;
+  return environment;
+}

--- a/@blaxel/eve-sandbox/test/eve-tools.test.ts
+++ b/@blaxel/eve-sandbox/test/eve-tools.test.ts
@@ -26,6 +26,9 @@ describe("eve tools on Blaxel", { timeout: 59_000 }, () => {
         language: "typescript",
         "created-by": "vitest-integration",
       },
+      lifecycle: {
+        expirationPolicies: [{ type: "ttl-max-age", value: "1h", action: "delete" }],
+      },
       namePrefix,
       region: process.env.BL_REGION ?? "us-was-1",
     });

--- a/@blaxel/eve-sandbox/test/eve-tools.test.ts
+++ b/@blaxel/eve-sandbox/test/eve-tools.test.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  defineBashTool,
+  defineGlobTool,
+  defineGrepTool,
+  type ToolContext,
+} from "eve/tools";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { blaxel } from "../src/index.js";
+import { deleteSandboxesWithPrefix } from "./helpers.js";
+
+describe("eve tools on Blaxel", { timeout: 59_000 }, () => {
+  const namePrefix = `eve-tools-${randomUUID().replaceAll("-", "").slice(0, 8)}`;
+
+  afterAll(async () => {
+    await deleteSandboxesWithPrefix(namePrefix);
+  });
+
+  it("runs eve bash, glob, and grep through the Blaxel backend", async () => {
+    const backend = blaxel({
+      image: process.env.BL_EVE_TEST_IMAGE ?? "blaxel/ts-app:latest",
+      labels: {
+        env: "integration-test",
+        language: "typescript",
+        "created-by": "vitest-integration",
+      },
+      namePrefix,
+      region: process.env.BL_REGION ?? "us-was-1",
+    });
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "eve-tools-session",
+      templateKey: null,
+    });
+    const context = {
+      getSandbox: () => Promise.resolve(handle.session),
+    } as ToolContext;
+
+    expect(
+      await defineBashTool().execute(
+        {
+          command:
+            "mkdir -p durable && printf 'eve-tools-live-ok\\n' > durable/eve-tools.txt",
+        },
+        context,
+      ),
+    ).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+      truncated: false,
+    });
+
+    const globResult = await defineGlobTool().execute(
+      { pattern: "**/eve-tools.txt" },
+      context,
+    );
+    expect(globResult).toEqual(
+      expect.objectContaining({ count: 1, truncated: false }),
+    );
+    expect(JSON.stringify(globResult)).toContain("durable/eve-tools.txt");
+
+    const grepResult = await defineGrepTool().execute(
+      { literal: true, pattern: "eve-tools-live-ok" },
+      context,
+    );
+    expect(grepResult).toEqual(
+      expect.objectContaining({ matchCount: 1, truncated: false }),
+    );
+    expect(JSON.stringify(grepResult)).toContain("eve-tools-live-ok");
+
+    await handle.shutdown();
+  });
+});

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/.gitignore
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/.gitignore
@@ -1,0 +1,2 @@
+.eve/
+reports/

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/agent.ts
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/agent.ts
@@ -1,0 +1,60 @@
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  modelContextWindowTokens: 32_000,
+  model: mockModel(({ toolResults }) => {
+    switch (toolResults.length) {
+      case 0:
+        return {
+          toolCalls: [
+            {
+              name: "write_file",
+              input: {
+                content: "alpha\nbeta\n",
+                filePath: "/workspace/eve-acceptance.txt",
+              },
+            },
+          ],
+        };
+      case 1:
+        return {
+          toolCalls: [
+            {
+              name: "read_file",
+              input: { filePath: "/workspace/eve-acceptance.txt" },
+            },
+          ],
+        };
+      case 2:
+        return {
+          toolCalls: [
+            {
+              name: "glob",
+              input: { pattern: "**/eve-acceptance.txt" },
+            },
+          ],
+        };
+      case 3:
+        return {
+          toolCalls: [
+            {
+              name: "grep",
+              input: { literal: true, pattern: "beta" },
+            },
+          ],
+        };
+      case 4:
+        return {
+          toolCalls: [
+            {
+              name: "bash",
+              input: { command: "printf 'eve-blaxel-agent-live-ok'" },
+            },
+          ],
+        };
+      default:
+        return "eve-blaxel-acceptance-ok";
+    }
+  }),
+});

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/instructions.md
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox acceptance sequence.

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/sandbox.ts
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/sandbox.ts
@@ -13,6 +13,9 @@ export default defineSandbox({
       env: "integration-test",
       "created-by": "eve-eval",
     },
+    lifecycle: {
+      expirationPolicies: [{ type: "ttl-max-age", value: "1h", action: "delete" }],
+    },
     namePrefix,
     region: process.env.BL_REGION ?? "us-was-1",
   }),

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/sandbox.ts
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/agent/sandbox.ts
@@ -1,0 +1,19 @@
+import { blaxel } from "@blaxel/eve-sandbox";
+import { defineSandbox } from "eve/sandbox";
+
+const namePrefix = process.env.BL_EVE_TEST_NAME_PREFIX;
+if (!namePrefix) {
+  throw new Error("BL_EVE_TEST_NAME_PREFIX is required for the live eve test fixture.");
+}
+
+export default defineSandbox({
+  backend: blaxel({
+    image: "blaxel/ts-app:latest",
+    labels: {
+      env: "integration-test",
+      "created-by": "eve-eval",
+    },
+    namePrefix,
+    region: process.env.BL_REGION ?? "us-was-1",
+  }),
+});

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/evals/blaxel-sandbox.eval.ts
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/evals/blaxel-sandbox.eval.ts
@@ -1,0 +1,17 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+export default defineEval({
+  description: "All five eve sandbox tools run through the Blaxel backend.",
+  async test(t) {
+    await t.send("Run the Blaxel sandbox acceptance sequence.");
+
+    t.succeeded();
+    t.calledTool("write_file");
+    t.calledTool("read_file");
+    t.calledTool("glob");
+    t.calledTool("grep");
+    t.calledTool("bash");
+    t.check(t.reply, equals("eve-blaxel-acceptance-ok"));
+  },
+});

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/evals/evals.config.ts
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/evals/evals.config.ts
@@ -1,0 +1,3 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ timeoutMs: 59_000 });

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/package.json
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "blaxel-eve-acceptance-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@blaxel/eve-sandbox": "0.2.59",
+    "ai": "^7.0.38",
+    "eve": "^0.31.3"
+  }
+}

--- a/@blaxel/eve-sandbox/test/fixtures/eve-app/tsconfig.json
+++ b/@blaxel/eve-sandbox/test/fixtures/eve-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/@blaxel/eve-sandbox/test/helpers.ts
+++ b/@blaxel/eve-sandbox/test/helpers.ts
@@ -1,0 +1,24 @@
+import { SandboxInstance } from "@blaxel/core";
+
+export async function deleteSandboxesWithPrefix(namePrefix: string): Promise<void> {
+  const page = await SandboxInstance.list({
+    limit: 100,
+    q: namePrefix,
+    showTerminated: true,
+  });
+  const sandboxes = page.data.filter((sandbox) =>
+    sandbox.metadata.name?.startsWith(`${namePrefix}-`),
+  );
+  const results = await Promise.allSettled(
+    sandboxes.map((sandbox) => sandbox.delete()),
+  );
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason as unknown);
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Failed to delete ${failures.length} Blaxel test sandbox${failures.length === 1 ? "" : "es"}.`,
+    );
+  }
+}

--- a/@blaxel/eve-sandbox/test/tsconfig.json
+++ b/@blaxel/eve-sandbox/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/@blaxel/eve-sandbox/test/vitest.config.ts
+++ b/@blaxel/eve-sandbox/test/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["@blaxel/eve-sandbox/test/**/*.test.ts"],
+    hookTimeout: 59_000,
+    testTimeout: 59_000,
+  },
+});

--- a/@blaxel/eve-sandbox/tsconfig.json
+++ b/@blaxel/eve-sandbox/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "noEmitOnError": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Blaxel TypeScript SDK
 
-Monorepo for the Blaxel TypeScript SDK. The main package is `@blaxel/core`, with framework integrations in `@blaxel/langgraph`, `@blaxel/llamaindex`, `@blaxel/mastra`, `@blaxel/vercel`, and `@blaxel/telemetry`.
+Monorepo for the Blaxel TypeScript SDK. The main package is `@blaxel/core`, with framework integrations in `@blaxel/eve-sandbox`, `@blaxel/langgraph`, `@blaxel/llamaindex`, `@blaxel/mastra`, `@blaxel/vercel`, and `@blaxel/telemetry`.
 
 ## Repository structure
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ await job.deleteExecution(executionId);
 Blaxel provides additional packages for framework-specific integrations and telemetry:
 
 - [`@blaxel/telemetry`](./@blaxel/telemetry/README.md) - OpenTelemetry instrumentation
+- [`@blaxel/eve-sandbox`](./@blaxel/eve-sandbox/README.md) - Durable Blaxel sandbox backend for eve
 - [`@blaxel/vercel`](./@blaxel/vercel/README.md) - Vercel AI SDK integration
 - [`@blaxel/llamaindex`](./@blaxel/llamaindex/README.md) - LlamaIndex integration
 - [`@blaxel/langgraph`](./@blaxel/langgraph/README.md) - LangGraph integration

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "sdk-ts",
       "dependencies": {
         "@blaxel/core": "workspace:*",
+        "@blaxel/eve-sandbox": "workspace:*",
         "@blaxel/langgraph": "workspace:*",
         "@blaxel/llamaindex": "workspace:*",
         "@blaxel/mastra": "workspace:*",
@@ -66,6 +67,25 @@
         "typescript-eslint": "^8.31.1",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
+      },
+    },
+    "@blaxel/eve-sandbox": {
+      "name": "@blaxel/eve-sandbox",
+      "version": "0.2.59",
+      "dependencies": {
+        "@blaxel/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.5",
+        "ai": "^7.0.38",
+        "eslint": "9.39.2",
+        "eve": "^0.31.3",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.64.0",
+      },
+      "peerDependencies": {
+        "ai": "^7.0.38",
+        "eve": "^0.31.3",
       },
     },
     "@blaxel/langgraph": {
@@ -313,6 +333,8 @@
 
     "@blaxel/core": ["@blaxel/core@workspace:@blaxel/core"],
 
+    "@blaxel/eve-sandbox": ["@blaxel/eve-sandbox@workspace:@blaxel/eve-sandbox"],
+
     "@blaxel/langgraph": ["@blaxel/langgraph@workspace:@blaxel/langgraph"],
 
     "@blaxel/llamaindex": ["@blaxel/llamaindex@workspace:@blaxel/llamaindex"],
@@ -391,13 +413,13 @@
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
     "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
 
     "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
 
     "@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
 
@@ -659,6 +681,8 @@
 
     "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.143.0", "", {}, "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
@@ -682,6 +706,36 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.3", "", { "os": "android", "cpu": "arm64" }, "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.3", "", { "os": "linux", "cpu": "arm" }, "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.3", "", { "os": "none", "cpu": "arm64" }, "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw=="],
 
@@ -939,6 +993,8 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
@@ -1097,6 +1153,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
+
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -1106,6 +1164,8 @@
     "date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1175,6 +1235,8 @@
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
@@ -1195,7 +1257,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+    "eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -1215,6 +1277,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "eve": ["eve@0.31.3", "", { "dependencies": { "nitro": "3.0.260610-beta", "undici": "8.9.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "ai": "^7.0.38", "braintrust": "^3.0.0", "just-bash": "^3.0.0", "microsandbox": "^0.5.0" }, "optionalPeers": ["@opentelemetry/api", "braintrust", "just-bash", "microsandbox"], "bin": { "eve": "./bin/eve.js" } }, "sha512-/ae8kfsVLGoy68BU+7uNEkXeEQzOHWaXi0Q+Fj5oA2On5POcU0DGR9AnZlOaDQoFLoEtMxRnR1urTw4H0U2O7Q=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -1233,7 +1297,7 @@
 
     "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
 
-    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+    "exsolve": ["exsolve@1.1.1", "", {}, "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1335,6 +1399,8 @@
 
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
+    "h3": ["h3@2.0.1-rc.22", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.15" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA=="],
+
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -1353,6 +1419,8 @@
 
     "hono-openapi": ["hono-openapi@0.4.8", "", { "dependencies": { "json-schema-walker": "^2.0.0" }, "peerDependencies": { "@hono/arktype-validator": "^2.0.0", "@hono/effect-validator": "^1.2.0", "@hono/typebox-validator": "^0.2.0 || ^0.3.0", "@hono/valibot-validator": "^0.5.1", "@hono/zod-validator": "^0.4.1", "@sinclair/typebox": "^0.34.9", "@valibot/to-json-schema": "^1.0.0-beta.3", "arktype": "^2.0.0", "effect": "^3.11.3", "hono": "^4.6.13", "openapi-types": "^12.1.3", "valibot": "^1.0.0-beta.9", "zod": "^3.23.8", "zod-openapi": "^4.0.0" }, "optionalPeers": ["@hono/arktype-validator", "@hono/effect-validator", "@hono/typebox-validator", "@hono/valibot-validator", "@hono/zod-validator", "@sinclair/typebox", "@valibot/to-json-schema", "arktype", "effect", "hono", "valibot", "zod", "zod-openapi"] }, "sha512-LYr5xdtD49M7hEAduV1PftOMzuT8ZNvkyWfh1DThkLsIr4RkvDb12UxgIiFbwrJB6FLtFXLoOZL9x4IeDk2+VA=="],
 
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
@@ -1364,6 +1432,8 @@
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "httpxy": ["httpxy@0.5.5", "", {}, "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1457,7 +1527,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
@@ -1541,7 +1611,7 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -1558,6 +1628,10 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "nf3": ["nf3@0.3.23", "", {}, "sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg=="],
+
+    "nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
     "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
@@ -1584,6 +1658,10 @@
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "ocache": ["ocache@0.1.5", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w=="],
+
+    "ofetch": ["ofetch@2.0.0-alpha.3", "", {}, "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
@@ -1747,7 +1825,11 @@
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
+    "rolldown": ["rolldown@1.2.3", "", { "dependencies": { "@oxc-project/types": "=0.143.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.3", "@rolldown/binding-darwin-arm64": "1.2.3", "@rolldown/binding-darwin-x64": "1.2.3", "@rolldown/binding-freebsd-x64": "1.2.3", "@rolldown/binding-linux-arm-gnueabihf": "1.2.3", "@rolldown/binding-linux-arm64-gnu": "1.2.3", "@rolldown/binding-linux-arm64-musl": "1.2.3", "@rolldown/binding-linux-ppc64-gnu": "1.2.3", "@rolldown/binding-linux-s390x-gnu": "1.2.3", "@rolldown/binding-linux-x64-gnu": "1.2.3", "@rolldown/binding-linux-x64-musl": "1.2.3", "@rolldown/binding-openharmony-arm64": "1.2.3", "@rolldown/binding-win32-arm64-msvc": "1.2.3", "@rolldown/binding-win32-x64-msvc": "1.2.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A=="],
+
     "rollup": ["rollup@4.56.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.56.0", "@rollup/rollup-android-arm64": "4.56.0", "@rollup/rollup-darwin-arm64": "4.56.0", "@rollup/rollup-darwin-x64": "4.56.0", "@rollup/rollup-freebsd-arm64": "4.56.0", "@rollup/rollup-freebsd-x64": "4.56.0", "@rollup/rollup-linux-arm-gnueabihf": "4.56.0", "@rollup/rollup-linux-arm-musleabihf": "4.56.0", "@rollup/rollup-linux-arm64-gnu": "4.56.0", "@rollup/rollup-linux-arm64-musl": "4.56.0", "@rollup/rollup-linux-loong64-gnu": "4.56.0", "@rollup/rollup-linux-loong64-musl": "4.56.0", "@rollup/rollup-linux-ppc64-gnu": "4.56.0", "@rollup/rollup-linux-ppc64-musl": "4.56.0", "@rollup/rollup-linux-riscv64-gnu": "4.56.0", "@rollup/rollup-linux-riscv64-musl": "4.56.0", "@rollup/rollup-linux-s390x-gnu": "4.56.0", "@rollup/rollup-linux-x64-gnu": "4.56.0", "@rollup/rollup-linux-x64-musl": "4.56.0", "@rollup/rollup-openbsd-x64": "4.56.0", "@rollup/rollup-openharmony-arm64": "4.56.0", "@rollup/rollup-win32-arm64-msvc": "4.56.0", "@rollup/rollup-win32-ia32-msvc": "4.56.0", "@rollup/rollup-win32-x64-gnu": "4.56.0", "@rollup/rollup-win32-x64-msvc": "4.56.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg=="],
+
+    "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -1816,6 +1898,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -1905,9 +1989,15 @@
 
     "typescript-eslint": ["typescript-eslint@8.64.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.64.0", "@typescript-eslint/parser": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/utils": "8.64.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ=="],
 
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
+
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -2055,6 +2145,8 @@
 
     "@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg=="],
 
+    "@apidevtools/json-schema-ref-parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -2073,19 +2165,35 @@
 
     "@aws-sdk/util-endpoints/@aws-sdk/types": ["@aws-sdk/types@3.972.0", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug=="],
 
+    "@blaxel/eve-sandbox/ai": ["ai@7.0.58", "", { "dependencies": { "@ai-sdk/gateway": "4.0.46", "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q=="],
+
+    "@blaxel/eve-sandbox/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
     "@blaxel/langgraph/@langchain/openai": ["@langchain/openai@1.2.6", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^6.18.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.0.0" } }, "sha512-fD+fRjqeWIM2r7mcFWCL9lp6iecUMJ8ePeqDjSQZtENP/u+RQ/18nfZE5wG9zBk7PT9BPlJWh8cZf07p748jzQ=="],
+
+    "@blaxel/langgraph/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
 
     "@blaxel/llamaindex/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.203.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.203.0", "import-in-the-middle": "^1.8.1", "require-in-the-middle": "^7.1.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ=="],
 
+    "@blaxel/llamaindex/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "@blaxel/mastra/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "@blaxel/telemetry/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "@blaxel/vercel/eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "@eslint/eslintrc/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "@fastify/fast-json-stringify-compiler/fast-json-stringify": ["fast-json-stringify@6.2.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-Eaf/KNIDwHkzfyeQFNfLXJnQ7cl1XQI3+zRqmPlvtkMigbXnAcasTrvJQmquBSxKfFGeRA6PFog8t+hFmpDoWw=="],
 
     "@fastify/proxy-addr/ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
+
+    "@hey-api/json-schema-ref-parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -2401,15 +2509,15 @@
 
     "c12/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
+    "c12/exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "convict/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
-    "eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
-
-    "eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "fast-json-stringify/fast-uri": ["fast-uri@4.1.1", "", {}, "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ=="],
 
@@ -2451,6 +2559,8 @@
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
+    "pkg-types/exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "protobufjs/@types/node": ["@types/node@24.10.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="],
@@ -2491,7 +2601,73 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
+    "@blaxel/eve-sandbox/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.46", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.25", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA=="],
+
+    "@blaxel/eve-sandbox/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
+
+    "@blaxel/eve-sandbox/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.25", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA=="],
+
+    "@blaxel/eve-sandbox/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/eve-sandbox/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/eve-sandbox/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/eve-sandbox/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/eve-sandbox/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@blaxel/langgraph/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/langgraph/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/langgraph/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/langgraph/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/langgraph/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "@blaxel/llamaindex/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.203.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ=="],
+
+    "@blaxel/llamaindex/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/llamaindex/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/llamaindex/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/llamaindex/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/llamaindex/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@blaxel/mastra/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/mastra/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/mastra/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/mastra/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/mastra/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@blaxel/telemetry/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/telemetry/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/telemetry/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/telemetry/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/telemetry/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@blaxel/vercel/eslint/@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@blaxel/vercel/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@blaxel/vercel/eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@blaxel/vercel/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "@blaxel/vercel/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -2712,6 +2888,48 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@blaxel/eve-sandbox/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@blaxel/eve-sandbox/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "@blaxel/eve-sandbox/ai/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@blaxel/eve-sandbox/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/eve-sandbox/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/eve-sandbox/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@blaxel/langgraph/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/langgraph/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/langgraph/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@blaxel/llamaindex/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/llamaindex/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/llamaindex/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@blaxel/mastra/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/mastra/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/mastra/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@blaxel/telemetry/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/telemetry/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/telemetry/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@blaxel/vercel/eslint/@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@blaxel/vercel/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@blaxel/vercel/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "type": "module",
   "scripts": {
     "lint": "bun --filter '*' lint && tsc -p tests/tsconfig.json && eslint tests/",
-    "build": "bun run --filter @blaxel/core build && bun run --filter '@blaxel/{telemetry,langgraph,llamaindex,vercel}' build && bun run --filter @blaxel/mastra build",
+    "build": "bun run --filter @blaxel/core build && bun run --filter '@blaxel/{telemetry,langgraph,llamaindex,vercel,eve-sandbox}' build && bun run --filter @blaxel/mastra build",
     "set-version": "npm version --workspaces --no-workspaces-update",
-    "dev": "concurrently -n core,telemetry,langgraph,llamaindex,vercel,mastra -c blue,green,yellow,magenta,cyan,white \"bun run --filter @blaxel/core dev\" \"bun run --filter @blaxel/telemetry dev\" \"bun run --filter @blaxel/langgraph dev\" \"bun run --filter @blaxel/llamaindex dev\" \"bun run --filter @blaxel/vercel dev\" \"bun run --filter @blaxel/mastra dev\"",
+    "dev": "concurrently -n core,telemetry,langgraph,llamaindex,vercel,eve,mastra -c blue,green,yellow,magenta,cyan,blue,white \"bun run --filter @blaxel/core dev\" \"bun run --filter @blaxel/telemetry dev\" \"bun run --filter @blaxel/langgraph dev\" \"bun run --filter @blaxel/llamaindex dev\" \"bun run --filter @blaxel/vercel dev\" \"bun run --filter @blaxel/eve-sandbox dev\" \"bun run --filter @blaxel/mastra dev\"",
     "test": "vitest run",
     "test:integration": "vitest run tests/integration",
     "test:e2e": "vitest run tests/e2e --config vitest.e2e.config.ts",
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@blaxel/core": "workspace:*",
+    "@blaxel/eve-sandbox": "workspace:*",
     "@blaxel/langgraph": "workspace:*",
     "@blaxel/llamaindex": "workspace:*",
     "@blaxel/mastra": "workspace:*",
@@ -57,6 +58,7 @@
   },
   "workspaces": [
     "@blaxel/core",
+    "@blaxel/eve-sandbox",
     "@blaxel/telemetry",
     "@blaxel/langgraph",
     "@blaxel/llamaindex",

--- a/scripts/replace-workspace-versions.js
+++ b/scripts/replace-workspace-versions.js
@@ -14,7 +14,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
 // Get all workspace package.json files
-const workspaces = ['core', 'telemetry', 'langgraph', 'llamaindex', 'vercel', 'mastra'];
+const workspaces = ['core', 'eve-sandbox', 'telemetry', 'langgraph', 'llamaindex', 'vercel', 'mastra'];
 
 // Build a map of package name -> version
 const packageVersions = new Map();

--- a/tests/integration/sandbox/eve-backend.test.ts
+++ b/tests/integration/sandbox/eve-backend.test.ts
@@ -1,0 +1,143 @@
+import { SandboxInstance } from "@blaxel/core";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { blaxel } from "../../../@blaxel/eve-sandbox/src/index.js";
+import {
+  defaultImage,
+  defaultLabels,
+  defaultRegion,
+  uniqueName,
+} from "./helpers.js";
+
+describe("Blaxel eve sandbox backend", { timeout: 59_000 }, () => {
+  const namePrefix = uniqueName("eve");
+
+  afterAll(async () => {
+    const page = await SandboxInstance.list({
+      limit: 100,
+      q: namePrefix,
+      showTerminated: true,
+    });
+    const results = await Promise.allSettled(
+      page.data
+        .filter((sandbox) => sandbox.metadata.name?.startsWith(`${namePrefix}-`))
+        .map((sandbox) => sandbox.delete()),
+    );
+    const failures = results
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason as unknown);
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `Failed to delete ${failures.length} Blaxel test sandbox${failures.length === 1 ? "" : "es"}.`,
+      );
+    }
+  });
+
+  const options = {
+    image: defaultImage,
+    labels: defaultLabels,
+    namePrefix,
+    region: defaultRegion,
+  };
+
+  it("runs and reconnects a durable eve session", async () => {
+    const firstBackend = blaxel(options);
+    const firstHandle = await firstBackend.create({
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "integration-base-session",
+      tags: { test: "eve-backend" },
+      templateKey: null,
+    });
+
+    expect(
+      await firstHandle.session.run({ command: "printf 'eve-live-ok'" }),
+    ).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "eve-live-ok",
+    });
+    expect(
+      await firstHandle.session.run({ command: "printf 'line-one\\nline-two\\n'" }),
+    ).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "line-one\nline-two\n",
+    });
+    const background = await firstHandle.session.spawn({
+      command: "sleep 0.2; printf 'spawn-live-ok'",
+    });
+    const [backgroundStdout, backgroundStderr, backgroundResult] = await Promise.all([
+      streamToText(background.stdout),
+      streamToText(background.stderr),
+      background.wait(),
+    ]);
+    expect(backgroundResult).toEqual({ exitCode: 0 });
+    expect(backgroundStdout).toBe("spawn-live-ok");
+    expect(backgroundStderr).toBe("");
+
+    await firstHandle.session.writeTextFile({
+      path: "durable/session.txt",
+      content: "persists-across-backend-instances",
+    });
+    const binary = new Uint8Array([0, 1, 127, 128, 255]);
+    await firstHandle.session.writeBinaryFile({ path: "durable/session.bin", content: binary });
+    expect(await firstHandle.session.readBinaryFile({ path: "durable/session.bin" })).toEqual(
+      binary,
+    );
+    const state = await firstHandle.captureState();
+    await firstHandle.shutdown();
+
+    const secondBackend = blaxel(options);
+    const secondHandle = await secondBackend.create({
+      existingMetadata: state.metadata,
+      runtimeContext: { appRoot: "/new-process" },
+      sessionKey: state.sessionKey,
+      templateKey: null,
+    });
+
+    expect(await secondHandle.session.readTextFile({ path: "durable/session.txt" })).toBe(
+      "persists-across-backend-instances",
+    );
+    expect(await secondHandle.session.readBinaryFile({ path: "durable/session.bin" })).toEqual(
+      binary,
+    );
+    expect((await secondHandle.captureState()).metadata).toEqual(state.metadata);
+    await secondHandle.session.setNetworkPolicy("deny-all");
+    const blocked = await secondHandle.session.run({
+      command: "curl -sS --max-time 3 -o /dev/null https://example.com",
+    });
+    expect(blocked.exitCode).not.toBe(0);
+    await secondHandle.shutdown();
+  });
+
+  it("enforces eve deny-all before the first command", async () => {
+    const backend = blaxel({ ...options, networkPolicy: "deny-all" });
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "integration-network-session",
+      templateKey: null,
+    });
+
+    const result = await handle.session.run({
+      command: "curl -sS --max-time 3 -o /dev/null https://example.com",
+    });
+    expect(result.exitCode).not.toBe(0);
+    await handle.shutdown();
+  });
+});
+
+async function streamToText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = "";
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) return result + decoder.decode();
+      result += decoder.decode(chunk.value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/tests/integration/sandbox/eve-backend.test.ts
+++ b/tests/integration/sandbox/eve-backend.test.ts
@@ -37,6 +37,9 @@ describe("Blaxel eve sandbox backend", { timeout: 59_000 }, () => {
   const options = {
     image: defaultImage,
     labels: defaultLabels,
+    lifecycle: {
+      expirationPolicies: [{ type: "ttl-max-age" as const, value: "1h", action: "delete" as const }],
+    },
     namePrefix,
     region: defaultRegion,
   };

--- a/tests/unit/eve-sandbox-lifecycle.test.ts
+++ b/tests/unit/eve-sandbox-lifecycle.test.ts
@@ -59,6 +59,7 @@ class FakeSandbox {
 }
 
 const resources = new Map<string, FakeSandbox>();
+const kubernetesLabelValue = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
 
 describe("Blaxel eve durable lifecycle", () => {
   afterEach(() => {
@@ -92,7 +93,10 @@ describe("Blaxel eve durable lifecycle", () => {
       templateKey: null,
       sessionKey: "durable-session",
       runtimeContext: { appRoot: "/app" },
-      tags: { ["agent-".repeat(20)]: "researcher-".repeat(20) },
+      tags: {
+        ["agent-".repeat(20)]: "researcher-".repeat(20),
+        [`${"x".repeat(58)}-suffix`]: `${"v".repeat(62)}-suffix`,
+      },
     });
 
     await firstHandle.session.writeTextFile({
@@ -111,7 +115,11 @@ describe("Blaxel eve durable lifecycle", () => {
     if (!("name" in createInput)) throw new Error("expected sandbox create options");
     expect(
       Object.entries(createInput.labels ?? {}).every(
-        ([key, value]) => key.length <= 63 && value.length <= 63,
+        ([key, value]) =>
+          key.length <= 63 &&
+          value.length <= 63 &&
+          kubernetesLabelValue.test(key) &&
+          kubernetesLabelValue.test(value),
       ),
     ).toBe(true);
 
@@ -129,7 +137,11 @@ describe("Blaxel eve durable lifecycle", () => {
     if (!reconnectMetadata) throw new Error("expected a metadata update");
     expect(
       Object.entries(reconnectMetadata[1].labels ?? {}).every(
-        ([key, value]) => key.length <= 63 && value.length <= 63,
+        ([key, value]) =>
+          key.length <= 63 &&
+          value.length <= 63 &&
+          kubernetesLabelValue.test(key) &&
+          kubernetesLabelValue.test(value),
       ),
     ).toBe(true);
     expect((await reconnected.captureState()).metadata).toEqual(state.metadata);
@@ -159,6 +171,31 @@ describe("Blaxel eve durable lifecycle", () => {
       }),
     ).rejects.toThrow(guidance);
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a potentially shared sandbox after a startup failure", async () => {
+    const sandbox = new FakeSandbox("eve-session-failed");
+    const startupError = new Error("startup failed");
+    sandbox.process.exec.mockRejectedValue(startupError);
+    vi.spyOn(SandboxInstance, "get").mockRejectedValue(
+      Object.assign(new Error("missing"), { code: 404 }),
+    );
+    vi.spyOn(SandboxInstance, "createIfNotExists").mockResolvedValue(
+      sandbox as unknown as SandboxInstance,
+    );
+
+    const error = await blaxel({ startupTimeoutMs: 1 })
+      .create({
+        templateKey: null,
+        sessionKey: "failed-session",
+        runtimeContext: { appRoot: "/app" },
+      })
+      .catch((failure: unknown) => failure);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("startup failed");
+    expect((error as Error).cause).toBe(startupError);
+    expect(sandbox.delete).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/eve-sandbox-lifecycle.test.ts
+++ b/tests/unit/eve-sandbox-lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { SandboxInstance } from "@blaxel/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { blaxel } from "../../@blaxel/eve-sandbox/src/index.js";
+
+type SandboxCreateInput = NonNullable<
+  Parameters<typeof SandboxInstance.createIfNotExists>[0]
+>;
+
+class FakeSandbox {
+  readonly files = new Map<string, Uint8Array>();
+  readonly metadata: { name: string };
+  readonly fs = {
+    mkdir: vi.fn(() => Promise.resolve({})),
+    readBinary: vi.fn((path: string) => {
+      const value = this.files.get(path);
+      if (!value) throw Object.assign(new Error("missing"), { code: 404 });
+      return Promise.resolve(new Blob([new Uint8Array(value)]));
+    }),
+    rm: vi.fn((path: string) => {
+      this.files.delete(path);
+      return Promise.resolve({});
+    }),
+    write: vi.fn((path: string, content: string) => {
+      this.files.set(path, new TextEncoder().encode(content));
+      return Promise.resolve({});
+    }),
+    writeBinary: vi.fn((path: string, content: Uint8Array) => {
+      this.files.set(path, new Uint8Array(content));
+      return Promise.resolve({});
+    }),
+  };
+  readonly process = {
+    exec: vi.fn(() => Promise.resolve({
+      exitCode: 0,
+      pid: "process-1",
+      status: "completed" as const,
+      stderr: "",
+      stdout: "",
+    })),
+    get: vi.fn(() => Promise.resolve({
+      exitCode: 0,
+      pid: "process-1",
+      status: "completed" as const,
+      stderr: "",
+      stdout: "",
+    })),
+    kill: vi.fn(() => Promise.resolve({})),
+    streamLogs: vi.fn(() => ({ close() {}, wait: () => Promise.resolve() })),
+  };
+  readonly delete = vi.fn(() => {
+    resources.delete(this.metadata.name);
+    return Promise.resolve({});
+  });
+
+  constructor(name: string) {
+    this.metadata = { name };
+  }
+}
+
+const resources = new Map<string, FakeSandbox>();
+
+describe("Blaxel eve durable lifecycle", () => {
+  afterEach(() => {
+    resources.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("creates and reconnects durable sessions using generally available APIs", async () => {
+    const create = vi.spyOn(SandboxInstance, "createIfNotExists").mockImplementation((input) => {
+      const name = sandboxInputName(input);
+      if (!name) throw new Error("name required");
+      const existing = resources.get(name);
+      if (existing) return Promise.resolve(existing as unknown as SandboxInstance);
+      const sandbox = new FakeSandbox(name);
+      resources.set(name, sandbox);
+      return Promise.resolve(sandbox as unknown as SandboxInstance);
+    });
+    vi.spyOn(SandboxInstance, "get").mockImplementation((name) => {
+      const sandbox = resources.get(name);
+      if (!sandbox) throw Object.assign(new Error("missing"), { code: 404 });
+      return Promise.resolve(sandbox as unknown as SandboxInstance);
+    });
+    const updateMetadata = vi
+      .spyOn(SandboxInstance, "updateMetadata")
+      .mockImplementation((name) => {
+        return Promise.resolve(resources.get(name) as unknown as SandboxInstance);
+      });
+
+    const firstBackend = blaxel({ image: "blaxel/base-image:latest" });
+    const firstHandle = await firstBackend.create({
+      templateKey: null,
+      sessionKey: "durable-session",
+      runtimeContext: { appRoot: "/app" },
+      tags: { ["agent-".repeat(20)]: "researcher-".repeat(20) },
+    });
+
+    await firstHandle.session.writeTextFile({
+      path: "durable/session.txt",
+      content: "persists-across-backend-instances",
+    });
+    const state = await firstHandle.captureState();
+    await firstHandle.shutdown();
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const firstCreate = create.mock.calls[0];
+    if (!firstCreate) throw new Error("expected a sandbox create");
+    const createInput = firstCreate[0];
+    const sandboxName = sandboxInputName(createInput);
+    expect(sandboxName?.length).toBeLessThanOrEqual(49);
+    if (!("name" in createInput)) throw new Error("expected sandbox create options");
+    expect(
+      Object.entries(createInput.labels ?? {}).every(
+        ([key, value]) => key.length <= 63 && value.length <= 63,
+      ),
+    ).toBe(true);
+
+    const secondBackend = blaxel({ image: "blaxel/base-image:latest" });
+    const reconnected = await secondBackend.create({
+      templateKey: null,
+      sessionKey: state.sessionKey,
+      existingMetadata: state.metadata,
+      runtimeContext: { appRoot: "/different-process" },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(updateMetadata).toHaveBeenCalledTimes(1);
+    const reconnectMetadata = updateMetadata.mock.calls[0];
+    if (!reconnectMetadata) throw new Error("expected a metadata update");
+    expect(
+      Object.entries(reconnectMetadata[1].labels ?? {}).every(
+        ([key, value]) => key.length <= 63 && value.length <= 63,
+      ),
+    ).toBe(true);
+    expect((await reconnected.captureState()).metadata).toEqual(state.metadata);
+    expect(await reconnected.session.readTextFile({ path: "durable/session.txt" })).toBe(
+      "persists-across-backend-instances",
+    );
+  });
+
+  it("rejects eve template prewarming with actionable GA setup guidance", async () => {
+    const create = vi.spyOn(SandboxInstance, "createIfNotExists");
+    const backend = blaxel({ image: "blaxel/base-image:latest" });
+    const guidance = /custom Blaxel image.*omit eve bootstrap\(\).*onSession\(\)/s;
+
+    await expect(
+      backend.prewarm({
+        templateKey: "template-key",
+        runtimeContext: { appRoot: "/app" },
+        seedFiles: [{ path: "seed.txt", content: "seeded" }],
+      }),
+    ).rejects.toThrow(guidance);
+
+    await expect(
+      backend.create({
+        templateKey: "template-key",
+        sessionKey: "template-session",
+        runtimeContext: { appRoot: "/app" },
+      }),
+    ).rejects.toThrow(guidance);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+function sandboxInputName(input: SandboxCreateInput): string | undefined {
+  if ("name" in input && typeof input.name === "string") return input.name;
+  if ("metadata" in input) return input.metadata.name;
+  return undefined;
+}

--- a/tests/unit/eve-sandbox-network-policy.test.ts
+++ b/tests/unit/eve-sandbox-network-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { toBlaxelNetworkPolicy } from "../../@blaxel/eve-sandbox/src/network-policy.js";
+
+describe("Blaxel eve network policy", () => {
+  it("maps coarse and domain policies", () => {
+    expect(toBlaxelNetworkPolicy("allow-all")).toEqual({});
+    expect(toBlaxelNetworkPolicy("deny-all")).toEqual({
+      proxy: { allowedDomains: [], routing: [] },
+    });
+    expect(toBlaxelNetworkPolicy({ allow: ["github.com", "*.npmjs.org"] })).toEqual({
+      proxy: {
+        allowedDomains: ["github.com", "*.npmjs.org"],
+        routing: [],
+      },
+    });
+  });
+
+  it("brokers transformed headers through write-only Blaxel proxy secrets", () => {
+    const policy = toBlaxelNetworkPolicy({
+      allow: {
+        "api.example.com": [
+          {
+            transform: [
+              { headers: { authorization: "Bearer secret", "x-tenant": "acme" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(policy.proxy?.allowedDomains).toEqual(["api.example.com"]);
+    expect(policy.proxy?.routing).toEqual([
+      {
+        destinations: ["api.example.com"],
+        headers: {
+          authorization: "{{SECRET:eve-0-0-0-0}}",
+          "x-tenant": "{{SECRET:eve-0-0-0-1}}",
+        },
+        secrets: {
+          "eve-0-0-0-0": "Bearer secret",
+          "eve-0-0-0-1": "acme",
+        },
+      },
+    ]);
+    expect(JSON.stringify(policy.proxy?.routing?.[0]?.headers)).not.toContain("Bearer secret");
+  });
+
+  it("rejects eve policies that Blaxel cannot enforce exactly", () => {
+    expect(() =>
+      toBlaxelNetworkPolicy({ allow: ["github.com"], subnets: { deny: ["10.0.0.0/8"] } }),
+    ).toThrow(/subnet/);
+    expect(() =>
+      toBlaxelNetworkPolicy({
+        allow: {
+          "api.example.com": [{ match: { path: { exact: "/v1" } }, transform: [] }],
+        },
+      }),
+    ).toThrow(/match condition/);
+    expect(() =>
+      toBlaxelNetworkPolicy({
+        allow: { "api.example.com": [{ forwardURL: "https://proxy.example.com" }] },
+      }),
+    ).toThrow(/forward requests/);
+  });
+});

--- a/tests/unit/eve-sandbox-session.test.ts
+++ b/tests/unit/eve-sandbox-session.test.ts
@@ -1,0 +1,135 @@
+import { SandboxInstance } from "@blaxel/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createBlaxelEveSession } from "../../@blaxel/eve-sandbox/src/session.js";
+
+type ProcessResult = {
+  exitCode: number;
+  pid: string;
+  status: "completed" | "killed" | "running";
+  stderr: string;
+  stdout: string;
+};
+
+describe("Blaxel eve session", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("maps eve commands, files, paths, removal, and network policy", async () => {
+    const files = new Map<string, Uint8Array>();
+    const processResult: ProcessResult = {
+      exitCode: 0,
+      pid: "process-1",
+      status: "completed",
+      stderr: "",
+      stdout: "hello",
+    };
+    const processExec = vi.fn((input: { command: string; workingDir?: string }) => {
+      void input;
+      return Promise.resolve(processResult);
+    });
+    const sandbox = {
+      metadata: { name: "eve-session-test" },
+      fs: {
+        mkdir: () => Promise.resolve(),
+        readBinary(filePath: string) {
+          const value = files.get(filePath);
+          if (!value) throw Object.assign(new Error("missing"), { code: 404 });
+          return Promise.resolve(new Blob([new Uint8Array(value)]));
+        },
+        rm(filePath: string) {
+          if (!files.delete(filePath)) throw Object.assign(new Error("missing"), { code: 404 });
+          return Promise.resolve();
+        },
+        write(filePath: string, content: string) {
+          files.set(filePath, new TextEncoder().encode(content));
+          return Promise.resolve();
+        },
+        writeBinary(filePath: string, content: Uint8Array) {
+          files.set(filePath, new Uint8Array(content));
+          return Promise.resolve();
+        },
+      },
+      process: {
+        exec: processExec,
+        get() {
+          return Promise.resolve(processResult);
+        },
+        kill: () => Promise.resolve(),
+        streamLogs(
+          _pid: string,
+          handlers: { onStdout?: (value: string) => void; onStderr?: (value: string) => void },
+        ) {
+          handlers.onStdout?.("hello");
+          return { close() {}, wait: () => Promise.resolve() };
+        },
+      },
+    } as unknown as SandboxInstance;
+    const updateNetwork = vi
+      .spyOn(SandboxInstance, "updateNetwork")
+      .mockResolvedValue(sandbox);
+    const session = createBlaxelEveSession({ id: "session-key", sandbox });
+
+    expect(session.id).toBe("session-key");
+    expect(session.resolvePath("notes/a.txt")).toBe("/workspace/notes/a.txt");
+    await session.writeTextFile({ path: "notes/a.txt", content: "one\ntwo\nthree\n" });
+    expect(await session.readTextFile({ path: "notes/a.txt", startLine: 2, endLine: 2 })).toBe(
+      "two\n",
+    );
+    await session.writeBinaryFile({ path: "data.bin", content: new Uint8Array([0, 1, 255]) });
+    expect(await session.readBinaryFile({ path: "data.bin" })).toEqual(
+      new Uint8Array([0, 1, 255]),
+    );
+    expect(await session.readFile({ path: "missing.txt" })).toBeNull();
+    await session.removePath({ path: "data.bin" });
+    await expect(session.removePath({ path: "data.bin", force: true })).resolves.toBeUndefined();
+
+    expect(await session.run({ command: "printf hello" })).toEqual({
+      exitCode: 0,
+      stdout: "hello",
+      stderr: "",
+    });
+    await session.run({ command: "pwd", workingDirectory: "notes" });
+    expect(processExec).toHaveBeenLastCalledWith(
+      expect.objectContaining({ workingDir: "/workspace/notes" }),
+    );
+    await session.setNetworkPolicy({ allow: ["github.com"] });
+    expect(updateNetwork).toHaveBeenCalledWith("eve-session-test", {
+      network: { proxy: { allowedDomains: ["github.com"], routing: [] } },
+    });
+  });
+
+  it("kills a provider process when unread output exceeds its bound", async () => {
+    const kill = vi.fn(() => Promise.resolve({}));
+    const sandbox = {
+      metadata: { name: "eve-overflow-test" },
+      process: {
+        exec: vi.fn(() => Promise.resolve({
+          exitCode: 0,
+          pid: "overflow-process",
+          status: "running" as const,
+          stderr: "",
+          stdout: "",
+        })),
+        get: vi.fn(),
+        kill,
+        streamLogs(
+          _pid: string,
+          handlers: { onStdout?: (value: string) => void },
+        ) {
+          handlers.onStdout?.("too-much-output");
+          return { close() {}, wait: () => Promise.resolve() };
+        },
+      },
+    } as unknown as SandboxInstance;
+    const session = createBlaxelEveSession({
+      id: "overflow-session",
+      processOutputBufferBytes: 4,
+      sandbox,
+    });
+
+    await expect(session.run({ command: "generate-output" })).rejects.toThrow(
+      /output exceeded the 4-byte buffer/,
+    );
+    expect(kill).toHaveBeenCalledWith("overflow-process");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-party `@blaxel/eve-sandbox` package that implements Eve's public `SandboxBackend` interface on top of GA Blaxel sandbox APIs.

- supports Eve's `bash`, `read_file`, `write_file`, `glob`, and `grep` paths
- supports foreground/background commands, streaming, text and binary files, recursive removal, and network policy updates
- preserves sessions across fresh backend instances through deterministic sandbox identity plus metadata/API lookup
- maps supported network policies exactly and rejects unsupported policy fields instead of weakening them
- includes a runnable example, setup guide, capability matrix, security/lifecycle guidance, CI coverage, and npm release registration

Tracks [ENG-4613](https://linear.app/blaxel/issue/ENG-4613/integration-eve-add-blaxel-sandbox-support).

## Why GA-only

Blaxel snapshot and fork APIs are not GA, so this adapter intentionally does not use them.

Template prewarming and agent seed files fail with actionable guidance to use a custom image and/or Eve's `onSession` hook. Durable reconnect uses deterministic named sandboxes and public lookup APIs available to GA customers.

## Validation

- full TypeScript SDK workspace build
- adapter lint and strict type checks
- 7 adapter unit tests
- 2 live Blaxel integration tests:
  - durable reconnect
  - deny-all network policy
- 2 live Eve tests:
  - public sandbox tool adapters
  - complete deterministic Eve agent turn through all five built-in sandbox tools
- npm package dry run confirming only the intended license, README, runtime/types, example, and package metadata

Live tests use unique per-run sandbox prefixes, surface teardown failures, and remove generated Eve state after each run.

## Repository baseline

The repository-wide lint command currently fails on clean `main` in unrelated existing packages. The lint gates covering this package and the changed test paths pass.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Follow-up commit addresses the `normalizeLabel` truncation bug and makes a deliberate behavioral change to not delete shared sandboxes on startup failure. Tests are strengthened with regex-based label validation and a new test case covering the startup failure path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0ccb9234e7c0a32c14276e149d8d97f764dc5558.</sup>
<!-- /MENDRAL_SUMMARY -->