### PR TITLE
fix(core): keep multipart upload slots busy across part boundaries (ENG-3585)

### DIFF
--- a/@blaxel/core/src/sandbox/filesystem/filesystem.test.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settings } from "../../common/settings.js";
 import { MultipartInitiateResponse, MultipartPartInfo, MultipartUploadPartResponse, SuccessResponse } from "../client/index.js";
 import { SandboxFileSystem } from "./filesystem.js";
 
@@ -8,13 +9,77 @@ type MultipartUploadHarness = {
   uploadPart: (uploadId: string, partNumber: number, fileBlob: Blob) => Promise<MultipartUploadPartResponse>;
   completeMultipartUpload: (uploadId: string, parts: Array<MultipartPartInfo>) => Promise<SuccessResponse>;
   abortMultipartUpload: (uploadId: string) => Promise<SuccessResponse>;
+  sandbox?: { h2Domain?: string };
 };
 
 const waitForPartUpload = () => new Promise((resolve) => setTimeout(resolve, 5));
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("SandboxFileSystem multipart upload", () => {
-  it("limits concurrent part uploads", async () => {
+  afterEach(() => {
+    delete settings.config.maxConcurrentUploadH2Requests;
+    delete settings.config.fsPartRetries;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps an H2 upload slot busy across former batch boundaries for 100 MiB", async () => {
+    settings.config.maxConcurrentUploadH2Requests = 2;
     const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    filesystem.sandbox = { h2Domain: "eng-3585.test" };
+    const started = [deferred(), deferred(), deferred(), deferred()];
+    const release = [deferred(), deferred(), deferred(), deferred()];
+    let completedParts: Array<MultipartPartInfo> = [];
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-1" });
+    filesystem.uploadPart = async (_uploadId, partNumber) => {
+      if (partNumber <= 4) {
+        started[partNumber - 1].resolve();
+        await release[partNumber - 1].promise;
+      }
+      return { partNumber, etag: `etag-${partNumber}` };
+    };
+    filesystem.completeMultipartUpload = (_uploadId, parts) => {
+      completedParts = parts;
+      return Promise.resolve({ message: "ok" });
+    };
+    filesystem.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+
+    const upload = filesystem.uploadWithMultipart(
+      "/tmp/large-file.bin",
+      { size: 100 * 1024 * 1024, slice: () => ({} as Blob) } as Blob,
+    );
+
+    await Promise.all([started[0].promise, started[1].promise]);
+    release[0].resolve();
+    await started[2].promise;
+    release[2].resolve();
+
+    const crossedBatchBoundary = await Promise.race([
+      started[3].promise.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 25)),
+    ]);
+
+    release[1].resolve();
+    await started[3].promise;
+    release[3].resolve();
+    await upload;
+
+    expect(crossedBatchBoundary).toBe(true);
+    expect(completedParts).toHaveLength(20);
+  });
+
+  it("limits concurrent H2 part uploads to the existing cap", async () => {
+    settings.config.maxConcurrentUploadH2Requests = 2;
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    filesystem.sandbox = { h2Domain: "concurrency.test" };
     let inFlight = 0;
     let maxInFlight = 0;
     const uploadedParts: number[] = [];
@@ -39,8 +104,191 @@ describe("SandboxFileSystem multipart upload", () => {
 
     await filesystem.uploadWithMultipart("/tmp/large-file.bin", blob);
 
-    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(maxInFlight).toBe(2);
     expect(uploadedParts.sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
     expect(completedParts.map((part) => part.partNumber)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("uploads every byte exactly once across chunk boundaries", async () => {
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    const partSize = 5 * 1024 * 1024;
+    const source = new Uint8Array(partSize + 17);
+    for (let index = 0; index < source.length; index++) {
+      source[index] = index % 251;
+    }
+    const uploadedChunks = new Map<number, Uint8Array>();
+    let completedParts: Array<MultipartPartInfo> = [];
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-bytes" });
+    filesystem.uploadPart = async (_uploadId, partNumber, fileBlob) => {
+      uploadedChunks.set(partNumber, new Uint8Array(await fileBlob.arrayBuffer()));
+      return { partNumber, etag: `etag-${partNumber}` };
+    };
+    filesystem.completeMultipartUpload = (_uploadId, parts) => {
+      completedParts = parts;
+      return Promise.resolve({ message: "ok" });
+    };
+    filesystem.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+
+    await filesystem.uploadWithMultipart("/tmp/bytes.bin", new Blob([source]));
+
+    const received = new Uint8Array(source.length);
+    let offset = 0;
+    for (const partNumber of [1, 2]) {
+      const chunk = uploadedChunks.get(partNumber);
+      expect(chunk).toBeDefined();
+      received.set(chunk!, offset);
+      offset += chunk!.length;
+    }
+    let mismatch = -1;
+    for (let index = 0; index < source.length; index++) {
+      if (received[index] !== source[index]) {
+        mismatch = index;
+        break;
+      }
+    }
+
+    expect([...uploadedChunks.values()].map((chunk) => chunk.length)).toEqual([partSize, 17]);
+    expect(offset).toBe(source.length);
+    expect(mismatch).toBe(-1);
+    expect(completedParts.map((part) => part.partNumber)).toEqual([1, 2]);
+  });
+
+  it("retries a transient part failure without duplicating completed parts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    settings.config.fsPartRetries = 1;
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    const attempts = new Map<number, number>();
+    let completedParts: Array<MultipartPartInfo> = [];
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-retry" });
+    filesystem.uploadPart = (_uploadId, partNumber) => {
+      const attempt = (attempts.get(partNumber) ?? 0) + 1;
+      attempts.set(partNumber, attempt);
+      if (partNumber === 1 && attempt === 1) {
+        return Promise.reject(Object.assign(new Error("connection reset"), { code: "ECONNRESET" }));
+      }
+      return Promise.resolve({ partNumber, etag: `etag-${partNumber}` });
+    };
+    filesystem.completeMultipartUpload = (_uploadId, parts) => {
+      completedParts = parts;
+      return Promise.resolve({ message: "ok" });
+    };
+    filesystem.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+
+    const upload = filesystem.uploadWithMultipart(
+      "/tmp/retry.bin",
+      new Blob([new Uint8Array(6 * 1024 * 1024)]),
+    );
+    await vi.runAllTimersAsync();
+    await upload;
+
+    expect(Object.fromEntries(attempts)).toEqual({ 1: 2, 2: 1 });
+    expect(completedParts.map((part) => part.partNumber)).toEqual([1, 2]);
+  });
+
+  it("stops assigning queued parts after a part failure", async () => {
+    settings.config.maxConcurrentUploadH2Requests = 2;
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    filesystem.sandbox = { h2Domain: "cancellation.test" };
+    const releaseFirstPart = deferred();
+    const secondPartStarted = deferred();
+    const failure = new Error("part 2 failed");
+    const startedParts: number[] = [];
+    const events: string[] = [];
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-cancel" });
+    filesystem.uploadPart = async (_uploadId, partNumber) => {
+      startedParts.push(partNumber);
+      if (partNumber === 1) {
+        await releaseFirstPart.promise;
+        events.push("part-1-finished");
+        return { partNumber, etag: "etag-1" };
+      }
+      secondPartStarted.resolve();
+      events.push("part-2-failed");
+      throw failure;
+    };
+    filesystem.completeMultipartUpload = () => {
+      throw new Error("completion must not run");
+    };
+    filesystem.abortMultipartUpload = () => {
+      events.push("aborted");
+      return Promise.resolve({ message: "aborted" });
+    };
+
+    const upload = filesystem.uploadWithMultipart(
+      "/tmp/cancel.bin",
+      new Blob([new Uint8Array(16 * 1024 * 1024)]),
+    );
+    await secondPartStarted.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFirstPart.resolve();
+
+    await expect(upload).rejects.toBe(failure);
+    expect(startedParts).toEqual([1, 2]);
+    expect(events).toEqual(["part-2-failed", "part-1-finished", "aborted"]);
+  });
+
+  it("keeps sliced part data bounded by the active worker count", async () => {
+    settings.config.maxConcurrentUploadH2Requests = 2;
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    filesystem.sandbox = { h2Domain: "memory.test" };
+    let unsettledSlices = 0;
+    let maxUnsettledSlices = 0;
+    let totalSlices = 0;
+    const fakeBlob = {
+      size: 100 * 1024 * 1024,
+      slice(start: number, end: number) {
+        totalSlices += 1;
+        unsettledSlices += 1;
+        maxUnsettledSlices = Math.max(maxUnsettledSlices, unsettledSlices);
+        return { size: end - start } as Blob;
+      },
+    } as Blob;
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-memory" });
+    filesystem.uploadPart = async (_uploadId, partNumber) => {
+      await waitForPartUpload();
+      unsettledSlices -= 1;
+      return { partNumber, etag: `etag-${partNumber}` };
+    };
+    filesystem.completeMultipartUpload = () => Promise.resolve({ message: "ok" });
+    filesystem.abortMultipartUpload = () => Promise.resolve({ message: "aborted" });
+
+    await filesystem.uploadWithMultipart("/tmp/100mb.bin", fakeBlob);
+
+    expect(totalSlices).toBe(20);
+    expect(maxUnsettledSlices).toBe(2);
+    expect(unsettledSlices).toBe(0);
+  });
+
+  it("aborts an abandoned multipart upload and preserves the part failure", async () => {
+    settings.config.maxConcurrentUploadH2Requests = 1;
+    const filesystem = Object.create(SandboxFileSystem.prototype) as MultipartUploadHarness;
+    filesystem.sandbox = { h2Domain: "cleanup.test" };
+    const partFailure = new Error("part failed");
+    const abortFailure = new Error("abort failed");
+    const aborts: string[] = [];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    filesystem.initiateMultipartUpload = () => Promise.resolve({ uploadId: "upload-cleanup" });
+    filesystem.uploadPart = () => Promise.reject(partFailure);
+    filesystem.completeMultipartUpload = () => {
+      throw new Error("completion must not run");
+    };
+    filesystem.abortMultipartUpload = (uploadId) => {
+      aborts.push(uploadId);
+      return Promise.reject(abortFailure);
+    };
+
+    await expect(filesystem.uploadWithMultipart(
+      "/tmp/cleanup.bin",
+      new Blob([new Uint8Array(6 * 1024 * 1024)]),
+    )).rejects.toBe(partFailure);
+
+    expect(aborts).toEqual(["upload-cleanup"]);
+    expect(consoleError).toHaveBeenCalledWith("Failed to abort multipart upload:", abortFailure);
   });
 });

--- a/@blaxel/core/src/sandbox/filesystem/filesystem.ts
+++ b/@blaxel/core/src/sandbox/filesystem/filesystem.ts
@@ -11,7 +11,7 @@ import { CopyResponse, FilesystemFindOptions, FilesystemGrepOptions, FilesystemS
 // Multipart upload constants
 const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB
 const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB per part
-const MAX_PARALLEL_UPLOADS = 3; // Number of parallel part uploads
+const MAX_PARALLEL_UPLOADS = 3; // Maximum workers when the H2 upload cap is disabled
 
 // The transient-reset classifier and retry loop live in
 // common/transient-retry.ts, shared with the idempotent sandbox-op retry
@@ -570,12 +570,23 @@ export class SandboxFileSystem extends SandboxAction {
       // so the shared-connection cap does not apply.
       const h2Domain = this.sandbox?.h2Domain;
 
-      // Upload parts in batches for parallel processing
-      for (let i = 0; i < numParts; i += MAX_PARALLEL_UPLOADS) {
-        const batch: Array<Promise<MultipartUploadPartResponse>> = [];
+      // Keep a bounded worker queue full instead of waiting at fixed batch
+      // boundaries. The upload gate remains authoritative across files; its
+      // default of 2 also bounds this queue on H2.
+      const h2UploadLimit = h2Domain ? settings.maxConcurrentUploadH2Requests : 0;
+      const workerCount = Math.min(
+        numParts,
+        h2UploadLimit > 0 ? Math.min(MAX_PARALLEL_UPLOADS, h2UploadLimit) : MAX_PARALLEL_UPLOADS,
+      );
+      let nextPartNumber = 1;
+      let stopped = false;
+      let uploadError: unknown;
 
-        for (let j = 0; j < MAX_PARALLEL_UPLOADS && i + j < numParts; j++) {
-          const partNumber = i + j + 1;
+      const uploadNextPart = async (): Promise<void> => {
+        while (!stopped) {
+          const partNumber = nextPartNumber++;
+          if (partNumber > numParts) return;
+
           const start = (partNumber - 1) * CHUNK_SIZE;
           const end = Math.min(start + CHUNK_SIZE, size);
           const chunk = blob.slice(start, end);
@@ -584,13 +595,20 @@ export class SandboxFileSystem extends SandboxAction {
           // concurrent part streams, not retry sequences; freed during backoff.
           const doPart = () => this.uploadPart(uploadId, partNumber, chunk);
           const partWithSlot = h2Domain ? () => withUploadSlot(h2Domain, doPart) : doPart;
-          batch.push(retryOnTransient(partWithSlot));
+          try {
+            parts.push(await retryOnTransient(partWithSlot));
+          } catch (error) {
+            if (!stopped) {
+              stopped = true;
+              uploadError = error;
+            }
+          }
         }
+      };
 
-        // Wait for batch to complete
-
-        const batchResults = await Promise.all(batch);
-        parts.push(...batchResults);
+      await Promise.all(Array.from({ length: workerCount }, () => uploadNextPart()));
+      if (stopped) {
+        throw uploadError;
       }
 
       // Sort parts by partNumber to ensure correct order


### PR DESCRIPTION
## Problem

`uploadWithMultipart` scheduled parts in fixed batches of three (`MAX_PARALLEL_UPLOADS`) and awaited `Promise.all` at every batch boundary. Since ENG-2680 the H2 upload gate caps concurrent part streams per domain at two by default. A batch of three therefore ran as two streams plus one queued part, and every batch ended with only one part in flight while the barrier waited for the slowest part. On a 100 MiB file (20 parts) that is seven barriers where one of the two available slots sits idle.

Observed in the benchmark dashboard: the 100 MB write row placed 4th of 4 at 6.41s (ENG-3585). The row is produced by our own `sandbox-providers-benchmark` runner calling `sandbox.fs.write()` with a 100 MiB string, which enters this exact code path.

## Change

- Replace the batch loop with a bounded worker queue. Workers pull the next part number as soon as they finish one, so a slot never idles at a former batch boundary.
- Worker count is `min(numParts, min(3, maxConcurrentUploadH2Requests))` on H2, and `min(numParts, 3)` when the gate is disabled or there is no `h2Domain`. The default H2 behaviour is now exactly two streams; the non-H2 path keeps its historical three.
- Each part still goes through `retryOnTransient` and acquires its H2 slot per attempt via `withUploadSlot`, so cross-file gating and backoff semantics are unchanged.
- On the first part failure the queue stops assigning new parts, in-flight parts drain, the original error is rethrown, and the existing abort path runs.
- Parts are sliced only when a worker starts them, so live slice memory is bounded by the worker count rather than the batch size.

No public API or default configuration changes.

## Tests

New/updated in `@blaxel/core/src/sandbox/filesystem/filesystem.test.ts`, run against the real `withUploadSlot` gate:

- Deterministic proof that part 4 starts as soon as one of two slots frees, with parts 2 and 4 outliving the old batch boundary, and all 20 parts of a 100 MiB upload complete.
- H2 concurrency stays at exactly the configured cap (2).
- Every byte is uploaded exactly once across chunk boundaries (5 MiB + 17 B fixture).
- A transient part failure is retried without duplicating completed parts.
- After a non-transient part failure, no further parts are assigned, completion is never called, and abort runs after in-flight parts finish.
- Unsettled slices never exceed the worker count.
- Abort failure is logged and the original part error is preserved.

Verification on this branch against current `main`:

- `@blaxel/core` unit suite: 186/186
- Root ENG-2680 upload-cap, single-PUT retry, part-retry, browser-stub parity, idempotent-op retry, and H2 real-transport fault-injection suites: 43/43
- `tsc --noEmit` for ESM and CJS targets: clean
- ESLint: one pre-existing `no-unnecessary-type-assertion` error in `watch()` (`filesystem.ts:486`) that exists on `main` and is untouched here

### Live A/B on the unchanged benchmark (2026-09-01, prod, us-pdx-1)

Two isolated copies of the `sandbox-providers-benchmark` runner (`-p Blaxel -t filesystem -i 1 -s 1`), one with `@blaxel/core` packed from `main` @ 75fcf8d, one packed from this branch. 8 rounds each, order alternated per round.

| | Baseline (`main`) | This branch |
|---|---|---|
| Median | 15,860 ms | 13,714 ms |
| Mean | 18,309 ms | 14,473 ms |
| Range | 14,921–23,283 ms | 11,548–18,168 ms |

Fix faster in 7 of 8 paired rounds; median -13.5%, mean -21.0%; Mann-Whitney U 49/64; exact permutation p = 0.041. The baseline distribution was bimodal (~15s and ~23s clusters, consistent with one slow part stalling a whole batch); the fix produced no run above 18.2s.

Caveat: these ran from a laptop whose uplink delivered ~7 MB/s versus ~16 MB/s on the CodeBuild runner that produced the 6.41s row, so absolute numbers are not a forecast of the dashboard. The relative signal is the evidence. `@blaxel/core` 0.3.11 (what the benchmark lockfile pins) and `main` have identical multipart code, so the baseline arm represents the published SDK.

## Still unknown

- Effect on the CodeBuild-hosted canonical run. `run.yml` in the benchmark repo has no `@blaxel/core` override input yet; adding one (as `verify-blaxel-serial.yml` already has) is the cheapest way to A/B on the real runner before release.
- Provider rows in that benchmark may not use identical upload protocols, so the comparison to peers is not apples to apples.

## Acceptance gate

ENG-3585 closes only when the unchanged canonical 100 MB write workload produces an accepted result on a released `@blaxel/core` containing this change.

Linear: ENG-3585 (child of ENG-5112)

Made with [Cursor](https://cursor.com)