### PR TITLE
feat(core): settings.integration appends an integration product token to the User-Agent

### DIFF
--- a/@blaxel/core/src/common/settings.test.ts
+++ b/@blaxel/core/src/common/settings.test.ts
@@ -259,3 +259,64 @@ describe('Settings H2 tuning knobs (config > env > default)', () => {
     );
   });
 });
+
+describe('Settings.integration', () => {
+  const sdkUserAgent = /^blaxel\/sdk\/typescript\/\S+ \([^)]+\) blaxel\/\S+/;
+
+  async function authenticated() {
+    const { settings } = await import('./settings.js');
+    settings.credentials = new ApiKey({ apiKey: 'test-key', workspace: 'test-ws' });
+    delete settings.config.integration;
+    delete process.env.BL_INTEGRATION;
+    return settings;
+  }
+
+  afterEach(async () => {
+    const { settings } = await import('./settings.js');
+    delete settings.config.integration;
+    delete process.env.BL_INTEGRATION;
+  });
+
+  it('sends the plain SDK User-Agent by default', async () => {
+    const settings = await authenticated();
+    expect(settings.integration).toBe('');
+    expect(settings.headers['User-Agent']).toMatch(new RegExp(sdkUserAgent.source + '$'));
+  });
+
+  it('appends the token set programmatically, once', async () => {
+    const settings = await authenticated();
+    settings.integration = 'deepseek-harness-blaxel-sandbox/0.1.2';
+    const userAgent = settings.headers['User-Agent'];
+    expect(userAgent).toMatch(sdkUserAgent);
+    expect(userAgent.endsWith(' deepseek-harness-blaxel-sandbox/0.1.2')).toBe(true);
+    expect(userAgent.split('deepseek-harness-blaxel-sandbox').length).toBe(2);
+  });
+
+  it('reads BL_INTEGRATION when nothing is set programmatically, and config wins', async () => {
+    const settings = await authenticated();
+    process.env.BL_INTEGRATION = 'herdr/1.4.0-rc.1';
+    expect(settings.headers['User-Agent'].endsWith(' herdr/1.4.0-rc.1')).toBe(true);
+    settings.setConfig({ ...settings.config, integration: 'deepseek-harness-blaxel-sandbox/0.1.2' });
+    expect(settings.headers['User-Agent'].endsWith(' deepseek-harness-blaxel-sandbox/0.1.2')).toBe(true);
+  });
+
+  it.each(['Deepseek/0.1.2', 'deepseek-harness', 'deepseek/0.1', 'a/1.0.0 b/1.0.0', 'deepseek/0.1.2 (extra)', ' x/1.0.0'])(
+    'ignores the invalid token %j',
+    async (value) => {
+      const settings = await authenticated();
+      settings.integration = value;
+      expect(settings.integration).toBe('');
+      expect(settings.headers['User-Agent']).toMatch(new RegExp(sdkUserAgent.source + '$'));
+    }
+  );
+
+  it('changes no header other than User-Agent', async () => {
+    const settings = await authenticated();
+    const plain = { ...settings.headers };
+    settings.integration = 'deepseek-harness-blaxel-sandbox/0.1.2';
+    const tagged = { ...settings.headers };
+    delete plain['User-Agent'];
+    delete tagged['User-Agent'];
+    expect(tagged).toEqual(plain);
+  });
+});

