### PR TITLE
fix(sandbox): a throwing callback must not kill the stream

### DIFF
--- a/@blaxel/core/src/common/callbacks.ts
+++ b/@blaxel/core/src/common/callbacks.ts
@@ -1,0 +1,66 @@
+/**
+ * Helpers for invoking user-supplied callbacks from inside a streaming read
+ * loop.
+ *
+ * A callback belongs to the caller, so it can throw for reasons that have
+ * nothing to do with the stream: a `JSON.parse` on a line that is not JSON, a
+ * bug in a handler, a rejected promise. Called bare, that exception escapes the
+ * read loop, the loop's `catch` treats it as a transport failure, and the
+ * stream ends for good while the sandbox process keeps running and producing
+ * output nobody receives.
+ *
+ * The stream must outlive its consumer's mistakes: report the error and keep
+ * reading.
+ */
+
+function report(error: unknown, onError?: (error: Error) => void): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  if (!onError) {
+    // Same fallback the stream error path already uses: never swallow silently.
+    console.error("Stream callback error:", err);
+    return;
+  }
+  // A throwing error handler must not take the stream down either.
+  try {
+    onError(err);
+  } catch {
+    // nothing left to report to
+  }
+}
+
+/**
+ * Invoke a synchronous callback. If it returns a promise, a later rejection is
+ * reported too rather than surfacing as an unhandled rejection.
+ */
+export function safeCallback<T>(
+  fn: ((arg: T) => unknown) | undefined,
+  arg: T,
+  onError?: (error: Error) => void,
+): void {
+  if (!fn) return;
+  try {
+    const result = fn(arg);
+    if (result && typeof (result as Promise<unknown>).then === "function") {
+      void (result as Promise<unknown>).then(undefined, (e: unknown) => report(e, onError));
+    }
+  } catch (error) {
+    report(error, onError);
+  }
+}
+
+/**
+ * Await a callback, preserving delivery order, without letting a rejection end
+ * the stream.
+ */
+export async function safeCallbackAsync<T>(
+  fn: ((arg: T) => unknown) | undefined,
+  arg: T,
+  onError?: (error: Error) => void,
+): Promise<void> {
+  if (!fn) return;
+  try {
+    await fn(arg);
+  } catch (error) {
+    report(error, onError);
+  }
+}

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "../../client/types.gen.js";
+import { safeCallback, safeCallbackAsync } from "../../common/callbacks.js";
 import { fs } from "../../common/node.js";
 import { settings } from "../../common/settings.js";
 import { withUploadSlot } from "../../common/h2fetch.js";
@@ -457,24 +458,36 @@ export class SandboxFileSystem extends SandboxAction {
             if (line.startsWith("[keepalive]")) {
               continue;
             }
-            const fileEvent = JSON.parse(trimmed) as WatchEvent;
-            if (options?.withContent && ["CREATE", "WRITE"].includes(fileEvent.op)) {
-              try {
-                let filePath = ""
-                if (fileEvent.path.endsWith("/")) {
-                  filePath = fileEvent.path + fileEvent.name;
-                } else {
-                  filePath = fileEvent.path + "/" + fileEvent.name;
-                }
-
-                const content = await this.read(filePath);
-                await callback({ ...fileEvent, content: content });
-              } catch {
-                await callback({ ...fileEvent, content: undefined });
-              }
-            } else {
-              await callback(fileEvent);
+            // One malformed line must not tear down the watch: report it and
+            // keep reading.
+            let fileEvent: WatchEvent;
+            try {
+              fileEvent = JSON.parse(trimmed) as WatchEvent;
+            } catch (parseError) {
+              safeCallback(options?.onError, parseError instanceof Error
+                ? parseError
+                : new Error(`Unparseable watch event: ${trimmed}`));
+              continue;
             }
+
+            let content: string | undefined;
+            if (options?.withContent && ["CREATE", "WRITE"].includes(fileEvent.op)) {
+              const filePath = fileEvent.path.endsWith("/")
+                ? fileEvent.path + fileEvent.name
+                : fileEvent.path + "/" + fileEvent.name;
+              // A file already gone by the time we read it still deserves its event.
+              try {
+                content = await this.read(filePath);
+              } catch {
+                content = undefined;
+              }
+            }
+            // Delivered exactly once, and a throwing callback never ends the watch.
+            await safeCallbackAsync(
+              callback,
+              content === undefined ? fileEvent : { ...fileEvent, content },
+              options?.onError,
+            );
           }
         }
       } finally {

--- a/@blaxel/core/src/sandbox/process/process.ts
+++ b/@blaxel/core/src/sandbox/process/process.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "../../client/types.gen.js";
+import { safeCallback } from "../../common/callbacks.js";
 import { settings } from "../../common/settings.js";
 import { SandboxAction } from "../action.js";
 import { retryOnTransientReset } from "../../common/transient-retry.js";
@@ -28,18 +29,21 @@ export class SandboxProcess extends SandboxAction {
       }
     };
 
