### PR TITLE
feat(core): report H2 degradations to Sentry

### DIFF
--- a/@blaxel/core/src/common/h2stats.ts
+++ b/@blaxel/core/src/common/h2stats.ts
@@ -1,4 +1,5 @@
 import { logger } from "./logger.js";
+import { reportH2TransportDegradation } from "./sentry.js";
 
 export type H2FallbackReason =
   | "no-session"
@@ -72,6 +73,7 @@ class H2TransportStatsStore {
     } catch {
       // Diagnostics must never change transport behavior.
     }
+    reportH2TransportDegradation(domain, "establish-failure");
     publishDebugSnapshot(this.snapshot());
   }
 
@@ -87,6 +89,7 @@ class H2TransportStatsStore {
     } catch {
       // Diagnostics must never change transport behavior.
     }
+    reportH2TransportDegradation(domain, reason);
     publishDebugSnapshot(this.snapshot());
   }
 

--- a/@blaxel/core/src/common/sentry.test.ts
+++ b/@blaxel/core/src/common/sentry.test.ts
@@ -54,20 +54,44 @@ function makeTraversalStackError(): Error {
 }
 
 type CapturedEvent = {
-  exception: {
+  exception?: {
     values: Array<{
       type: string;
       value: string;
       stacktrace: { frames: Array<Record<string, unknown>> };
     }>;
   };
+  extra?: { count?: number };
+  fingerprint?: string[];
+  level?: string;
+  message?: string;
   tags: Record<string, string>;
 };
 
-function eventFromFetch(fetchMock: ReturnType<typeof vi.fn>): CapturedEvent {
-  const request = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+function createFetchMock() {
+  return vi.fn((input: unknown, init?: RequestInit): Promise<{ ok: boolean }> => {
+    void input;
+    void init;
+    return Promise.resolve({ ok: true });
+  });
+}
+
+type FetchMock = ReturnType<typeof createFetchMock>;
+
+function eventFromFetch(fetchMock: FetchMock): CapturedEvent {
+  const request = fetchMock.mock.calls[0]?.[1];
   if (typeof request?.body !== "string") throw new Error("Expected a string Sentry envelope");
   return JSON.parse(request.body.split("\n")[2]) as CapturedEvent;
+}
+
+function eventsFromFetch(fetchMock: FetchMock): CapturedEvent[] {
+  return fetchMock.mock.calls.map((call) => {
+    const request = call[1];
+    if (typeof request?.body !== "string") {
+      throw new Error("Expected a string Sentry envelope");
+    }
+    return JSON.parse(request.body.split("\n")[2]) as CapturedEvent;
+  });
 }
 
 function emitUncaughtExceptionMonitor(error: Error): boolean {
@@ -95,6 +119,8 @@ describe("SDK Sentry boundary", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("./node.js");
     vi.unstubAllGlobals();
     for (const listener of process.listeners("uncaughtExceptionMonitor")) {
       if (!originalMonitorListeners.includes(listener)) {
@@ -105,7 +131,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("does not replace console.error or report caught errors", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     const hostConsoleError = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "error").mockImplementation(hostConsoleError);
@@ -122,7 +148,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("composes with host handlers and reports one sanitized SDK-owned event", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     const hostMonitor = vi.fn();
     const hostRejection = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -144,7 +170,7 @@ describe("SDK Sentry boundary", () => {
       expect(fetchMock).toHaveBeenCalledOnce();
 
       const event = eventFromFetch(fetchMock);
-      expect(event.exception.values[0]).toMatchObject({
+      expect(event.exception?.values[0]).toMatchObject({
         type: "TypeError",
         value: "Unhandled SDK exception",
       });
@@ -154,7 +180,7 @@ describe("SDK Sentry boundary", () => {
         "blaxel.error_source": "unhandled-sdk-exception",
       });
       expect(event.tags).not.toHaveProperty("blaxel.workspace");
-      const frames = event.exception.values[0].stacktrace.frames;
+      const frames = event.exception?.values[0]?.stacktrace.frames ?? [];
       expect(frames.length).toBeGreaterThan(0);
       for (const frame of frames) {
         expect(frame.filename).toBe("@blaxel/core/src/common/sentry.test.ts");
@@ -172,7 +198,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("does not attribute an application-owned exception with a later SDK frame", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     const { initSentry } = await import("./sentry.js");
@@ -183,7 +209,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("rejects a forged owned path containing parent traversal", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     const { initSentry } = await import("./sentry.js");
@@ -194,7 +220,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("contains delivery setup failures without creating an unhandled rejection", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal(
       "AbortController",
@@ -214,7 +240,7 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("composes with browser handlers and ignores primitive rejections", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     const listeners = new Map<string, (event: unknown) => void>();
     const addEventListener = vi.fn((type: string, listener: (event: unknown) => void) => {
       listeners.set(type, listener);
@@ -238,15 +264,229 @@ describe("SDK Sentry boundary", () => {
   });
 
   it("does not initialize when tracking is disabled", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
     mockSettings.tracking = false;
 
-    const { initSentry, isSentryInitialized } = await import("./sentry.js");
+    const {
+      flushSentry,
+      initSentry,
+      isSentryInitialized,
+      reportH2TransportDegradation,
+    } = await import("./sentry.js");
     initSentry();
     emitUncaughtExceptionMonitor(makeSdkError());
+    reportH2TransportDegradation(
+      "sbx-test-workspace.us-pdx-1.bl.run",
+      "no-session",
+    );
+    await flushSentry();
 
     expect(isSentryInitialized()).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rolls a 100-fallback burst into one warning event", async () => {
+    vi.useFakeTimers();
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+    const domain = "sbx-test-workspace.us-pdx-1.bl.run";
+    const domainTag = "blaxel-edge:prod:us-pdx-1";
+
+    for (let index = 0; index < 100; index++) {
+      reportH2TransportDegradation(domain, "no-session");
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(eventFromFetch(fetchMock)).toMatchObject({
+      level: "warning",
+      message: "h2 transport degradation: no-session",
+      fingerprint: ["h2-degradation", "no-session", domainTag],
+      tags: {
+        "blaxel.version": "9.9.9",
+        "blaxel.commit": "abcdef0",
+        "blaxel.error_source": "h2-transport-degradation",
+        "blaxel.runtime": `node/${process.versions.node}`,
+        reason: "no-session",
+        domainTag,
+      },
+      extra: { count: 100 },
+    });
+  });
+
+  it("groups keys independently and hashes external domains", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+    const externalDomain = "customer.internal.example";
+    const blaxelDomain = "sbx-test-workspace.us-pdx-1.bl.run";
+
+    reportH2TransportDegradation(externalDomain, "no-session");
+    reportH2TransportDegradation(externalDomain, "no-session");
+    reportH2TransportDegradation(blaxelDomain, "request-rejected");
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const events = eventsFromFetch(fetchMock);
+    const externalEvent = events.find(
+      (event) => event.tags.reason === "no-session",
+    );
+    const blaxelEvent = events.find(
+      (event) => event.tags.reason === "request-rejected",
+    );
+
+    expect(externalEvent).toMatchObject({ extra: { count: 2 } });
+    expect(externalEvent?.tags.domainTag).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(JSON.stringify(externalEvent)).not.toContain(externalDomain);
+    expect(blaxelEvent).toMatchObject({
+      tags: { domainTag: "blaxel-edge:prod:us-pdx-1" },
+      extra: { count: 1 },
+    });
+  });
+
+  it("groups Blaxel edge hosts by environment and region", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+
+    reportH2TransportDegradation(
+      "sbx-first-workspace.us-pdx-1.bl.run",
+      "no-session",
+    );
+    reportH2TransportDegradation(
+      "sbx-second-workspace.us-pdx-1.bl.run",
+      "no-session",
+    );
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(eventFromFetch(fetchMock)).toMatchObject({
+      fingerprint: [
+        "h2-degradation",
+        "no-session",
+        "blaxel-edge:prod:us-pdx-1",
+      ],
+      extra: { count: 2 },
+    });
+  });
+
+  it("keeps stable Blaxel control-plane domains identifiable", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+
+    reportH2TransportDegradation("api.blaxel.ai", "no-session");
+    await flushSentry();
+
+    expect(eventFromFetch(fetchMock)).toMatchObject({
+      tags: { domainTag: "blaxel-api:prod" },
+      fingerprint: ["h2-degradation", "no-session", "blaxel-api:prod"],
+    });
+  });
+
+  it("caps active rollup keys at 20", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+
+    for (let index = 0; index < 21; index++) {
+      reportH2TransportDegradation(
+        `sbx-test-workspace.us-test-${index}.bl.run`,
+        "no-session",
+      );
+    }
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledTimes(20);
+  });
+
+  it("caps H2 degradation events at 100 per process", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+
+    for (let index = 0; index < 101; index++) {
+      reportH2TransportDegradation(
+        "sbx-test-workspace.us-pdx-1.bl.run",
+        "no-session",
+      );
+      await flushSentry();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(100);
+  });
+
+  it("fails closed when an external domain cannot be hashed", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.doMock("./node.js", () => ({
+      crypto: {
+        createHash: () => {
+          throw new Error("hash unavailable");
+        },
+      },
+    }));
+
+    const { flushSentry, initSentry, reportH2TransportDegradation } = await import(
+      "./sentry.js"
+    );
+    initSentry();
+
+    expect(() =>
+      reportH2TransportDegradation("private.customer.example", "no-session"),
+    ).not.toThrow();
+    await flushSentry();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports degradations through the H2 statistics hooks", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { flushSentry, initSentry } = await import("./sentry.js");
+    initSentry();
+    const { recordH2Fallback } = await import("./h2stats.js");
+
+    recordH2Fallback(
+      "sbx-test-workspace.us-pdx-1.bl.run",
+      "unsupported-body",
+    );
+    await flushSentry();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(eventFromFetch(fetchMock)).toMatchObject({
+      message: "h2 transport degradation: unsupported-body",
+      extra: { count: 1 },
+    });
   });
 });

--- a/@blaxel/core/src/common/sentry.ts
+++ b/@blaxel/core/src/common/sentry.ts
@@ -1,4 +1,6 @@
+import { crypto } from "./node.js";
 import { settings } from "./settings.js";
+import type { H2FallbackReason } from "./h2stats.js";
 
 type SentryConfig = {
   publicKey: string;
@@ -14,6 +16,15 @@ type ParsedFrame = {
 };
 
 type SentryEvent = Record<string, unknown> & { event_id: string };
+
+export type H2DegradationReason = "establish-failure" | H2FallbackReason;
+
+type H2DegradationRollup = {
+  count: number;
+  domainTag: string;
+  reason: H2DegradationReason;
+  timer: ReturnType<typeof setTimeout>;
+};
 
 const PACKAGE_LAYOUT_MARKERS = [
   "/src/common/sentry.ts",
@@ -43,7 +54,11 @@ const SAFE_ERROR_NAMES = new Set([
 ]);
 
 const MAX_IN_FLIGHT_EVENTS = 20;
+const MAX_ACTIVE_H2_ROLLUPS = 20;
+const MAX_CACHED_DOMAIN_TAGS = 100;
+const MAX_H2_EVENTS_PER_PROCESS = 100;
 const DELIVERY_TIMEOUT_MS = 500;
+const H2_ROLLUP_WINDOW_MS = 60_000;
 const SAFE_FILENAME_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
 let sentryInitialized = false;
@@ -53,6 +68,9 @@ let flushPromise: Promise<void> | null = null;
 
 const capturedExceptions = new WeakSet<Error>();
 const inFlightDeliveries = new Set<Promise<void>>();
+const domainTagCache = new Map<string, string | null>();
+const h2DegradationRollups = new Map<string, H2DegradationRollup>();
+let h2EventsEmitted = 0;
 
 /**
  * Normalize stack filenames without resolving or exposing host filesystem data.
@@ -255,6 +273,101 @@ function errorToSentryEvent(error: Error, ownedFrames: ParsedFrame[]): SentryEve
   };
 }
 
+function runtimeTag(): string {
+  const host = globalThis as typeof globalThis & {
+    Deno?: { version?: { deno?: string } };
+    process?: { versions?: { bun?: string; node?: string } };
+  };
+
+  if (host.process?.versions?.bun) return `bun/${host.process.versions.bun}`;
+  if (host.Deno?.version?.deno) return `deno/${host.Deno.version.deno}`;
+  if (host.process?.versions?.node) return `node/${host.process.versions.node}`;
+  return "browser";
+}
+
+function normalizeDomain(domain: string): string | null {
+  const normalized = domain.trim().toLowerCase().replace(/\.$/, "");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function blaxelEdgeDomainTag(domain: string): string | null {
+  const edgeSuffixes = [
+    { environment: "prod", suffix: ".bl.run" },
+    { environment: "dev", suffix: ".runv2.blaxel.dev" },
+  ] as const;
+
+  for (const { environment, suffix } of edgeSuffixes) {
+    if (!domain.endsWith(suffix)) continue;
+
+    const region = domain.slice(0, -suffix.length).split(".").at(-1);
+    if (region && /^[a-z0-9-]+$/.test(region)) {
+      return `blaxel-edge:${environment}:${region}`;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function uncachedDomainTag(domain: string): string | null {
+  const stableBlaxelDomains: Record<string, string> = {
+    "api.blaxel.ai": "blaxel-api:prod",
+    "api.blaxel.dev": "blaxel-api:dev",
+    "run.blaxel.ai": "blaxel-run:prod",
+    "run.blaxel.dev": "blaxel-run:dev",
+  };
+  const stableTag = stableBlaxelDomains[domain];
+  if (stableTag) return stableTag;
+
+  const edgeTag = blaxelEdgeDomainTag(domain);
+  if (edgeTag) return edgeTag;
+  if (!crypto) return null;
+
+  try {
+    return `sha256:${crypto.createHash("sha256").update(domain).digest("hex")}`;
+  } catch {
+    return null;
+  }
+}
+
+function domainToTag(domain: string): string | null {
+  if (domainTagCache.has(domain)) return domainTagCache.get(domain) ?? null;
+
+  const domainTag = uncachedDomainTag(domain);
+  if (domainTagCache.size >= MAX_CACHED_DOMAIN_TAGS) {
+    const oldestDomain = domainTagCache.keys().next().value;
+    if (oldestDomain !== undefined) domainTagCache.delete(oldestDomain);
+  }
+  domainTagCache.set(domain, domainTag);
+  return domainTag;
+}
+
+function h2DegradationToSentryEvent(
+  reason: H2DegradationReason,
+  domainTag: string,
+  count: number,
+): SentryEvent {
+  return {
+    event_id: generateEventId(),
+    timestamp: Date.now() / 1000,
+    platform: "javascript",
+    level: "warning",
+    environment: settings.env,
+    release: `sdk-typescript@${settings.version}`,
+    message: `h2 transport degradation: ${reason}`,
+    fingerprint: ["h2-degradation", reason, domainTag],
+    tags: {
+      "blaxel.version": settings.version,
+      "blaxel.commit": settings.commit,
+      "blaxel.error_source": "h2-transport-degradation",
+      "blaxel.runtime": runtimeTag(),
+      reason,
+      domainTag,
+    },
+    extra: { count },
+  };
+}
+
 async function sendToSentry(event: SentryEvent): Promise<void> {
   if (!sentryConfig) return;
 
@@ -293,14 +406,83 @@ async function sendToSentry(event: SentryEvent): Promise<void> {
   }
 }
 
-function scheduleDelivery(event: SentryEvent): void {
-  if (inFlightDeliveries.size >= MAX_IN_FLIGHT_EVENTS) return;
+function scheduleDelivery(event: SentryEvent): boolean {
+  if (inFlightDeliveries.size >= MAX_IN_FLIGHT_EVENTS) return false;
 
   // Contain rejections from setup that occurs before sendToSentry's internal
   // fetch guard (for example, a host-provided AbortController implementation).
   const delivery = sendToSentry(event).catch(() => undefined);
   inFlightDeliveries.add(delivery);
   void delivery.then(() => inFlightDeliveries.delete(delivery));
+  return true;
+}
+
+function emitH2DegradationRollup(key: string): void {
+  const rollup = h2DegradationRollups.get(key);
+  if (!rollup) return;
+
+  h2DegradationRollups.delete(key);
+  clearTimeout(rollup.timer);
+  if (h2EventsEmitted >= MAX_H2_EVENTS_PER_PROCESS) return;
+
+  if (
+    scheduleDelivery(
+      h2DegradationToSentryEvent(rollup.reason, rollup.domainTag, rollup.count),
+    )
+  ) {
+    h2EventsEmitted++;
+  }
+}
+
+function flushH2DegradationRollups(): void {
+  for (const key of [...h2DegradationRollups.keys()]) {
+    emitH2DegradationRollup(key);
+  }
+}
+
+/** @internal */
+export function reportH2TransportDegradation(
+  domain: string,
+  reason: H2DegradationReason,
+): void {
+  if (!sentryInitialized || !sentryConfig) return;
+
+  try {
+    if (h2EventsEmitted >= MAX_H2_EVENTS_PER_PROCESS) return;
+
+    const normalizedDomain = normalizeDomain(domain);
+    if (!normalizedDomain) return;
+
+    const domainTag = domainToTag(normalizedDomain);
+    if (!domainTag) return;
+
+    const key = `${reason}\0${domainTag}`;
+    const existing = h2DegradationRollups.get(key);
+    if (existing) {
+      existing.count++;
+      return;
+    }
+
+    if (h2DegradationRollups.size >= MAX_ACTIVE_H2_ROLLUPS) return;
+
+    const timer = setTimeout(() => {
+      try {
+        emitH2DegradationRollup(key);
+      } catch {
+        // Telemetry must never change transport behavior.
+      }
+    }, H2_ROLLUP_WINDOW_MS);
+    (timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+
+    h2DegradationRollups.set(key, {
+      count: 1,
+      domainTag,
+      reason,
+      timer,
+    });
+  } catch {
+    // Telemetry must never change transport behavior.
+  }
 }
 
 function captureException(error: Error): void {
@@ -377,7 +559,15 @@ export function initSentry(): void {
  * Events are sent exactly once; flush never re-enqueues them.
  */
 export async function flushSentry(timeout = DELIVERY_TIMEOUT_MS): Promise<void> {
-  if (!sentryInitialized || inFlightDeliveries.size === 0) return;
+  if (!sentryInitialized) return;
+
+  try {
+    flushH2DegradationRollups();
+  } catch {
+    // Flushing telemetry must never affect application shutdown.
+  }
+
+  if (inFlightDeliveries.size === 0) return;
 
   if (flushPromise) {
     await flushPromise;


### PR DESCRIPTION
## Summary

- Report H2 establishment failures and fetch fallbacks through the existing Sentry client.
- Roll up events for 60 seconds by reason and canonical domain tag.
- Canonicalize Blaxel edge hosts by environment and region. Hash all external domains.
- Bound active rollups, process events, in-flight delivery, and delivery time.

## Why

H2 can silently degrade to fetch. The SDK counts these cases, but we need fleet-level visibility without sending one Sentry event per request or exposing resource-bearing hostnames.

## Safety

- Uses the existing `settings.tracking` consent boundary.
- Adds no public export or H2 telemetry flag.
- Keeps telemetry failures outside the transport path.
- Uses unreferenced timers and flushes pending rollups during `flushSentry()`.

## Verification

- `npm test` in `@blaxel/core`: 175 passed
- `npm run build` in `@blaxel/core`: passed
- Focused ESLint: passed
- H2 transport and debug tests: 14 passed
- Sentry tests: 15 passed

This draft is stacked on #409. Its diff contains only the ENG-4647 Sentry work. Retarget it to `main` after #409 merges.

Linear: [ENG-4647](https://linear.app/blaxel/issue/ENG-4647/report-h2-transport-degradations-to-sentry)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds H2 transport degradation reporting to Sentry with a 60-second rollup window. Events are grouped by reason and canonicalized domain tag, with bounds on active rollups (20), cached domain tags (100), in-flight deliveries (20), and total per-process events (100). External domains are SHA-256 hashed to avoid leaking hostnames.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b80f22ead0fc3fa4d35d46385b2bcb4d9f8cc934.</sup>
<!-- /MENDRAL_SUMMARY -->