### PR TITLE
fix(sandbox): quote cp() paths to prevent shell injection

### DIFF
--- a/@blaxel/core/src/common/shell.ts
+++ b/@blaxel/core/src/common/shell.ts
@@ -1,0 +1,15 @@
+/**
+ * Quote a string so a POSIX shell reads it as one literal argument.
+ *
+ * The sandbox process API accepts a single command string, which the server
+ * runs as `sh -c <command>`. Any value interpolated into that string is parsed
+ * by the shell, so an unquoted path containing `;`, `|`, `&&`, `$()`, backticks
+ * or `>` would execute as its own command. Single quotes suppress every form of
+ * shell expansion; the only character they cannot contain is a single quote
+ * itself, which is closed, escaped, and reopened.
+ *
+ * This is the TypeScript equivalent of Python's `shlex.quote`.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -3,6 +3,7 @@ import { fs } from "../../common/node.js";
 import { settings } from "../../common/settings.js";
 import { withUploadSlot } from "../../common/h2fetch.js";
 import { isTransientResetError, retryOnTransientReset } from "../../common/transient-retry.js";
+import { shellQuote } from "../../common/shell.js";
 import { SandboxAction } from "../action.js";
 import { ContentSearchResponse, deleteFilesystemByPath, deleteFilesystemMultipartByUploadIdAbort, Directory, FindResponse, FuzzySearchResponse, getFilesystemByPath, getFilesystemContentSearchByPath, getFilesystemFindByPath, getFilesystemSearchByPath, getWatchFilesystemByPath, MultipartInitiateResponse, MultipartPartInfo, MultipartUploadPartResponse, postFilesystemMultipartByUploadIdComplete, postFilesystemMultipartInitiateByPath, putFilesystemByPath, PutFilesystemByPathError, putFilesystemMultipartByUploadIdPart, SuccessResponse } from "../client/index.js";
 import { SandboxProcess } from "../process/index.js";
@@ -398,8 +399,10 @@ export class SandboxFileSystem extends SandboxAction {
   }
 
   async cp(source: string, destination: string, { maxWait = 180000 }: { maxWait?: number } = {}): Promise<CopyResponse> {
+    // Quote both paths so the shell that runs this command treats them as
+    // single literal arguments instead of interpreting metacharacters in them.
     let process = await this.process.exec({
-      command: `cp -r ${source} ${destination}`,
+      command: `cp -r ${shellQuote(source)} ${shellQuote(destination)}`,
     })
     process = await this.process.wait(process.pid, { maxWait, interval: 100 })
     if (process.status === "failed") {

--- a/tests/manual/cp-injection-live.ts
+++ b/tests/manual/cp-injection-live.ts
@@ -1,0 +1,105 @@
+// Live verification of the cp() shell-injection fix against a real sandbox.
+// Run: npx tsx tests/manual/cp-injection-live.ts
+import { SandboxInstance } from "@blaxel/core";
+
+const NAME = `cp-inject-${Date.now()}`;
+const DIR = "/verify";
+
+async function sh(sandbox: SandboxInstance, command: string) {
+  const p = await sandbox.process.exec({ command, waitForCompletion: true });
+  return { status: p.status, logs: (p.logs ?? "").trim() };
+}
+
+async function exists(sandbox: SandboxInstance, path: string) {
+  const r = await sh(sandbox, `test -e ${path} && echo YES || echo NO`);
+  return r.logs.includes("YES");
+}
+
+const results: Array<{ check: string; pass: boolean; detail: string }> = [];
+function record(check: string, pass: boolean, detail: string) {
+  results.push({ check, pass, detail });
+  console.log(`${pass ? "PASS" : "FAIL"}  ${check}\n      ${detail}`);
+}
+
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: NAME,
+  image: "blaxel/node:latest",
+  memory: 2048,
+  ttl: "10m",
+});
+console.log(`sandbox: ${NAME}`);
+
+try {
+  await sh(sandbox, `mkdir -p '${DIR}'`);
+  await sh(sandbox, `echo hello-from-source > ${DIR}/src.txt`);
+
+  // 1. Ordinary copy still works.
+  await sandbox.fs.cp(`${DIR}/src.txt`, `${DIR}/dst.txt`);
+  const copied = await sh(sandbox, `cat ${DIR}/dst.txt`);
+  record(
+    "ordinary copy still works",
+    copied.logs === "hello-from-source",
+    `cat dst.txt -> ${JSON.stringify(copied.logs)}`,
+  );
+
+  // 2. Injected command in the source path must not run.
+  const payload = `${DIR}/src.txt; touch ${DIR}/pwned-source`;
+  try {
+    await sandbox.fs.cp(payload, `${DIR}/out1`);
+  } catch (e) {
+    console.log(`      (cp threw, expected: ${(e as Error).message.slice(0, 90)})`);
+  }
+  const pwnedSource = await exists(sandbox, `${DIR}/pwned-source`);
+  record(
+    "injection via source path does not execute",
+    !pwnedSource,
+    `${DIR}/pwned-source exists: ${pwnedSource}`,
+  );
+
+  // 3. Injected command in the destination path must not run.
+  const payload2 = `${DIR}/out2; touch ${DIR}/pwned-dest`;
+  try {
+    await sandbox.fs.cp(`${DIR}/src.txt`, payload2);
+  } catch (e) {
+    console.log(`      (cp threw, expected: ${(e as Error).message.slice(0, 90)})`);
+  }
+  const pwnedDest = await exists(sandbox, `${DIR}/pwned-dest`);
+  record(
+    "injection via destination path does not execute",
+    !pwnedDest,
+    `${DIR}/pwned-dest exists: ${pwnedDest}`,
+  );
+
+  // 4. Command substitution must not run either.
+  try {
+    await sandbox.fs.cp(`$(touch ${DIR}/pwned-subst)`, `${DIR}/out3`);
+  } catch (e) {
+    console.log(`      (cp threw, expected: ${(e as Error).message.slice(0, 90)})`);
+  }
+  const pwnedSubst = await exists(sandbox, `${DIR}/pwned-subst`);
+  record(
+    "command substitution does not execute",
+    !pwnedSubst,
+    `${DIR}/pwned-subst exists: ${pwnedSubst}`,
+  );
+
+  // 5. A path with a space is now a single argument, so this copy succeeds.
+  await sh(sandbox, `mkdir -p '${DIR}/with space'`);
+  await sandbox.fs.cp(`${DIR}/src.txt`, `${DIR}/with space/copied.txt`);
+  const spaced = await sh(sandbox, `cat '${DIR}/with space/copied.txt'`);
+  record(
+    "path containing a space copies correctly",
+    spaced.logs === "hello-from-source",
+    `cat 'with space/copied.txt' -> ${JSON.stringify(spaced.logs)}`,
+  );
+
+  const listing = await sh(sandbox, `ls -A ${DIR}`);
+  console.log(`\nfinal ${DIR} listing:\n${listing.logs}`);
+} finally {
+  await SandboxInstance.delete(NAME);
+  console.log(`\ndeleted sandbox: ${NAME}`);
+}
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length > 0) process.exit(1);

--- a/tests/unit/sandbox-filesystem-cp-injection.test.ts
+++ b/tests/unit/sandbox-filesystem-cp-injection.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { SandboxFileSystem } from "../../@blaxel/core/src/sandbox/filesystem/filesystem.js";
+
+// The sandbox process API takes a single command string, which the server runs
+// as `sh -c <command>`. Anything cp() interpolates into that string is parsed
+// by a shell, so a path carrying shell metacharacters would otherwise run as
+// its own command.
+const injectionPayloads = [
+  "/tmp/out; touch /tmp/pwned",
+  "/tmp/$(touch /tmp/pwned)",
+  "/tmp/`touch /tmp/pwned`",
+  "/tmp/a && touch /tmp/pwned",
+  "/tmp/a | touch /tmp/pwned",
+  "/tmp/a > /tmp/pwned",
+  "/tmp/with space",
+  "/tmp/it's-quoted",
+];
+
+type CpHarness = {
+  cp(source: string, destination: string): Promise<unknown>;
+  process: {
+    exec(request: { command: string }): Promise<{ pid: string }>;
+    wait(pid: string, options: unknown): Promise<{ status: string; logs: string }>;
+  };
+};
+
+function createCpHarness(): { filesystem: CpHarness; commands: string[] } {
+  const commands: string[] = [];
+  const filesystem = Object.create(SandboxFileSystem.prototype) as CpHarness;
+  filesystem.process = {
+    exec: (request) => {
+      commands.push(request.command);
+      return Promise.resolve({ pid: "pid-1" });
+    },
+    wait: () => Promise.resolve({ status: "completed", logs: "" }),
+  };
+  return { filesystem, commands };
+}
+
+// A path is safe only if the shell would read it as one literal argument.
+// Strip the quoted form of the payload out of the command; whatever is left is
+// what the shell gets to interpret, and it must contain no injected command.
+function assertPayloadIsInert(command: string, payload: string) {
+  const quotedPayload = `'${payload.replace(/'/g, `'\\''`)}'`;
+  expect(command).toContain(quotedPayload);
+  expect(command.replace(quotedPayload, "")).not.toContain("touch /tmp/pwned");
+}
+
+describe("SandboxFileSystem.cp shell injection", () => {
+  for (const payload of injectionPayloads) {
+    it(`quotes a malicious source path: ${payload}`, async () => {
+      const { filesystem, commands } = createCpHarness();
+
+      await filesystem.cp(payload, "/tmp/dst");
+
+      expect(commands).toHaveLength(1);
+      assertPayloadIsInert(commands[0], payload);
+    });
+
+    it(`quotes a malicious destination path: ${payload}`, async () => {
+      const { filesystem, commands } = createCpHarness();
+
+      await filesystem.cp("/tmp/src", payload);
+
+      expect(commands).toHaveLength(1);
+      assertPayloadIsInert(commands[0], payload);
+    });
+  }
+
+  it("still copies ordinary paths", async () => {
+    const { filesystem, commands } = createCpHarness();
+
+    const result = await filesystem.cp("/tmp/src", "/tmp/dst");
+
+    expect(commands[0]).toBe("cp -r '/tmp/src' '/tmp/dst'");
+    expect(result).toEqual({
+      message: "Files copied",
+      source: "/tmp/src",
+      destination: "/tmp/dst",
+    });
+  });
+});


### PR DESCRIPTION
*AI-Generated PR description*

`fs.cp()` interpolated its two paths straight into `cp -r ${source} ${destination}`. The sandbox process API runs a command string as `sh -c`, so `;`, `|`, `&&`, `$()`, backticks and `>` in a path executed as their own command, as root.

Adds `shellQuote()` (TypeScript's missing `shlex.quote`) and applies it to both paths, with unit tests per metacharacter class.

This is the TypeScript counterpart of blaxel-ai/sdk-python#185, which fixed the identical bug there in July. The finding was filed against Python only, so this copy was missed. No Linear issue exists for it that I could find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes a security bug in sandbox command execution; the change is narrow and well-tested, though other exec call sites may still need the same treatment if they interpolate user-controlled strings.
> 
> **Overview**
> **Fixes a shell-injection vulnerability in `fs.cp()`** where `source` and `destination` were interpolated into `cp -r` without quoting. Because sandbox `process.exec` runs commands via `sh -c`, paths containing `;`, `|`, `&&`, `$()`, backticks, or `>` could run arbitrary commands in the sandbox.
> 
> The PR adds a shared **`shellQuote()`** helper (POSIX single-quote escaping, analogous to Python `shlex.quote`) and uses it for both arguments in `cp()`. **Unit tests** assert malicious paths stay literal in the emitted command; a **manual live script** verifies behavior against a real sandbox (including paths with spaces).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b040684f59dcbdfd43e601cab5052c30cb8bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->