### PR TITLE
test(sandbox): proxy {{FUNC:*}} dynamic placeholder integration tests

### DIFF
--- a/tests/integration/sandbox/proxy/functions.test.ts
+++ b/tests/integration/sandbox/proxy/functions.test.ts
@@ -1,0 +1,404 @@
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { createEchoServerSandbox, funcProxyHelperScript, lowercaseKeys, parseFullJsonOutput, proxyCleanup } from './helpers.js'
+
+/**
+ * Exercises the proxy's dynamic `{{FUNC:*}}` placeholders end to end:
+ *  - the generated value reaches the upstream in the injected header/body, and
+ *  - the same value is echoed back to the client on the response, keyed by the
+ *    injection target: `X-Blaxel-Func-<target>: <funcname>=<value>[, …]`.
+ *
+ * Because at most 10 functions are expanded per request (across all headers and
+ * body values combined), every route below stays comfortably under that budget.
+ * Each route targets its own dedicated echo-server upstream so requests never
+ * share a function set, which keeps the target-keyed echo assertions and the
+ * budget test unambiguous.
+ */
+describe('dynamic {{FUNC:*}} placeholder validation', () => {
+  const createdSandboxes: string[] = []
+  afterAll(proxyCleanup(createdSandboxes))
+
+  let funcSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  // One URL per route/upstream.
+  let coreUrl: string
+  let corePostUrl: string
+  let echoFmtUrl: string
+  let aliasUrl: string
+  let failSafeUrl: string
+  let budgetUrl: string
+
+  const SECRET = "tok_live_abc123"
+  // A secret whose *value* is itself placeholder syntax. It must be substituted
+  // verbatim and never re-interpreted (functions run before secrets).
+  const TRICKY_SECRET = "{{FUNC:uuid()}}"
+
+  // 11 single-function headers -> one over the per-request budget of 10.
+  const budgetTargets = Array.from({ length: 11 }, (_, i) => `X-B${String(i).padStart(2, "0")}`)
+  const budgetHeaders = Object.fromEntries(budgetTargets.map((t) => [t, "{{FUNC:uuid()}}"]))
+
+  beforeAll(async () => {
+    // One upstream per route so no two routes ever share a request.
+    const [core, echoFmt, alias, failSafe, budget] = await Promise.all([
+      createEchoServerSandbox(createdSandboxes),
+      createEchoServerSandbox(createdSandboxes),
+      createEchoServerSandbox(createdSandboxes),
+      createEchoServerSandbox(createdSandboxes),
+      createEchoServerSandbox(createdSandboxes),
+    ])
+    coreUrl = `${core.url}/headers`
+    corePostUrl = `${core.url}/post`
+    echoFmtUrl = `${echoFmt.url}/headers`
+    aliasUrl = `${alias.url}/headers`
+    failSafeUrl = `${failSafe.url}/headers`
+    budgetUrl = `${budget.url}/headers`
+
+    const name = uniqueName("proxy-func")
+    funcSandbox = await SandboxInstance.create({
+      name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
+      network: {
+        proxy: {
+          routing: [
+            {
+              // ---- Core route: happy path, caps, trust boundary (8 funcs). --
+              destinations: [core.host],
+              headers: {
+                "X-Uuid": "{{FUNC:uuid()}}",
+                "X-Ts": "{{FUNC:timestamp()}}",
+                "X-Hex": "{{FUNC:randhex(16)}}",
+                "X-Nonce": "{{FUNC:nonce()}}",
+                // Case-insensitive function name; surrounding literal preserved.
+                "X-Case": "req-{{FUNC:UUIDV7()}}",
+                // Length argument at the 1024 cap: allowed.
+                "X-Hex-Cap": "{{FUNC:randhex(1024)}}",
+                "X-Str-Cap": "{{FUNC:randstr(1024)}}",
+                // Secret only (trust boundary + never echoed).
+                "X-Token": `Bearer {{SECRET:api-token}}`,
+              },
+              body: { "event_time": "{{FUNC:timestamp_ms()}}" },
+              secrets: { "api-token": SECRET },
+            },
+            {
+              // ---- Echo-format route: token format & multiplicity (7 funcs).-
+              destinations: [echoFmt.host],
+              headers: {
+                // Same function twice in one target -> two tokens, in order.
+                "X-Pair": "{{FUNC:randstr(8)}}-{{FUNC:randstr(8)}}",
+                // Two different functions in one target -> two named tokens.
+                "X-Two-Kinds": "{{FUNC:uuid()}}|{{FUNC:timestamp()}}",
+                // Function + resolvable secret: only the function token echoed.
+                "X-Func-And-Secret": "{{FUNC:datetime()}}::{{SECRET:api-token}}",
+                // Default lengths.
+                "X-Hex-Default": "{{FUNC:randhex()}}",
+                "X-Str-Default": "{{FUNC:randstr()}}",
+              },
+              secrets: { "api-token": SECRET },
+            },
+            {
+              // ---- Alias/format route: aliases, time formats, randint (7). --
+              destinations: [alias.host],
+              headers: {
+                "X-Uuidv4": "{{FUNC:uuidv4()}}",
+                "X-Iso": "{{FUNC:iso8601()}}",
+                "X-Date": "{{FUNC:date()}}",
+                "X-Time": "{{FUNC:time()}}",
+                "X-Ts-Ns": "{{FUNC:timestamp_ns()}}",
+                "X-Randint": "{{FUNC:randint()}}",
+                "X-Randint-N": "{{FUNC:randint(10)}}",
+              },
+            },
+            {
+              // ---- Fail-safe route: literals + resolution order + skip. ------
+              // Only one function here (nonce, in the skipped injection), so the
+              // uncertain budget-accounting of literals can never affect it.
+              destinations: [failSafe.host],
+              headers: {
+                "X-Unknown": "{{FUNC:notafunction()}}",
+                "X-Malformed": "{{FUNC:uuid}}",
+                "X-No-Parens": "{{FUNC:randhex}}",
+                "X-Over-Cap-Hex": "{{FUNC:randhex(1025)}}",
+                "X-Over-Cap-Str": "{{FUNC:randstr(5000)}}",
+                "X-Bad-Hex-Arg": "{{FUNC:randhex(abc)}}",
+                "X-Bad-Int-Zero": "{{FUNC:randint(0)}}",
+                // Secret value is placeholder syntax: substituted verbatim.
+                "X-Tricky-Secret": "{{SECRET:tricky}}",
+                // Function + failing secret -> whole injection skipped, nothing
+                // echoed for its target.
+                "X-Skip": "{{FUNC:nonce()}}-{{SECRET:missing}}",
+              },
+              secrets: { "tricky": TRICKY_SECRET },
+            },
+            {
+              // ---- Budget route: 11 functions -> exactly one over the cap. --
+              destinations: [budget.host],
+              headers: budgetHeaders,
+            },
+          ],
+        },
+      },
+    })
+    createdSandboxes.push(name)
+    await funcSandbox.fs.write("/tmp/func-proxy-test.js", funcProxyHelperScript)
+  }, 300_000)
+
+  type FuncResult = {
+    status: number
+    responseHeaders: Record<string, string>
+    upstream: { headers: Record<string, string>; json: Record<string, unknown> }
+  }
+  type EchoToken = { name: string; value: string }
+
+  const runGet = async (url: string, extraHeaders?: string): Promise<FuncResult> => {
+    const cmd = `node /tmp/func-proxy-test.js GET ${url}` + (extraHeaders ? ` '${extraHeaders}'` : "")
+    const result = await funcSandbox.process.exec({ command: cmd, waitForCompletion: true })
+    expect(result.exitCode).toBe(0)
+    return parseFullJsonOutput<FuncResult>(result.logs)
+  }
+
+  // Parses the `X-Blaxel-Func-<target>` echo header into `name=value` tokens.
+  // Generated values are hex / alphanumerics / digits / UUIDs / RFC 3339, none
+  // of which contain `,` or `=`, so the split is unambiguous.
+  const echoTokens = (res: FuncResult, target: string): EchoToken[] | undefined => {
+    const raw = res.responseHeaders[`x-blaxel-func-${target.toLowerCase()}`]
+    if (raw === undefined) return undefined
+    return raw.split(",").map((t) => t.trim()).map((tok) => {
+      const i = tok.indexOf("=")
+      return { name: tok.slice(0, i), value: tok.slice(i + 1) }
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core route: happy path, caps, trust boundary.
+  // ---------------------------------------------------------------------------
+
+  it('injects {{FUNC:uuid()}} and echoes it keyed by the target header', async () => {
+    const res = await runGet(coreUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-uuid"]
+    expect(injected).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    // New echo format: X-Blaxel-Func-X-Uuid: uuid=<value>
+    expect(echoTokens(res, "X-Uuid")).toEqual([{ name: "uuid", value: injected }])
+  }, 60_000)
+
+  it('generates a fresh value on every request', async () => {
+    const first = await runGet(coreUrl)
+    const second = await runGet(coreUrl)
+    expect(echoTokens(first, "X-Uuid")![0].value).not.toBe(echoTokens(second, "X-Uuid")![0].value)
+  }, 60_000)
+
+  it('injects {{FUNC:timestamp()}} as unix seconds and echoes it back', async () => {
+    const res = await runGet(coreUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-ts"]
+    expect(injected).toMatch(/^\d+$/)
+    expect(echoTokens(res, "X-Ts")).toEqual([{ name: "timestamp", value: injected }])
+    expect(Math.abs(Number(injected) - Math.floor(Date.now() / 1000))).toBeLessThan(300)
+  }, 60_000)
+
+  it('injects {{FUNC:randhex(16)}} and {{FUNC:nonce()}} with the right shapes', async () => {
+    const res = await runGet(coreUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-hex"]).toMatch(/^[0-9a-f]{16}$/)
+    expect(echoTokens(res, "X-Hex")).toEqual([{ name: "randhex", value: h["x-hex"] }])
+    expect(h["x-nonce"]).toMatch(/^[0-9a-f]{32}$/)
+    expect(echoTokens(res, "X-Nonce")).toEqual([{ name: "nonce", value: h["x-nonce"] }])
+  }, 60_000)
+
+  it('resolves function names case-insensitively and echoes only the generated value', async () => {
+    const res = await runGet(coreUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-case"]
+    // {{FUNC:UUIDV7()}} resolved despite the uppercase name.
+    expect(injected).toMatch(/^req-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    // The echo carries only the generated value, not the surrounding "req-".
+    expect(echoTokens(res, "X-Case")).toEqual([{ name: "uuidv7", value: injected.slice("req-".length) }])
+  }, 60_000)
+
+  it('allows the maximum length argument (1024) for randhex/randstr', async () => {
+    const res = await runGet(coreUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-hex-cap"]).toMatch(/^[0-9a-f]{1024}$/)
+    expect(h["x-str-cap"]).toMatch(/^[a-zA-Z0-9]{1024}$/)
+  }, 60_000)
+
+  it('injects {{FUNC:*}} into POST body fields and echoes keyed by the field name', async () => {
+    const result = await funcSandbox.process.exec({
+      command: `node /tmp/func-proxy-test.js POST ${corePostUrl} '{}' '{"user_field":"untouched","client_func":"{{FUNC:uuid()}}"}'`,
+      waitForCompletion: true,
+    })
+    expect(result.exitCode).toBe(0)
+    const res = parseFullJsonOutput<FuncResult>(result.logs)
+
+    const injected = String(res.upstream.json.event_time)
+    expect(injected).toMatch(/^\d+$/)
+    expect(echoTokens(res, "event_time")).toEqual([{ name: "timestamp_ms", value: injected }])
+    // Client-supplied fields are untouched; client {{FUNC:*}} stays literal.
+    expect(res.upstream.json.user_field).toBe("untouched")
+    expect(res.upstream.json.client_func).toBe("{{FUNC:uuid()}}")
+  }, 60_000)
+
+  it('resolves the secret on the wire but never exposes raw templates or the secret', async () => {
+    const res = await runGet(coreUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-token"]).toBe(`Bearer ${SECRET}`)
+    expect(h["x-uuid"]).not.toContain("{{FUNC:")
+    expect(h["x-token"]).not.toContain("{{SECRET:")
+    // Secret-only target is never echoed, and the secret never appears anywhere.
+    expect(echoTokens(res, "X-Token")).toBeUndefined()
+    expect(JSON.stringify(res.responseHeaders)).not.toContain(SECRET)
+  }, 60_000)
+
+  it('does not expand {{FUNC:*}} in client-supplied request headers (and never echoes them)', async () => {
+    const res = await runGet(coreUrl, '{"X-User-Func":"{{FUNC:uuid()}}"}')
+    expect(lowercaseKeys(res.upstream.headers)["x-user-func"]).toBe("{{FUNC:uuid()}}")
+    expect(echoTokens(res, "X-User-Func")).toBeUndefined()
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Echo-format route: token format, multiplicity, func+secret.
+  // ---------------------------------------------------------------------------
+
+  it('emits one token per function occurrence, in generation order', async () => {
+    const res = await runGet(echoFmtUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-pair"]
+    const [a, b] = injected.split("-")
+    expect(a).toMatch(/^[a-zA-Z0-9]{8}$/)
+    expect(b).toMatch(/^[a-zA-Z0-9]{8}$/)
+    expect(a).not.toBe(b)
+    // Two randstr tokens under the single target header, in generation order.
+    expect(echoTokens(res, "X-Pair")).toEqual([
+      { name: "randstr", value: a },
+      { name: "randstr", value: b },
+    ])
+  }, 60_000)
+
+  it('names each token by its own function when a target mixes functions', async () => {
+    const res = await runGet(echoFmtUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-two-kinds"]
+    const [u, t] = injected.split("|")
+    expect(u).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    expect(t).toMatch(/^\d+$/)
+    expect(echoTokens(res, "X-Two-Kinds")).toEqual([
+      { name: "uuid", value: u },
+      { name: "timestamp", value: t },
+    ])
+  }, 60_000)
+
+  it('echoes only the function token when a target mixes a function and a secret', async () => {
+    const res = await runGet(echoFmtUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-func-and-secret"]
+    const [funcPart, secretPart] = injected.split("::")
+    // Function expanded to an RFC 3339 timestamp; secret substituted after.
+    expect(funcPart).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    expect(secretPart).toBe(SECRET)
+    // Only the datetime function token is echoed; the secret is never present.
+    expect(echoTokens(res, "X-Func-And-Secret")).toEqual([{ name: "datetime", value: funcPart }])
+    expect(JSON.stringify(res.responseHeaders)).not.toContain(SECRET)
+  }, 60_000)
+
+  it('applies the default lengths for randhex() and randstr()', async () => {
+    const res = await runGet(echoFmtUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-hex-default"]).toMatch(/^[0-9a-f]{32}$/)
+    expect(h["x-str-default"]).toMatch(/^[a-zA-Z0-9]{16}$/)
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Alias / format route: aliases, time formats, randint ranges.
+  // ---------------------------------------------------------------------------
+
+  it('resolves the uuidv4() and iso8601() aliases', async () => {
+    const res = await runGet(aliasUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-uuidv4"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    expect(echoTokens(res, "X-Uuidv4")).toEqual([{ name: "uuidv4", value: h["x-uuidv4"] }])
+    expect(h["x-iso"]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    expect(echoTokens(res, "X-Iso")).toEqual([{ name: "iso8601", value: h["x-iso"] }])
+  }, 60_000)
+
+  it('resolves date() and time() in the documented formats', async () => {
+    const res = await runGet(aliasUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-date"]).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(echoTokens(res, "X-Date")).toEqual([{ name: "date", value: h["x-date"] }])
+    expect(h["x-time"]).toMatch(/^([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/)
+    expect(echoTokens(res, "X-Time")).toEqual([{ name: "time", value: h["x-time"] }])
+  }, 60_000)
+
+  it('resolves timestamp_ns() to a nanosecond integer', async () => {
+    const res = await runGet(aliasUrl)
+    const injected = lowercaseKeys(res.upstream.headers)["x-ts-ns"]
+    expect(injected).toMatch(/^\d+$/)
+    // Nanoseconds since epoch is ~19 digits (much wider than seconds/millis).
+    expect(injected.length).toBeGreaterThanOrEqual(18)
+    expect(echoTokens(res, "X-Ts-Ns")).toEqual([{ name: "timestamp_ns", value: injected }])
+  }, 60_000)
+
+  it('resolves randint() and randint(n) within their documented ranges', async () => {
+    const res = await runGet(aliasUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-randint"]).toMatch(/^\d+$/)
+    const full = Number(h["x-randint"])
+    expect(full).toBeGreaterThanOrEqual(0)
+    expect(full).toBeLessThan(2147483647)
+    expect(h["x-randint-n"]).toMatch(/^\d+$/)
+    const bounded = Number(h["x-randint-n"])
+    expect(bounded).toBeGreaterThanOrEqual(0)
+    expect(bounded).toBeLessThan(10)
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Fail-safe route: literals, resolution order, skip semantics.
+  // ---------------------------------------------------------------------------
+
+  it('leaves unknown, malformed, invalid-arg and over-cap placeholders literal (no echo)', async () => {
+    const res = await runGet(failSafeUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    expect(h["x-unknown"]).toBe("{{FUNC:notafunction()}}")
+    expect(h["x-malformed"]).toBe("{{FUNC:uuid}}")
+    expect(h["x-no-parens"]).toBe("{{FUNC:randhex}}")
+    expect(h["x-over-cap-hex"]).toBe("{{FUNC:randhex(1025)}}")
+    expect(h["x-over-cap-str"]).toBe("{{FUNC:randstr(5000)}}")
+    expect(h["x-bad-hex-arg"]).toBe("{{FUNC:randhex(abc)}}")
+    expect(h["x-bad-int-zero"]).toBe("{{FUNC:randint(0)}}")
+    // Nothing resolved -> no echo headers for any of these targets.
+    for (const t of ["X-Unknown", "X-Malformed", "X-No-Parens", "X-Over-Cap-Hex", "X-Bad-Hex-Arg"]) {
+      expect(echoTokens(res, t)).toBeUndefined()
+    }
+  }, 60_000)
+
+  it('substitutes a secret whose value is placeholder syntax verbatim (never re-interpreted)', async () => {
+    const res = await runGet(failSafeUrl)
+    // The secret value "{{FUNC:uuid()}}" is inserted after the function pass has
+    // already run, so it is never expanded into a UUID.
+    expect(lowercaseKeys(res.upstream.headers)["x-tricky-secret"]).toBe(TRICKY_SECRET)
+    expect(echoTokens(res, "X-Tricky-Secret")).toBeUndefined()
+  }, 60_000)
+
+  it('skips an injection whose secret fails to resolve, echoing nothing for its target', async () => {
+    const res = await runGet(failSafeUrl)
+    // The whole "X-Skip" injection is dropped: no header reaches the upstream...
+    expect(lowercaseKeys(res.upstream.headers)["x-skip"]).toBeUndefined()
+    // ...and its function is not echoed, so the response never claims otherwise.
+    expect(echoTokens(res, "X-Skip")).toBeUndefined()
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Budget route: per-request function cap.
+  // ---------------------------------------------------------------------------
+
+  it('expands at most 10 functions per request, leaving the excess literal', async () => {
+    const res = await runGet(budgetUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+    const resolved = budgetTargets.filter((t) => uuidRe.test(h[t.toLowerCase()] ?? ""))
+    const literal = budgetTargets.filter((t) => h[t.toLowerCase()] === "{{FUNC:uuid()}}")
+    // 11 requested, exactly 10 expand and exactly 1 is left literal (which one is
+    // non-deterministic, but the counts are not).
+    expect(resolved).toHaveLength(10)
+    expect(literal).toHaveLength(1)
+
+    // Exactly one echo header per expanded target.
+    const echoCount = Object.keys(res.responseHeaders)
+      .filter((k) => /^x-blaxel-func-x-b\d+$/.test(k)).length
+    expect(echoCount).toBe(10)
+  }, 60_000)
+})

--- a/tests/integration/sandbox/proxy/functions.test.ts
+++ b/tests/integration/sandbox/proxy/functions.test.ts
@@ -264,6 +264,35 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
     expect(echoTokens(res, "X-User-Func")).toBeUndefined()
   }, 60_000)
 
+  it('interprets a config-injected func but leaves a client-sent func literal in the same request', async () => {
+    // Mirrors the manual live check: one request carries both a func from the
+    // admin routing config and a func the client puts in its own header.
+    const res = await runGet(coreUrl, '{"X-Test-My-Header-Onfly":"{{FUNC:uuid()}}"}')
+    const h = lowercaseKeys(res.upstream.headers)
+
+    // Admin-configured injection value -> interpreted on the wire and echoed.
+    expect(h["x-uuid"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    expect(echoTokens(res, "X-Uuid")).toEqual([{ name: "uuid", value: h["x-uuid"] }])
+
+    // Same syntax sent by the client -> passed through verbatim, never echoed.
+    expect(h["x-test-my-header-onfly"]).toBe("{{FUNC:uuid()}}")
+    expect(echoTokens(res, "X-Test-My-Header-Onfly")).toBeUndefined()
+  }, 60_000)
+
+  it('interprets the injected func on every call (the value on the wire changes per request)', async () => {
+    // Prove the header is generated fresh per request, not resolved once at
+    // config time: the value the upstream actually receives must differ across
+    // several sequential calls.
+    const seen = new Set<string>()
+    for (let i = 0; i < 3; i++) {
+      const res = await runGet(coreUrl)
+      const v = lowercaseKeys(res.upstream.headers)["x-uuid"]
+      expect(v).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+      seen.add(v)
+    }
+    expect(seen.size).toBe(3)
+  }, 60_000)
+
   // ---------------------------------------------------------------------------
   // Echo-format route: token format, multiplicity, func+secret.
   // ---------------------------------------------------------------------------

--- a/tests/integration/sandbox/proxy/functions.test.ts
+++ b/tests/integration/sandbox/proxy/functions.test.ts
@@ -10,10 +10,12 @@ import { createEchoServerSandbox, funcProxyHelperScript, lowercaseKeys, parseFul
  *    injection target: `X-Blaxel-Func-<target>: <funcname>=<value>[, …]`.
  *
  * Because at most 10 functions are expanded per request (across all headers and
- * body values combined), every route below stays comfortably under that budget.
+ * body values combined), every non-budget route below stays comfortably under
+ * that budget. Two dedicated routes probe the cap itself: one with exactly 10
+ * functions (all resolve) and one with 11 (the excess breaks / stays literal).
  * Each route targets its own dedicated echo-server upstream so requests never
  * share a function set, which keeps the target-keyed echo assertions and the
- * budget test unambiguous.
+ * budget tests unambiguous.
  */
 describe('dynamic {{FUNC:*}} placeholder validation', () => {
   const createdSandboxes: string[] = []
@@ -26,6 +28,7 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
   let echoFmtUrl: string
   let aliasUrl: string
   let failSafeUrl: string
+  let budgetOkUrl: string
   let budgetUrl: string
 
   const SECRET = "tok_live_abc123"
@@ -33,13 +36,17 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
   // verbatim and never re-interpreted (functions run before secrets).
   const TRICKY_SECRET = "{{FUNC:uuid()}}"
 
+  // Exactly the per-request budget (10) -> all resolve, nothing breaks.
+  const budgetOkTargets = Array.from({ length: 10 }, (_, i) => `X-K${String(i).padStart(2, "0")}`)
+  const budgetOkHeaders = Object.fromEntries(budgetOkTargets.map((t) => [t, "{{FUNC:uuid()}}"]))
   // 11 single-function headers -> one over the per-request budget of 10.
   const budgetTargets = Array.from({ length: 11 }, (_, i) => `X-B${String(i).padStart(2, "0")}`)
   const budgetHeaders = Object.fromEntries(budgetTargets.map((t) => [t, "{{FUNC:uuid()}}"]))
 
   beforeAll(async () => {
     // One upstream per route so no two routes ever share a request.
-    const [core, echoFmt, alias, failSafe, budget] = await Promise.all([
+    const [core, echoFmt, alias, failSafe, budgetOk, budget] = await Promise.all([
+      createEchoServerSandbox(createdSandboxes),
       createEchoServerSandbox(createdSandboxes),
       createEchoServerSandbox(createdSandboxes),
       createEchoServerSandbox(createdSandboxes),
@@ -51,6 +58,7 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
     echoFmtUrl = `${echoFmt.url}/headers`
     aliasUrl = `${alias.url}/headers`
     failSafeUrl = `${failSafe.url}/headers`
+    budgetOkUrl = `${budgetOk.url}/headers`
     budgetUrl = `${budget.url}/headers`
 
     const name = uniqueName("proxy-func")
@@ -127,6 +135,11 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
                 "X-Skip": "{{FUNC:nonce()}}-{{SECRET:missing}}",
               },
               secrets: { "tricky": TRICKY_SECRET },
+            },
+            {
+              // ---- Budget boundary route: exactly 10 -> all resolve. --------
+              destinations: [budgetOk.host],
+              headers: budgetOkHeaders,
             },
             {
               // ---- Budget route: 11 functions -> exactly one over the cap. --
@@ -384,19 +397,34 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
   // Budget route: per-request function cap.
   // ---------------------------------------------------------------------------
 
-  it('expands at most 10 functions per request, leaving the excess literal', async () => {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+  it('expands exactly 10 functions in a request with none left literal (budget boundary)', async () => {
+    const res = await runGet(budgetOkUrl)
+    const h = lowercaseKeys(res.upstream.headers)
+    // At the cap: every one of the 10 functions resolves, nothing is literal.
+    const resolved = budgetOkTargets.filter((t) => uuidRe.test(h[t.toLowerCase()] ?? ""))
+    const literal = budgetOkTargets.filter((t) => (h[t.toLowerCase()] ?? "").includes("{{FUNC:"))
+    expect(resolved).toHaveLength(10)
+    expect(literal).toHaveLength(0)
+    const echoCount = Object.keys(res.responseHeaders)
+      .filter((k) => /^x-blaxel-func-x-k\d+$/.test(k)).length
+    expect(echoCount).toBe(10)
+  }, 60_000)
+
+  it('breaks the 11th function: at most 10 expand per request, the excess stays literal', async () => {
     const res = await runGet(budgetUrl)
     const h = lowercaseKeys(res.upstream.headers)
-    const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
     const resolved = budgetTargets.filter((t) => uuidRe.test(h[t.toLowerCase()] ?? ""))
     const literal = budgetTargets.filter((t) => h[t.toLowerCase()] === "{{FUNC:uuid()}}")
-    // 11 requested, exactly 10 expand and exactly 1 is left literal (which one is
-    // non-deterministic, but the counts are not).
+    // 11 requested: exactly 10 expand and exactly 1 is left literal (which one is
+    // non-deterministic, but the counts are not). Contrast with the 10-function
+    // boundary test above, which resolves all 10 -- pinning the cutoff at 10->11.
     expect(resolved).toHaveLength(10)
     expect(literal).toHaveLength(1)
 
-    // Exactly one echo header per expanded target.
+    // Exactly one echo header per expanded target (the broken one is not echoed).
     const echoCount = Object.keys(res.responseHeaders)
       .filter((k) => /^x-blaxel-func-x-b\d+$/.test(k)).length
     expect(echoCount).toBe(10)

--- a/tests/integration/sandbox/proxy/functions.test.ts
+++ b/tests/integration/sandbox/proxy/functions.test.ts
@@ -372,7 +372,7 @@ describe('dynamic {{FUNC:*}} placeholder validation', () => {
     expect(h["x-bad-hex-arg"]).toBe("{{FUNC:randhex(abc)}}")
     expect(h["x-bad-int-zero"]).toBe("{{FUNC:randint(0)}}")
     // Nothing resolved -> no echo headers for any of these targets.
-    for (const t of ["X-Unknown", "X-Malformed", "X-No-Parens", "X-Over-Cap-Hex", "X-Bad-Hex-Arg"]) {
+    for (const t of ["X-Unknown", "X-Malformed", "X-No-Parens", "X-Over-Cap-Hex", "X-Over-Cap-Str", "X-Bad-Hex-Arg", "X-Bad-Int-Zero"]) {
       expect(echoTokens(res, t)).toBeUndefined()
     }
   }, 60_000)

--- a/tests/integration/sandbox/proxy/helpers.ts
+++ b/tests/integration/sandbox/proxy/helpers.ts
@@ -133,6 +133,107 @@ else {
 }
 `.trim()
 
+/**
+ * Like {@link proxyHelperScript}, but instead of writing only the upstream
+ * response body it emits a single JSON object combining the response status,
+ * the *response headers* the proxy returned (so tests can assert the
+ * `X-Blaxel-Func-*` echo headers), and the parsed upstream echo body:
+ *
+ *   { "status": 200, "responseHeaders": {..}, "upstream": {..} }
+ *
+ * Response header keys are already lowercased by Node's HTTP client.
+ */
+export const funcProxyHelperScript = `
+const https = require("https");
+const tls = require("tls");
+const method = process.argv[2] || "GET";
+const targetUrl = process.argv[3] || "https://httpbin.org/headers";
+const extraHeaders = process.argv[4] ? JSON.parse(process.argv[4]) : {};
+const bodyData = process.argv[5] || null;
+const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
+                 process.env.HTTP_PROXY || process.env.http_proxy;
+
+function fire(socket) {
+  const t = new URL(targetUrl);
+  const opts = {
+    hostname: t.hostname, port: t.port || 443,
+    path: t.pathname + t.search, method,
+    headers: { ...extraHeaders }, servername: t.hostname,
+  };
+  if (socket) { opts.socket = socket; opts.agent = false; }
+  if (bodyData) {
+    opts.headers["Content-Type"] = "application/json";
+    opts.headers["Content-Length"] = Buffer.byteLength(bodyData);
+  }
+  const req = https.request(opts, (r) => {
+    let d = ""; r.on("data", c => d += c);
+    r.on("end", () => {
+      let upstream = null; try { upstream = JSON.parse(d); } catch (e) { upstream = d; }
+      process.stdout.write(JSON.stringify({ status: r.statusCode, responseHeaders: r.headers, upstream }));
+      process.exit(0);
+    });
+  });
+  req.on("error", (e) => { process.stderr.write("REQ ERR: " + e.message + "\\n"); process.exit(1); });
+  if (bodyData) req.write(bodyData);
+  req.end();
+}
+
+if (!proxyUrl) { fire(null); }
+else {
+  const p = new URL(proxyUrl);
+  const t = new URL(targetUrl);
+  const port = parseInt(p.port) || (p.protocol === "https:" ? 443 : 3128);
+  const auth = (p.username || p.password)
+    ? "Proxy-Authorization: Basic " +
+      Buffer.from(decodeURIComponent(p.username||"") + ":" + decodeURIComponent(p.password||"")).toString("base64") + "\\r\\n"
+    : "";
+  const connectMsg = "CONNECT " + t.hostname + ":443 HTTP/1.1\\r\\n" +
+    "Host: " + t.hostname + ":443\\r\\n" + auth + "\\r\\n";
+
+  function onSocket(sock) {
+    let buf = "";
+    sock.on("data", function h(chunk) {
+      buf += chunk.toString();
+      if (buf.indexOf("\\r\\n\\r\\n") < 0) return;
+      sock.removeListener("data", h);
+      const code = parseInt(buf.split(" ")[1]);
+      if (code !== 200) {
+        process.stderr.write("CONNECT " + code + "\\n");
+        process.exit(1);
+      }
+      fire(sock);
+    });
+    sock.write(connectMsg);
+  }
+
+  const timeout = setTimeout(() => { process.stderr.write("PROXY TIMEOUT\\n"); process.exit(1); }, 15000);
+  if (p.protocol === "https:") {
+    const s = tls.connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onSocket(s); });
+    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TLS: " + e.message + "\\n"); process.exit(1); });
+  } else {
+    const s = require("net").connect({ host: p.hostname, port }, () => { clearTimeout(timeout); onSocket(s); });
+    s.on("error", (e) => { clearTimeout(timeout); process.stderr.write("PROXY TCP: " + e.message + "\\n"); process.exit(1); });
+  }
+}
+`.trim()
+
+/**
+ * Extracts a JSON object from command output by taking everything between the
+ * first `{` and the last `}`. Unlike {@link parseJsonOutput}, this is safe even
+ * when nested string values contain unbalanced braces (e.g. a header left
+ * literal as `{{FUNC:uuid}}`).
+ */
+export function parseFullJsonOutput<T = any>(logs: string | undefined): T {
+  if (!logs) throw new Error("No output from command")
+  const trimmed = logs.trim()
+  const start = trimmed.indexOf('{')
+  const end = trimmed.lastIndexOf('}')
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`No JSON object found in output: ${trimmed.slice(0, 300)}`)
+  }
+  return JSON.parse(trimmed.slice(start, end + 1)) as T
+}
+
 export function parseJsonOutput(logs: string | undefined): any {
   if (!logs) throw new Error("No output from command")
   const trimmed = logs.trim()


### PR DESCRIPTION
## Summary

Adds end-to-end integration tests for the proxy's dynamic `{{FUNC:*}}` placeholders, exercised against a controlled httpbin-compatible echo-server upstream (no dependency on public httpbin.org).

Each test validates both directions: the generated value reaches the **upstream** in the injected header/body, and the same value is **echoed back** to the client in the target-keyed format:

```
X-Blaxel-Func-<target>: <funcname>=<value>[, <funcname>=<value> …]
```

## Coverage

- **Happy path + echo format** — single tokens, repeated-function tokens (in generation order), mixed-function tokens, and function+secret targets (function token only).
- **Full catalog** — `uuid`/`uuidv4`/`uuidv7`, `timestamp`/`_ms`/`_ns`, `datetime`/`iso8601`, `date`, `time`, `randint`/`randint(n)`, `randhex`/`randstr` (default + `n`), `nonce`; case-insensitive names.
- **Boundaries & fail-safes** — 1024 cap allowed; over-cap / invalid-arg / malformed / unknown left literal with no echo.
- **Resolution order** — functions before secrets; a secret whose value is `{{...}}` is substituted verbatim; func + failing-secret injection is skipped with nothing echoed.
- **Trust boundary** — client-supplied `{{FUNC:*}}` in headers/body left literal, never echoed.
- **Secrets never reflected** on the response.
- **Per-request budget** — 11-function route resolves exactly 10 and leaves 1 literal (10 echo headers).

## Notes

- Functions are split across **5 dedicated echo-server routes**, each kept under the 10-function per-request budget, so the target-keyed echo and budget assertions are deterministic (unaffected by Go map ordering).
- Adds `funcProxyHelperScript` (captures response headers) and `parseFullJsonOutput` to `proxy/helpers.ts`.
- Gated behind `RUN_PROXY_TESTS=true`; requires `BL_WORKSPACE` + `BL_API_KEY`. Resources are labeled and cleaned up in `afterAll`.

## Test run

All 21 tests pass against the live proxy (~15s):

```
RUN_PROXY_TESTS=true npx vitest run tests/integration/sandbox/proxy/functions.test.ts --reporter=verbose
Test Files  1 passed (1)
     Tests  21 passed (21)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (integration suite and helpers); no production proxy or runtime code is modified.
> 
> **Overview**
> Adds **live sandbox integration coverage** for the proxy’s `{{FUNC:*}}` placeholders: config-driven injections must reach the upstream (headers/body) and matching values must come back on **`X-Blaxel-Func-<target>`** response headers.
> 
> The new `functions.test.ts` suite spins up **six echo-server upstreams** and one proxy sandbox with dedicated routes for core behavior, echo token shape, aliases/formats, fail-safes, and the **10-functions-per-request** cap (10 vs 11). Assertions cover happy paths, secrets vs functions, client-supplied literals, budget boundaries, and cases where placeholders stay literal with no echo.
> 
> **`proxy/helpers.ts`** gains `funcProxyHelperScript` (returns status, response headers, and upstream JSON) and `parseFullJsonOutput` so tests can parse helper output when values contain `{{FUNC:…}}` braces without breaking JSON extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9862169e3b8c7277daba44a23462232de4b67d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new integration tests (config-vs-client trust boundary and per-request freshness) and extends the fail-safe echo assertion to cover all seven literal targets that were previously missing (`X-Over-Cap-Str`, `X-Bad-Int-Zero`).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9862169e3b8c7277daba44a23462232de4b67d7b.</sup>
<!-- /MENDRAL_SUMMARY -->