### PR TITLE
fix(core): return immediately for terminal processes

### DIFF
--- a/@blaxel/core/src/sandbox/process/process.test.ts
+++ b/@blaxel/core/src/sandbox/process/process.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SandboxProcess } from "./process.js";
+
+describe("SandboxProcess.wait", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns immediately when the initial status is terminal", async () => {
+    vi.useFakeTimers();
+    const process = Object.create(SandboxProcess.prototype) as SandboxProcess;
+    const completed = { status: "completed" } as Awaited<ReturnType<SandboxProcess["get"]>>;
+    const get = vi.spyOn(process, "get").mockResolvedValue(completed);
+
+    await expect(process.wait("process-id", { interval: 5000 })).resolves.toBe(completed);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -314,8 +314,8 @@ export class SandboxProcess extends SandboxAction {
 
   async wait(identifier: string, { maxWait = 60000, interval = 1000 }: { maxWait?: number, interval?: number } = {}): Promise<GetProcessByIdentifierResponse> {
     const startTime = Date.now();
-    let status = "running";
     let data = await this.get(identifier);
+    let status = data.status ?? "running";
     while (status === "running") {
       await new Promise((resolve) => setTimeout(resolve, interval));
       try {


### PR DESCRIPTION
Fixes ENG-4802

## Summary
- Use the initial process status when entering `SandboxProcess.wait()`.
- Return immediately when that first lookup is already terminal instead of sleeping one full poll interval.
- Add a regression test covering an already-completed process.

## Testing
- `bun --filter @blaxel/core test` (87 passed, 3 skipped)