+    // Callbacks are caller code: a throw in one is reported, never fatal to the
+    // stream. Otherwise a single unparseable line ends the stream for good
+    // while the process keeps running and producing output nobody receives.
     const processLine = (line: string) => {
       if (line.startsWith("[keepalive]")) {
         return;
       }
       if (line.startsWith('stdout:')) {
-        options.onStdout?.(line.slice(7));
-        options.onLog?.(line.slice(7));
+        safeCallback(options.onStdout, line.slice(7), options.onError);
+        safeCallback(options.onLog, line.slice(7), options.onError);
       } else if (line.startsWith('stderr:')) {
-        options.onStderr?.(line.slice(7));
-        options.onLog?.(line.slice(7));
+        safeCallback(options.onStderr, line.slice(7), options.onError);
+        safeCallback(options.onLog, line.slice(7), options.onError);
       } else {
-        options.onLog?.(line);
+        safeCallback(options.onLog, line, options.onError);
       }
     };
 
@@ -184,17 +188,17 @@ export class SandboxProcess extends SandboxAction {
         // Emit any captured logs through callbacks
         if (data.stdout) {
           for (const line of data.stdout.split('\n').filter(l => l)) {
-            options.onStdout?.(line);
+            safeCallback(options.onStdout, line);
           }
         }
         if (data.stderr) {
           for (const line of data.stderr.split('\n').filter(l => l)) {
-            options.onStderr?.(line);
+            safeCallback(options.onStderr, line);
           }
         }
         if (data.logs) {
           for (const line of data.logs.split('\n').filter(l => l)) {
-            options.onLog?.(line);
+            safeCallback(options.onLog, line);
           }
         }
         return {
@@ -218,6 +222,20 @@ export class SandboxProcess extends SandboxAction {
     let buffer = '';
     let result: PostProcessResponse | null = null;
 
+    // The server wraps every write to this stream as a "stdout" event,
+    // including its own 30s "[keepalive]" marker, so filter it here the way
+    // streamLogs does rather than handing an internal marker to the caller.
+    const emit = (parsed: { type: string, data: string }) => {
+      if (!parsed.data || parsed.data.startsWith("[keepalive]")) return;
+      if (parsed.type === 'stdout') {
+        safeCallback(options.onStdout, parsed.data);
+        safeCallback(options.onLog, parsed.data);
+      } else if (parsed.type === 'stderr') {
+        safeCallback(options.onStderr, parsed.data);
+        safeCallback(options.onLog, parsed.data);
+      }
+    };
+
     while (true) {
       const readResult = await reader.read();
       if (readResult.done) break;
@@ -231,28 +249,14 @@ export class SandboxProcess extends SandboxAction {
 
       for (const line of lines) {
         const parsed = JSON.parse(line) as { type: string, data: string };
-        switch (parsed.type) {
-          case 'stdout':
-            if (parsed.data) {
-              options.onStdout?.(parsed.data);
-              options.onLog?.(parsed.data);
-            }
-            break;
-          case 'stderr':
-            if (parsed.data) {
-              options.onStderr?.(parsed.data);
-              options.onLog?.(parsed.data);
-            }
-            break;
-          case 'result':
-            try {
-              result = JSON.parse(parsed.data) as PostProcessResponse;
-            } catch {
-              throw new Error(`Failed to parse result JSON: ${parsed.data}`);
-            }
-            break;
-          default:
-            break;
+        if (parsed.type === 'result') {
+          try {
+            result = JSON.parse(parsed.data) as PostProcessResponse;
+          } catch {
+            throw new Error(`Failed to parse result JSON: ${parsed.data}`);
+          }
+        } else {
+          emit(parsed);
         }
       }
     }
@@ -278,26 +282,14 @@ export class SandboxProcess extends SandboxAction {
         }
       }
       if (parsed) {
-        switch (parsed.type) {
-          case 'stdout':
-            if (parsed.data) {
-              options.onStdout?.(parsed.data);
-              options.onLog?.(parsed.data);
-            }
-            break;
-          case 'stderr':
-            if (parsed.data) {
-              options.onStderr?.(parsed.data);
-              options.onLog?.(parsed.data);
-            }
-            break;
-          case 'result':
-            try {
-              result = JSON.parse(parsed.data) as PostProcessResponse;
-            } catch {
-              throw new Error(`Failed to parse result JSON: ${parsed.data}`);
-            }
-            break;
+        if (parsed.type === 'result') {
+          try {
+            result = JSON.parse(parsed.data) as PostProcessResponse;
+          } catch {
+            throw new Error(`Failed to parse result JSON: ${parsed.data}`);
+          }
+        } else {
+          emit(parsed);
         }
       }
     }

--- a/tests/integration/sandbox/stream-callback-resilience.test.ts
+++ b/tests/integration/sandbox/stream-callback-resilience.test.ts
@@ -1,0 +1,74 @@
+import { SandboxInstance } from "@blaxel/core"
+import { afterAll, describe, expect, it } from 'vitest'
+import { defaultImage, defaultLabels, defaultRegion, uniqueName } from './helpers.js'
+
+/**
+ * A log stream must outlive its consumer's mistakes.
+ *
+ * A caller whose onLog parses every line hits an exception the moment a line is
+ * not what it expects. That exception used to escape the SDK read loop and end
+ * the stream for good, while the sandbox process kept running and producing
+ * output nobody received: the process looks healthy, the client sees silence.
+ */
+describe('Log stream survives a throwing callback', () => {
+  const createdSandboxes: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(
+      createdSandboxes.map(async (name) => {
+        try {
+          await SandboxInstance.delete(name)
+        } catch {
+          // Ignore cleanup errors
+        }
+      })
+    )
+  })
+
+  it('keeps delivering lines after onLog throws, and the process lives on', async () => {
+    const name = uniqueName("stream-cb")
+
+    const sandbox = await SandboxInstance.create({
+      name,
+      image: defaultImage,
+      memory: 4096,
+      region: defaultRegion,
+      labels: defaultLabels,
+    })
+    createdSandboxes.push(name)
+    await sandbox.wait({ maxWait: 120000, interval: 1000 })
+
+    // Emits JSON lines with one unparseable line in the middle, then keeps going.
+    await sandbox.process.exec({
+      name: "emitter",
+      command: `sh -c 'i=0; while [ $i -lt 8 ]; do if [ $i -eq 2 ]; then echo "not-json-at-all"; else echo "{\\"tick\\":$i}"; fi; i=$((i+1)); sleep 1; done; echo DONE; sleep 30'`,
+      waitForCompletion: false,
+    })
+
+    const parsed: number[] = []
+    const errors: string[] = []
+    const control = sandbox.process.streamLogs("emitter", {
+      onLog: (line) => {
+        const trimmed = line.trim()
+        if (!trimmed || trimmed === "DONE") return
+        parsed.push((JSON.parse(trimmed) as { tick: number }).tick)
+      },
+      onError: (e) => errors.push(e.message),
+    })
+
+    // Long enough for every tick, short enough to keep the test under a minute.
+    await new Promise((resolve) => setTimeout(resolve, 15000))
+    control.close()
+    await control.wait()
+
+    // The bad line is reported, not fatal: ticks after it still arrive.
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    expect(errors[0]).toMatch(/JSON/i)
+    expect(parsed).toContain(7)
+    expect(parsed).toEqual([0, 1, 3, 4, 5, 6, 7])
+
+    // And the process was never the problem.
+    const info = await sandbox.process.get("emitter")
+    expect(info.status).toBe("running")
+  })
+})

--- a/tests/unit/stream-callback-isolation.test.ts
+++ b/tests/unit/stream-callback-isolation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { safeCallback, safeCallbackAsync } from "../../@blaxel/core/src/common/callbacks.js";
+import { SandboxProcess } from "../../@blaxel/core/src/sandbox/process/process.js";
+import type { SandboxConfiguration } from "../../@blaxel/core/src/sandbox/types.js";
+
+/**
+ * A caller's callback is caller code and can throw for reasons unrelated to the
+ * transport. It used to escape the read loop, get caught as a stream failure,
+ * and end the stream for good while the sandbox process kept running and
+ * producing output nobody received.
+ */
+
+function streamOf(lines: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+      controller.close();
+    },
+  });
+  return { status: 200, body } as unknown as Response;
+}
+
+/** A SandboxProcess whose transport is a canned stream instead of the network. */
+function processServing(lines: string[]): SandboxProcess {
+  const sandbox = {
+    metadata: { name: "test-sandbox" },
+    forceUrl: "http://sandbox.test",
+    headers: {},
+  } as unknown as SandboxConfiguration;
+  const proc = new SandboxProcess(sandbox);
+  (proc as unknown as { h2Fetch: () => Promise<Response> }).h2Fetch = () =>
+    Promise.resolve(streamOf(lines));
+  return proc;
+}
+
+describe("streamLogs callback isolation", () => {
+  it("keeps streaming after a callback throws", async () => {
+    const received: string[] = [];
+    const errors: string[] = [];
+
+    const control = processServing([
+      '{"tick":1}',
+      "not-json-at-all", // a client parsing every line blows up here
+      '{"tick":2}',
+      '{"tick":3}',
+    ]).streamLogs("187", {
+      onLog: (line) => {
+        JSON.parse(line); // what a protocol client does
+        received.push(line);
+      },
+      onError: (e) => errors.push(e.message),
+    });
+
+    await control.wait();
+
+    // The lines after the bad one must still arrive.
+    expect(received).toEqual(['{"tick":1}', '{"tick":2}', '{"tick":3}']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/JSON/i);
+  });
+
+  it("reports every failing line without dropping the good ones", async () => {
+    const received: string[] = [];
+    const errors: string[] = [];
+
+    const control = processServing(["bad", "good", "bad", "good"]).streamLogs("187", {
+      onLog: (line) => {
+        if (line === "bad") throw new Error("boom");
+        received.push(line);
+      },
+      onError: (e) => errors.push(e.message),
+    });
+
+    await control.wait();
+
+    expect(received).toEqual(["good", "good"]);
+    expect(errors).toEqual(["boom", "boom"]);
+  });
+
+  it("still filters the server's internal keepalive marker", async () => {
+    const received: string[] = [];
+
+    const control = processServing(['{"tick":1}', "[keepalive]", '{"tick":2}']).streamLogs("187", {
+      onLog: (line) => received.push(line),
+    });
+
+    await control.wait();
+
+    expect(received).toEqual(['{"tick":1}', '{"tick":2}']);
+  });
+});
+
+describe("safeCallback", () => {
+  it("swallows nothing when an onError is given", () => {
+    const errors: string[] = [];
+    safeCallback(() => { throw new Error("sync boom"); }, "x", (e) => errors.push(e.message));
+    expect(errors).toEqual(["sync boom"]);
+  });
+
+  it("reports a rejected promise from a sync-looking callback", async () => {
+    const errors: string[] = [];
+    safeCallback(() => Promise.reject(new Error("async boom")), "x", (e) => errors.push(e.message));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(errors).toEqual(["async boom"]);
+  });
+
+  it("survives an onError that throws", () => {
+    expect(() =>
+      safeCallback(() => { throw new Error("boom"); }, "x", () => { throw new Error("handler boom"); }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op without a callback", () => {
+    expect(() => safeCallback(undefined, "x", () => { throw new Error("never"); })).not.toThrow();
+  });
+
+  it("awaits async callbacks and reports rejections", async () => {
+    const errors: string[] = [];
+    const order: string[] = [];
+    await safeCallbackAsync(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      order.push("callback");
+    }, "x", (e) => errors.push(e.message));
+    order.push("after");
+    expect(order).toEqual(["callback", "after"]);
+
+    await safeCallbackAsync(() => Promise.reject(new Error("rejected")), "x", (e) => errors.push(e.message));
+    expect(errors).toEqual(["rejected"]);
+  });
+});


### PR DESCRIPTION
## What

A callback that throws no longer kills the stream feeding it.

## Why

`streamLogs`, `execWithStreaming` and `filesystem.watch` called user callbacks bare inside their read loops:

```ts
for (const line of lines) {
  options.onLog?.(line);   // caller code, can throw
}
```

A callback is caller code and can throw for reasons unrelated to the transport. The common case: a client running `JSON.parse` on every line, hitting one line that is not JSON. That exception escaped the read loop, got caught by the loop's `catch` as a transport failure, and ended the stream **for good**.

The sandbox process kept running and producing output nobody received. The process looks healthy, the client sees silence, and the gateway logs it as a client-side disconnect because the SDK stopped reading the body.

Reproduced against a real sandbox: one non-JSON line, stream dead at 10s, process still `running` and still emitting.

## Changes

- New `safeCallback` / `safeCallbackAsync` in `common/callbacks.ts`: report the error through `onError` (falling back to `console.error`, matching the existing stream error path) and keep reading. A throwing `onError` cannot take the stream down either.
- Every user callback in the three read paths now goes through them.

Two related bugs found in the same code and fixed here:

- **`execWithStreaming` leaked `[keepalive]` as application stdout.** The server wraps every write to that stream as a stdout event, including its own 30s keepalive marker, so callers received an internal marker as output every 30 seconds. `streamLogs` already filtered it; this path did not.
- **`filesystem.watch` delivered an event twice.** On the `withContent` path, the `try/catch` meant for the file read also caught the callback, so a throwing callback got the same event again with `content: undefined`. Reading content and delivering the event are now separate steps.

`filesystem.watch` also died on a single unparseable line; it now reports and continues.

## Tests

- `tests/unit/stream-callback-isolation.test.ts` — a throwing callback is reported and the following lines still arrive. **The two stream tests fail without the fix.**
- `tests/integration/sandbox/stream-callback-resilience.test.ts` — same thing against a real sandbox, 17s.

Full unit suite green except 6 pre-existing failures (`sandbox-list-h2-dedup`, `sandbox-filesystem-read-binary`) that fail on `main` too.

## Context

Found while investigating customer reports of log streams ending early with HTTP 200 while the process kept running. This is the mechanism that best matches those reports, though it is not yet confirmed to be their cause. Either way, a caller's bug should never silently kill their stream.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-typescript/pull/432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->