### PR TITLE
test(sandbox): egress pattern grammar conformance tests

### DIFF
--- a/tests/integration/sandbox/proxy/firewall-patterns.test.ts
+++ b/tests/integration/sandbox/proxy/firewall-patterns.test.ts
@@ -1,0 +1,223 @@
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from '../helpers.js'
+import { createEchoServerSandbox, createReadyProxySandbox, funcProxyHelperScript, parseFullJsonOutput, proxyCleanup } from './helpers.js'
+
+/**
+ * Conformance tests for the egress pattern grammar packed into the
+ * `allowedDomains` / `forbiddenDomains` string arrays: `METHOD:...:host/path`
+ * with an optional leading `!` negation.
+ *
+ * Two block signals exist and are handled distinctly:
+ *  - Host-level denial (a host that fails the allow/forbid host check) is
+ *    enforced at CONNECT time, so the tunneled request fails (non-zero exit).
+ *  - Method/path denial happens after the proxy inspects the decrypted request,
+ *    so the host connects fine and the proxy answers with HTTP 403
+ *    (`Proxy-Error: firewall_blocked`). We read the response status to detect it.
+ *
+ * Every scenario asserts both the allow and the intended break. Checks retry to
+ * absorb firewall-config propagation lag.
+ */
+describe('egress pattern grammar (allowedDomains / forbiddenDomains)', () => {
+  const createdSandboxes: string[] = []
+  afterAll(proxyCleanup(createdSandboxes))
+
+  // One controlled upstream shared by every route; H is its hostname.
+  let echoHost: string
+  let echoUrl: string
+
+  let methodSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  let pathSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  let forbidSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+  let bangSandbox: Awaited<ReturnType<typeof SandboxInstance.create>>
+
+  async function mkSandbox(
+    prefix: string,
+    network: Record<string, unknown>,
+    probe: string,
+  ): Promise<Awaited<ReturnType<typeof SandboxInstance.create>>> {
+    const sandbox = await createReadyProxySandbox(
+      async () => {
+        const name = uniqueName(prefix)
+        const s = await SandboxInstance.create({
+          name, image: defaultImage, region: defaultRegion, labels: defaultLabels,
+          network: { ...network, proxy: { routing: [] } },
+        })
+        return { name, sandbox: s }
+      },
+      createdSandboxes,
+      `node /tmp/proxy-test.js GET ${echoUrl}${probe}`,
+    )
+    await sandbox.fs.write("/tmp/fw-test.js", funcProxyHelperScript)
+    return sandbox
+  }
+
+  beforeAll(async () => {
+    const echo = await createEchoServerSandbox(createdSandboxes)
+    echoHost = echo.host
+    echoUrl = echo.url
+
+    ;[methodSandbox, pathSandbox, forbidSandbox, bangSandbox] = await Promise.all([
+      mkSandbox("fw-method", {
+        allowedDomains: [
+          `GET:POST:${echoHost}/m-*`,   // method-restricted path
+          `!POST:${echoHost}/n-*`,      // negated method set
+          `get:${echoHost}/c-*`,        // lower-case verb token
+        ],
+      }, "/m-ok"),
+      mkSandbox("fw-path", {
+        allowedDomains: [
+          `${echoHost}/prefix/`,        // start-anchored prefix, trailing slash
+          `${echoHost}/mercor*`,        // glob prefix
+        ],
+      }, "/mercor-1"),
+      mkSandbox("fw-forbid", {
+        allowedDomains: [`${echoHost}`],           // allow the whole host...
+        forbiddenDomains: [
+          `POST:${echoHost}/f-*`,       // ...but forbid POST under /f-*
+          `${echoHost}/secret*`,        // ...and everything under /secret*
+        ],
+      }, "/anything"),
+      mkSandbox("fw-bang", {
+        allowedDomains: [`!${echoHost}`],          // lone `!` is a no-op -> host H
+      }, "/x"),
+    ])
+  }, 300_000)
+
+  // --- egress probe -------------------------------------------------------
+  type Egress = { allowed: boolean; via: 'connect' | 'response'; status?: number }
+
+  const target = (t: string) => (t.startsWith("http") ? t : `${echoUrl}${t}`)
+
+  async function probe(
+    sandbox: Awaited<ReturnType<typeof SandboxInstance.create>>,
+    method: string,
+    t: string,
+  ): Promise<Egress> {
+    const res = await sandbox.process.exec({
+      command: `node /tmp/fw-test.js ${method} ${target(t)}`,
+      waitForCompletion: true,
+    })
+    // Host-level denial (or a hard network failure) surfaces as a non-zero exit.
+    if (res.exitCode !== 0) return { allowed: false, via: 'connect' }
+    let out: { status?: number }
+    try {
+      out = parseFullJsonOutput<{ status?: number }>(res.logs)
+    } catch {
+      return { allowed: false, via: 'connect' }
+    }
+    const status = typeof out.status === 'number' ? out.status : undefined
+    return { allowed: status !== undefined && status >= 200 && status < 300, via: 'response', status }
+  }
+
+  // Retry until the outcome matches expectation (absorbs propagation lag).
+  async function settle(fn: () => Promise<Egress>, want: boolean, retries = 5, delayMs = 2000): Promise<Egress> {
+    let last = await fn()
+    for (let i = 0; i < retries && last.allowed !== want; i++) {
+      await new Promise((r) => setTimeout(r, delayMs))
+      last = await fn()
+    }
+    return last
+  }
+
+  const allow = (s: Parameters<typeof probe>[0]) => async (method: string, t: string) => {
+    const o = await settle(() => probe(s, method, t), true)
+    expect(o.allowed, `expected ALLOW ${method} ${t} -> ${JSON.stringify(o)}`).toBe(true)
+    return o
+  }
+  const block = (s: Parameters<typeof probe>[0]) => async (method: string, t: string) => {
+    const o = await settle(() => probe(s, method, t), false)
+    expect(o.allowed, `expected BLOCK ${method} ${t} -> ${JSON.stringify(o)}`).toBe(false)
+    // Method/path denials are answered with a 403 after CONNECT succeeds.
+    if (o.via === 'response') expect(o.status, JSON.stringify(o)).toBe(403)
+    return o
+  }
+
+  // ---------------------------------------------------------------------------
+  // Method matching and negation.
+  // ---------------------------------------------------------------------------
+
+  it('allows a method in the set and blocks one outside it', async () => {
+    const A = { allow: allow(methodSandbox), block: block(methodSandbox) }
+    await A.allow("GET", "/m-ok")     // GET is in GET:POST
+    await A.allow("POST", "/m-ok")    // POST is in GET:POST
+    await A.block("DELETE", "/m-ok")  // DELETE is not -> blocked
+  }, 60_000)
+
+  it('parses method tokens case-insensitively', async () => {
+    // `get:` must be recognized as the GET verb, not kept as a literal host.
+    await allow(methodSandbox)("GET", "/c-x")
+  }, 60_000)
+
+  it('negated method set allows everything except the listed method', async () => {
+    await allow(methodSandbox)("GET", "/n-x")   // !POST allows GET
+    await block(methodSandbox)("POST", "/n-x")  // !POST blocks POST
+  }, 60_000)
+
+  it('blocks a path that matches no allow pattern', async () => {
+    await block(methodSandbox)("GET", "/unmatched")
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Path globs and normalization.
+  // ---------------------------------------------------------------------------
+
+  it('treats a path pattern as a start-anchored prefix', async () => {
+    await allow(pathSandbox)("GET", "/prefix/file.txt")  // under /prefix/
+    await allow(pathSandbox)("GET", "/prefix/")          // the dir root itself
+    await block(pathSandbox)("GET", "/prefix")           // no trailing slash -> no match
+  }, 60_000)
+
+  it('ignores the query string when matching a path', async () => {
+    await allow(pathSandbox)("GET", "/prefix/x?sig=secret")
+  }, 60_000)
+
+  it('matches a glob prefix and blocks a sibling path', async () => {
+    await allow(pathSandbox)("GET", "/mercor-1/obj")
+    await block(pathSandbox)("GET", "/other/obj")
+  }, 60_000)
+
+  it('canonicalizes duplicate slashes before matching', async () => {
+    await allow(pathSandbox)("GET", "//mercor//obj")  // -> /mercor/obj, matches /mercor*
+  }, 60_000)
+
+  it('blocks a path traversal that escapes the allowed prefix', async () => {
+    // /mercor/../other/obj normalizes to /other/obj, which matches nothing.
+    await block(pathSandbox)("GET", "/mercor/../other/obj")
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Forbidden precedence (forbidden always wins over allow).
+  // ---------------------------------------------------------------------------
+
+  it('allows a request that matches allow and no forbid rule', async () => {
+    await allow(forbidSandbox)("GET", "/anything")
+  }, 60_000)
+
+  it('lets a forbidden rule override the host allow (method-scoped)', async () => {
+    await block(forbidSandbox)("POST", "/f-x")  // POST:/f-* forbidden -> blocked
+    await allow(forbidSandbox)("GET", "/f-x")   // GET not forbidden -> allowed through
+  }, 60_000)
+
+  it('blocks a forbidden path even though the host is allowed', async () => {
+    await block(forbidSandbox)("GET", "/secret/key")
+  }, 60_000)
+
+  it('blocks a traversal that lands inside a forbidden prefix', async () => {
+    // /public/../secret/key normalizes to /secret/key -> forbidden.
+    await block(forbidSandbox)("GET", "/public/../secret/key")
+  }, 60_000)
+
+  it('strips the query string before evaluating a forbidden path', async () => {
+    await block(forbidSandbox)("GET", "/secret/x?sig=z")
+  }, 60_000)
+
+  // ---------------------------------------------------------------------------
+  // Host-grammar edge: a lone `!` (no method) degrades to the plain host.
+  // ---------------------------------------------------------------------------
+
+  it('treats `!host` (no method) as the plain host, keeping the allowlist active', async () => {
+    await allow(bangSandbox)("GET", "/x")                     // H is allowed
+    await block(bangSandbox)("GET", "https://example.com")    // a non-listed host is not
+  }, 60_000)
+})


### PR DESCRIPTION
Fixes ENG-4821

## Summary

Adds end-to-end conformance tests for the egress pattern grammar packed into the `allowedDomains` / `forbiddenDomains` string arrays: `[!]METHOD:...:host/path`. Exercised through the real proxy against a controlled echo-server upstream. Every scenario asserts both the allow and the intended break.

## Coverage (15 tests)

**Method matching & negation**
- GET/POST allowed on a `GET:POST:...` path; **DELETE blocked**
- `get:` verb parsed case-insensitively
- `!POST` allows GET, **blocks POST**
- unmatched path **blocked**

**Path globs & normalization**
- start-anchored prefix: `/prefix/file.txt` and `/prefix/` allowed, **`/prefix` blocked**
- query string ignored
- glob prefix match, **sibling path blocked**
- duplicate slashes canonicalized
- **path traversal blocked**

**Forbidden precedence (forbidden wins)**
- allow + no forbid → allowed
- method-scoped forbid **blocks POST** while GET passes
- **forbidden path blocked** despite host allow
- **traversal into a forbidden prefix blocked**
- **query stripped** before evaluating a forbidden path

**Host-grammar edge**
- lone `!host` (no method) degrades to the plain host; allow works, non-listed host **blocked**

## How blocks are detected

- Method/path denials connect fine, then the proxy answers **HTTP 403 `Proxy-Error: firewall_blocked`** — the probe reads the response status.
- Host-level denials fail at CONNECT (non-zero exit).

Each check retries to absorb firewall-config propagation lag. The tests use one echo upstream + four proxy sandboxes (one per config), and reuse the existing `funcProxyHelperScript` / `parseFullJsonOutput` helpers.

## Notes

- Gated behind `RUN_PROXY_TESTS=true`; requires `BL_WORKSPACE` + `BL_API_KEY`. Resources are labeled and cleaned up in `afterAll`.
- These pass only where the new grammar parser is deployed; an older proxy treats `GET:POST:host/path` as a literal hostname, which fails the allowed-path readiness probe fast at setup.
- Docs for this feature: blaxel-ai/docs#733.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modifications.
> 
> **Overview**
> Adds **`firewall-patterns.test.ts`**, a new proxy integration suite that exercises the **`[!]METHOD:...:host/path`** grammar in `allowedDomains` and `forbiddenDomains` against a real sandbox egress proxy and shared echo upstream.
> 
> The file spins up four sandboxes (method, path, forbid, and `!host` edge cases), probes egress with retries for config propagation, and distinguishes **CONNECT-time host blocks** from **HTTP 403 `firewall_blocked`** method/path denials. **15 Vitest cases** cover method sets and `!POST` negation, path prefixes/globs, query stripping and slash normalization, traversal blocking, and **forbidden-over-allow** precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d33851c1087fe3520b89246c3b13303ff933da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end conformance tests for the egress pattern grammar (`METHOD:...:host/path` with `!` negation) in `allowedDomains`/`forbiddenDomains`. Tests cover method matching, path globs, normalization (duplicate slashes, traversal), forbidden precedence, and host-grammar edge cases across four proxy sandbox configurations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 51d33851c1087fe3520b89246c3b13303ff933da.</sup>
<!-- /MENDRAL_SUMMARY -->