--- a/@blaxel/core/src/common/settings.ts
+++ b/@blaxel/core/src/common/settings.ts
@@ -39,6 +39,15 @@ export type Config = {
   apikey?: string;
   workspace?: string;
   /**
+   * Product token identifying the integration built on this SDK, appended to
+   * the `User-Agent` so Blaxel can attribute traffic to it. Format
+   * `<name>/<semver>` with a lowercase name, e.g.
+   * `"deepseek-harness-blaxel-sandbox/0.1.2"`. Also settable through
+   * `BL_INTEGRATION` or `settings.integration`. An invalid value is ignored
+   * with a warning.
+   */
+  integration?: string;
+  /**
    * Disables the SDK-managed HTTP/2 transport. Defaults to `false` (H2 on);
    * set this to `true` (or `BL_DISABLE_H2=1`) to opt out of H2. Note that H2 is
    * always force-disabled on Bun < 1.3.11, which has a broken H2 flow-control
@@ -201,6 +210,12 @@ function getOsArch(): string {
   return "browser/unknown";
 }
 
+/**
+ * An integration built on this SDK identifies itself with one User-Agent
+ * product token: `<name>/<semver>`, lowercase name.
+ */
+const INTEGRATION_TOKEN_PATTERN = /^[a-z0-9][a-z0-9._-]*\/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
 class Settings {
   private _credentials: Credentials | null;
   config: Config;
@@ -311,14 +326,38 @@ class Settings {
     return env.BL_API_VERSION || BLAXEL_API_VERSION;
   }
 
+  /**
+   * Product token identifying the integration built on this SDK, or `""`.
+   * Resolved from `config.integration`, then `BL_INTEGRATION`. See `Config.integration`.
+   */
+  get integration(): string {
+    const value = this.config.integration ?? env.BL_INTEGRATION ?? "";
+    if (!value) {
+      return "";
+    }
+    if (!INTEGRATION_TOKEN_PATTERN.test(value)) {
+      logger.warn(
+        `Ignoring invalid Blaxel integration token "${value}": expected <name>/<semver> with a lowercase name`
+      );
+      return "";
+    }
+    return value;
+  }
+
+  set integration(value: string | undefined) {
+    this.config.integration = value;
+  }
+
   get headers(): Record<string, string> {
     this.assertCredentials();
     const osArch = getOsArch();
+    const sdkUserAgent = `blaxel/sdk/typescript/${this.version} (${osArch}) blaxel/${this.commit}`;
+    const integration = this.integration;
     return {
       "x-blaxel-authorization": this.authorization,
       "x-blaxel-workspace": this.workspace || "",
       "Blaxel-Version": this.apiVersion,
-      "User-Agent": `blaxel/sdk/typescript/${this.version} (${osArch}) blaxel/${this.commit}`,
+      "User-Agent": integration ? `${sdkUserAgent} ${integration}` : sdkUserAgent,
     };
   }
 


### PR DESCRIPTION
## Why

Every Blaxel integration built on this SDK should be attributable in PostHog, Sentry, and SigNoz at a base level. The convention (ENG-1681) is one product token appended to the SDK User-Agent:

```
blaxel/sdk/typescript/0.3.12 (darwin/arm64) blaxel/4b5045a deepseek-harness-blaxel-sandbox/0.1.2
```

The DeepSeek Harness plugin does this today by shadowing the `headers` getter on the `settings` singleton. This PR makes it a supported one-liner instead of a monkey patch.

## What

- `Config.integration` / `settings.integration` / `BL_INTEGRATION`, resolved in that order. Format `<name>/<semver>`, lowercase name, prerelease allowed. An invalid value is ignored with a `logger.warn` so it can never break a request.
- `settings.headers` appends the token to `User-Agent`. No other header changes. Exactly one token.
- Tests in `settings.test.ts`: default, programmatic, env, config precedence, six invalid shapes, header isolation.

Control plane counterpart that parses the token into `integration` / `integration-version` tracking properties: blaxel-ai/controlplane#5349. Python SDK counterpart: blaxel-ai/sdk-python PR linked in ENG-1681.

Refs [ENG-1681](https://linear.app/blaxel/issue/ENG-1681)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: optional User-Agent suffix with strict validation and safe fallback; no changes to auth, workspace, or API version headers.
> 
> **Overview**
> Adds first-class **integration attribution** on outbound SDK requests so products built on `@blaxel/core` can identify themselves without overriding `settings.headers`.
> 
> Integrators can set a single product token via **`Config.integration`**, **`settings.integration`**, or **`BL_INTEGRATION`** (config wins over env). Values must match **`<lowercase-name>/<semver>`**; invalid tokens are dropped with a **`logger.warn`** and do not affect requests. When valid, **`settings.headers`** appends exactly one token to **`User-Agent`** after the existing SDK string; other headers are unchanged.
> 
> New **`Settings.integration`** tests cover defaults, programmatic/env/config resolution, invalid shapes, and User-Agent-only changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed607fe45d4a15407e77f7c40f31815d763df5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->